### PR TITLE
Fix sports managers background updates and update intervals

### DIFF
--- a/src/display_controller.py
+++ b/src/display_controller.py
@@ -591,6 +591,55 @@ class DisplayController:
                 self.display_manager.defer_update(self.nfl_recent.update, priority=3)
             if hasattr(self, 'nfl_upcoming') and self.nfl_upcoming:
                 self.display_manager.defer_update(self.nfl_upcoming.update, priority=3)
+            # Defer other sport manager updates
+            if hasattr(self, 'nhl_live') and self.nhl_live:
+                self.display_manager.defer_update(self.nhl_live.update, priority=3)
+            if hasattr(self, 'nhl_recent') and self.nhl_recent:
+                self.display_manager.defer_update(self.nhl_recent.update, priority=3)
+            if hasattr(self, 'nhl_upcoming') and self.nhl_upcoming:
+                self.display_manager.defer_update(self.nhl_upcoming.update, priority=3)
+            if hasattr(self, 'nba_live') and self.nba_live:
+                self.display_manager.defer_update(self.nba_live.update, priority=3)
+            if hasattr(self, 'nba_recent') and self.nba_recent:
+                self.display_manager.defer_update(self.nba_recent.update, priority=3)
+            if hasattr(self, 'nba_upcoming') and self.nba_upcoming:
+                self.display_manager.defer_update(self.nba_upcoming.update, priority=3)
+            if hasattr(self, 'mlb_live') and self.mlb_live:
+                self.display_manager.defer_update(self.mlb_live.update, priority=3)
+            if hasattr(self, 'mlb_recent') and self.mlb_recent:
+                self.display_manager.defer_update(self.mlb_recent.update, priority=3)
+            if hasattr(self, 'mlb_upcoming') and self.mlb_upcoming:
+                self.display_manager.defer_update(self.mlb_upcoming.update, priority=3)
+            if hasattr(self, 'milb_live') and self.milb_live:
+                self.display_manager.defer_update(self.milb_live.update, priority=3)
+            if hasattr(self, 'milb_recent') and self.milb_recent:
+                self.display_manager.defer_update(self.milb_recent.update, priority=3)
+            if hasattr(self, 'milb_upcoming') and self.milb_upcoming:
+                self.display_manager.defer_update(self.milb_upcoming.update, priority=3)
+            if hasattr(self, 'soccer_live') and self.soccer_live:
+                self.display_manager.defer_update(self.soccer_live.update, priority=3)
+            if hasattr(self, 'soccer_recent') and self.soccer_recent:
+                self.display_manager.defer_update(self.soccer_recent.update, priority=3)
+            if hasattr(self, 'soccer_upcoming') and self.soccer_upcoming:
+                self.display_manager.defer_update(self.soccer_upcoming.update, priority=3)
+            if hasattr(self, 'ncaa_baseball_live') and self.ncaa_baseball_live:
+                self.display_manager.defer_update(self.ncaa_baseball_live.update, priority=3)
+            if hasattr(self, 'ncaa_baseball_recent') and self.ncaa_baseball_recent:
+                self.display_manager.defer_update(self.ncaa_baseball_recent.update, priority=3)
+            if hasattr(self, 'ncaa_baseball_upcoming') and self.ncaa_baseball_upcoming:
+                self.display_manager.defer_update(self.ncaa_baseball_upcoming.update, priority=3)
+            if hasattr(self, 'ncaam_basketball_live') and self.ncaam_basketball_live:
+                self.display_manager.defer_update(self.ncaam_basketball_live.update, priority=3)
+            if hasattr(self, 'ncaam_basketball_recent') and self.ncaam_basketball_recent:
+                self.display_manager.defer_update(self.ncaam_basketball_recent.update, priority=3)
+            if hasattr(self, 'ncaam_basketball_upcoming') and self.ncaam_basketball_upcoming:
+                self.display_manager.defer_update(self.ncaam_basketball_upcoming.update, priority=3)
+            if hasattr(self, 'ncaam_hockey_live') and self.ncaam_hockey_live:
+                self.display_manager.defer_update(self.ncaam_hockey_live.update, priority=3)
+            if hasattr(self, 'ncaam_hockey_recent') and self.ncaam_hockey_recent:
+                self.display_manager.defer_update(self.ncaam_hockey_recent.update, priority=3)
+            if hasattr(self, 'ncaam_hockey_upcoming') and self.ncaam_hockey_upcoming:
+                self.display_manager.defer_update(self.ncaam_hockey_upcoming.update, priority=3)
             # Continue with non-scrolling-sensitive updates
             if self.weather: self.weather.get_weather()
             if self.calendar: self.calendar.update(time.time())
