### PR TITLE
Fix/odds ticker manager log spam

### DIFF
--- a/src/leaderboard_manager.py
+++ b/src/leaderboard_manager.py
@@ -56,8 +56,12 @@ class LeaderboardManager:
         # FPS tracking variables
         self.frame_times = []  # Store last 30 frame times for averaging
         self.last_frame_time = 0
-        self.fps_log_interval = 10.0  # Log FPS every 10 seconds
+        self.fps_log_interval = 30.0  # Log FPS every 30 seconds (increased from 10s)
         self.last_fps_log_time = 0
+        
+        # Progress logging throttling
+        self.progress_log_interval = 5.0  # Log progress every 5 seconds instead of every 50 pixels
+        self.last_progress_log_time = 0
         
         # Initialize managers
         self.cache_manager = CacheManager()
@@ -1259,6 +1263,8 @@ class LeaderboardManager:
         try:
             self.leaderboard_data = self._fetch_all_standings()
             self.last_update = current_time
+            # Reset progress logging timer when updating data
+            self.last_progress_log_time = 0
             
             if self.leaderboard_data:
                 self._create_leaderboard_image()
@@ -1313,6 +1319,8 @@ class LeaderboardManager:
             logger.debug(f"Reset/initialized display start time: {self._display_start_time}")
             # Also reset scroll position for clean start
             self.scroll_position = 0
+            # Reset progress logging timer
+            self.last_progress_log_time = 0
         else:
             # Check if the display start time is too old (more than 2x the dynamic duration)
             current_time = time.time()
@@ -1321,6 +1329,8 @@ class LeaderboardManager:
                 logger.debug(f"Display start time is too old ({elapsed_time:.1f}s), resetting")
                 self._display_start_time = current_time
                 self.scroll_position = 0
+                # Reset progress logging timer
+                self.last_progress_log_time = 0
         
         logger.debug(f"Number of leagues in data at start of display method: {len(self.leaderboard_data)}")
         if not self.leaderboard_data:
@@ -1397,9 +1407,10 @@ class LeaderboardManager:
             elapsed_time = current_time - self._display_start_time
             remaining_time = self.dynamic_duration - elapsed_time
             
-            # Log scroll progress every 50 pixels to help debug (less verbose)
-            if self.scroll_position % 50 == 0 and self.scroll_position > 0:
+            # Log scroll progress every 5 seconds to help debug (throttled to reduce spam)
+            if current_time - self.last_progress_log_time >= self.progress_log_interval and self.scroll_position > 0:
                 logger.info(f"Leaderboard progress: elapsed={elapsed_time:.1f}s, remaining={remaining_time:.1f}s, scroll_pos={self.scroll_position}/{self.leaderboard_image.width}px")
+                self.last_progress_log_time = current_time
             
             # If we have less than 2 seconds remaining, check if we can complete the content display
             if remaining_time < 2.0 and self.scroll_position > 0:

--- a/src/logo_downloader.py
+++ b/src/logo_downloader.py
@@ -102,10 +102,6 @@ class LogoDownloader:
         # Handle special characters that can cause filesystem issues
         normalized = abbreviation.upper()
         
-        # Special case for Texas A&M - keep as TA&M since that's how the file is named
-        if normalized == 'TA&M':
-            return 'TA&M'
-        
         # Replace problematic characters with safe alternatives
         normalized = normalized.replace('&', 'AND')
         normalized = normalized.replace('/', '_')
@@ -118,6 +114,23 @@ class LogoDownloader:
         normalized = normalized.replace('>', '_')
         normalized = normalized.replace('|', '_')
         return normalized
+    
+    @staticmethod
+    def get_logo_filename_variations(abbreviation: str) -> list:
+        """Get possible filename variations for a team abbreviation."""
+        variations = []
+        original = abbreviation.upper()
+        normalized = LogoDownloader.normalize_abbreviation(abbreviation)
+        
+        # Add original and normalized versions
+        variations.extend([f"{original}.png", f"{normalized}.png"])
+        
+        # Special handling for known cases
+        if original == 'TA&M':
+            # TA&M has a file named TA&M.png, but normalize creates TAANDM.png
+            variations = [f"{original}.png", f"{normalized}.png"]
+        
+        return variations
     
     def get_logo_directory(self, league: str) -> str:
         """Get the logo directory for a given league."""

--- a/src/logo_downloader.py
+++ b/src/logo_downloader.py
@@ -101,6 +101,11 @@ class LogoDownloader:
         """Normalize team abbreviation for consistent filename usage."""
         # Handle special characters that can cause filesystem issues
         normalized = abbreviation.upper()
+        
+        # Special case for Texas A&M - keep as TA&M since that's how the file is named
+        if normalized == 'TA&M':
+            return 'TA&M'
+        
         # Replace problematic characters with safe alternatives
         normalized = normalized.replace('&', 'AND')
         normalized = normalized.replace('/', '_')


### PR DESCRIPTION
reduce log spam for odds-ticker, leaderboard, music manager, and when a logo fails to download. Failed download has more robust naming handling now but didn't fix permission error.