### PR TITLE
Leaderboard hangs at end due to overestimate of time

### DIFF
--- a/src/display_controller.py
+++ b/src/display_controller.py
@@ -74,6 +74,7 @@ class DisplayController:
         logger.info(f"News Manager initialized: {'Object' if self.news_manager else 'None'}")
         logger.info("Display modes initialized in %.3f seconds", time.time() - init_time)
         
+        self.force_change = False
         # Initialize Music Manager
         music_init_time = time.time()
         self.music_manager = None
@@ -1090,7 +1091,7 @@ class DisplayController:
                     else:
                         # If no sport has live_priority takeover, treat as regular rotation
                         is_currently_live = False
-                if not is_currently_live:
+                else:
                     previous_mode_before_switch = self.current_display_mode
                     if live_priority_takeover:
                         # Switch to first live priority sport
@@ -1131,7 +1132,8 @@ class DisplayController:
                                 # Reset logged duration when mode changes
                                 if hasattr(self, '_last_logged_duration'):
                                     delattr(self, '_last_logged_duration')
-                        elif current_time - self.last_switch >= self.get_current_duration():
+                        elif current_time - self.last_switch >= self.get_current_duration() or self.force_change:
+                            self.force_change = False
                             if self.current_display_mode == 'calendar' and self.calendar:
                                 self.calendar.advance_event()
                             elif self.current_display_mode == 'of_the_day' and self.of_the_day:
@@ -1280,8 +1282,11 @@ class DisplayController:
                             manager_to_display.display_stocks(force_clear=self.force_clear)
                         elif self.current_display_mode == 'stock_news':
                              manager_to_display.display_news() # Assumes internal clearing
-                        elif self.current_display_mode == 'odds_ticker':
-                             manager_to_display.display(force_clear=self.force_clear)
+                        elif self.current_display_mode in {'odds_ticker', 'leaderboard'}:
+                            try:
+                                manager_to_display.display(force_clear=self.force_clear)
+                            except StopIteration:
+                                self.force_change = True
                         elif self.current_display_mode == 'calendar':
                              manager_to_display.display(force_clear=self.force_clear)
                         elif self.current_display_mode == 'youtube':


### PR DESCRIPTION
For me the leaderboard is overestimating the amount of time to run through the display and then just hangs at the end for almost 30 seconds. I added an exception that forces it to move to the next view.