@@ -607,6 +656,57 @@ class DisplayController:
             if self.youtube: self.youtube.update()
             if self.text_display: self.text_display.update()
             if self.of_the_day: self.of_the_day.update(time.time())
+            
+            # Update all sports managers in background
+            # NHL managers
+            if self.nhl_live: self.nhl_live.update()
+            if self.nhl_recent: self.nhl_recent.update()
+            if self.nhl_upcoming: self.nhl_upcoming.update()
+            
+            # NBA managers
+            if self.nba_live: self.nba_live.update()
+            if self.nba_recent: self.nba_recent.update()
+            if self.nba_upcoming: self.nba_upcoming.update()
+            
+            # MLB managers
+            if self.mlb_live: self.mlb_live.update()
+            if self.mlb_recent: self.mlb_recent.update()
+            if self.mlb_upcoming: self.mlb_upcoming.update()
+            
+            # MiLB managers
+            if self.milb_live: self.milb_live.update()
+            if self.milb_recent: self.milb_recent.update()
+            if self.milb_upcoming: self.milb_upcoming.update()
+            
+            # Soccer managers
+            if self.soccer_live: self.soccer_live.update()
+            if self.soccer_recent: self.soccer_recent.update()
+            if self.soccer_upcoming: self.soccer_upcoming.update()
+            
+            # NFL managers
+            if self.nfl_live: self.nfl_live.update()
+            if self.nfl_recent: self.nfl_recent.update()
+            if self.nfl_upcoming: self.nfl_upcoming.update()
+            
+            # NCAAFB managers
+            if self.ncaa_fb_live: self.ncaa_fb_live.update()
+            if self.ncaa_fb_recent: self.ncaa_fb_recent.update()
+            if self.ncaa_fb_upcoming: self.ncaa_fb_upcoming.update()
+            
+            # NCAA Baseball managers
+            if self.ncaa_baseball_live: self.ncaa_baseball_live.update()
+            if self.ncaa_baseball_recent: self.ncaa_baseball_recent.update()
+            if self.ncaa_baseball_upcoming: self.ncaa_baseball_upcoming.update()
+            
+            # NCAA Basketball managers
+            if self.ncaam_basketball_live: self.ncaam_basketball_live.update()
+            if self.ncaam_basketball_recent: self.ncaam_basketball_recent.update()
+            if self.ncaam_basketball_upcoming: self.ncaam_basketball_upcoming.update()
+            
+            # NCAA Hockey managers
+            if self.ncaam_hockey_live: self.ncaam_hockey_live.update()
+            if self.ncaam_hockey_recent: self.ncaam_hockey_recent.update()
+            if self.ncaam_hockey_upcoming: self.ncaam_hockey_upcoming.update()
         
         # News manager fetches data when displayed, not during updates
         # if self.news_manager: self.news_manager.fetch_news_data()

--- a/src/nba_managers.py
+++ b/src/nba_managers.py
@@ -748,7 +748,7 @@ class NBARecentManager(BaseNBAManager):
         self.recent_games = []
         self.current_game_index = 0
         self.last_update = 0
-        self.update_interval = 3600  # 1 hour for recent games
+        self.update_interval = self.nba_config.get("recent_update_interval", 3600)  # Use config, default 1 hour
         self.recent_games_to_show = self.nba_config.get("recent_games_to_show", 5)  # Number of most recent games to display
         self.last_game_switch = 0
         self.game_display_duration = 15  # Display each game for 15 seconds
@@ -842,7 +842,7 @@ class NBAUpcomingManager(BaseNBAManager):
         self.upcoming_games = []
         self.current_game_index = 0
         self.last_update = 0
-        self.update_interval = 3600  # 1 hour for upcoming games
+        self.update_interval = self.nba_config.get("upcoming_update_interval", 3600)  # Use config, default 1 hour
         self.upcoming_games_to_show = self.nba_config.get("upcoming_games_to_show", 5)  # Number of upcoming games to display
         self.last_game_switch = 0
         self.game_display_duration = 15  # Display each game for 15 seconds

