### PR TITLE
Fix display settings save error by adding missing config_type parameter

### DIFF
--- a/templates/index_v2.html
+++ b/templates/index_v2.html
@@ -2764,12 +2764,18 @@
         document.getElementById('display-form').addEventListener('submit', async function(e) {
             e.preventDefault();
             const formData = new FormData(this);
+            formData.append('config_type', 'main');
             
             try {
                 const response = await fetch('/save_config', {
                     method: 'POST',
                     body: formData
                 });
+                
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                }
+                
                 const result = await response.json();
                 showNotification(result.message, result.status);
             } catch (error) {


### PR DESCRIPTION
- Added config_type='main' to FormData when submitting display form
- Added proper HTTP error handling to catch non-JSON responses
- This fixes the 'Unexpected token <' JSON parsing error when saving display settings