--- a/src/ncaam_basketball_managers.py
+++ b/src/ncaam_basketball_managers.py
@@ -788,7 +788,7 @@ class NCAAMBasketballRecentManager(BaseNCAAMBasketballManager):
         self.recent_games = []
         self.current_game_index = 0
         self.last_update = 0
-        self.update_interval = 3600  # 1 hour for recent games
+        self.update_interval = self.ncaam_basketball_config.get("recent_update_interval", 3600)  # Use config, default 1 hour
         self.recent_games_to_show = self.ncaam_basketball_config.get("recent_games_to_show", 5)  # Number of most recent games to display
         self.last_game_switch = 0
         self.game_display_duration = self.ncaam_basketball_config.get("recent_game_duration", 15) # Configurable duration
@@ -939,7 +939,7 @@ class NCAAMBasketballUpcomingManager(BaseNCAAMBasketballManager):
         self.upcoming_games = []
         self.current_game_index = 0
         self.last_update = 0
-        self.update_interval = 3600  # 1 hour for upcoming games
+        self.update_interval = self.ncaam_basketball_config.get("upcoming_update_interval", 3600)  # Use config, default 1 hour
         self.upcoming_games_to_show = self.ncaam_basketball_config.get("upcoming_games_to_show", 5)  # Number of upcoming games to display
         self.last_warning_time = 0
         self.warning_cooldown = 300  # Only show warning every 5 minutes

--- a/src/ncaam_hockey_managers.py
+++ b/src/ncaam_hockey_managers.py
@@ -745,7 +745,7 @@ class NCAAMHockeyRecentManager(BaseNCAAMHockeyManager):
         self.recent_games = []
         self.current_game_index = 0
         self.last_update = 0
-        self.update_interval = 300  # 5 minutes
+        self.update_interval = self.ncaam_hockey_config.get("recent_update_interval", 3600)  # Use config, default 1 hour
         self.recent_games_to_show = self.ncaam_hockey_config.get("recent_games_to_show", 5)  # Number of most recent games to display
         self.last_game_switch = 0
         self.game_display_duration = 15  # Display each game for 15 seconds
@@ -842,7 +842,7 @@ class NCAAMHockeyUpcomingManager(BaseNCAAMHockeyManager):
         self.upcoming_games = []
         self.current_game_index = 0
         self.last_update = 0
-        self.update_interval = 300  # 5 minutes
+        self.update_interval = self.ncaam_hockey_config.get("upcoming_update_interval", 3600)  # Use config, default 1 hour
         self.upcoming_games_to_show = self.ncaam_hockey_config.get("upcoming_games_to_show", 5)  # Number of upcoming games to display
         self.last_log_time = 0
         self.log_interval = 300  # Only log status every 5 minutes

--- a/src/nhl_managers.py
+++ b/src/nhl_managers.py
@@ -680,7 +680,7 @@ class NHLRecentManager(BaseNHLManager):
         self.recent_games = []
         self.current_game_index = 0
         self.last_update = 0
-        self.update_interval = 300  # 5 minutes
+        self.update_interval = self.nhl_config.get("recent_update_interval", 3600)  # Use config, default 1 hour
         self.recent_games_to_show = self.nhl_config.get("recent_games_to_show", 5)  # Number of most recent games to display
         self.last_game_switch = 0
         self.game_display_duration = 15  # Display each game for 15 seconds
@@ -792,7 +792,7 @@ class NHLUpcomingManager(BaseNHLManager):
         self.upcoming_games = []
         self.current_game_index = 0
         self.last_update = 0
-        self.update_interval = 300  # 5 minutes
+        self.update_interval = self.nhl_config.get("recent_update_interval", 3600)  # Use config, default 1 hour
         self.upcoming_games_to_show = self.nhl_config.get("upcoming_games_to_show", 5)  # Number of upcoming games to display
         self.last_log_time = 0
         self.log_interval = 300  # Only log status every 5 minutes


### PR DESCRIPTION
- Add all sports managers to background updates in display_controller.py
- Add all sports managers to deferred updates when scrolling
- Fix hardcoded update intervals in NHL, NBA, NCAA Basketball, and NCAA Hockey managers
- Use config values for recent_update_interval and upcoming_update_interval
- Ensure all sports managers update continuously in background
- Only NFL managers had the season fetching issue, others were already optimized