### PR TITLE
team switch logging

### DIFF
--- a/src/base_classes/sports.py
+++ b/src/base_classes/sports.py
@@ -1015,7 +1015,15 @@ class SportsUpcoming(SportsCore):
                 self.current_game = self.games_list[self.current_game_index]
                 self.last_game_switch = current_time
                 force_clear = True # Force redraw on switch
-                self.logger.debug(f"Switched to game index {self.current_game_index}") # Changed log prefix
+                
+                # Log team switching with sport prefix
+                if self.current_game:
+                    away_abbr = self.current_game.get('away_abbr', 'UNK')
+                    home_abbr = self.current_game.get('home_abbr', 'UNK')
+                    sport_prefix = self.sport_key.upper() if hasattr(self, 'sport_key') else 'SPORT'
+                    self.logger.info(f"[{sport_prefix} Upcoming] Showing {away_abbr} vs {home_abbr}")
+                else:
+                    self.logger.debug(f"Switched to game index {self.current_game_index}")
 
             if self.current_game:
                 self._draw_scorebug_layout(self.current_game, force_clear)
@@ -1304,7 +1312,15 @@ class SportsRecent(SportsCore):
                 self.current_game = self.games_list[self.current_game_index]
                 self.last_game_switch = current_time
                 force_clear = True # Force redraw on switch
-                self.logger.debug(f"Switched to game index {self.current_game_index}") # Changed log prefix
+                
+                # Log team switching with sport prefix
+                if self.current_game:
+                    away_abbr = self.current_game.get('away_abbr', 'UNK')
+                    home_abbr = self.current_game.get('home_abbr', 'UNK')
+                    sport_prefix = self.sport_key.upper() if hasattr(self, 'sport_key') else 'SPORT'
+                    self.logger.info(f"[{sport_prefix} Recent] Showing {away_abbr} vs {home_abbr}")
+                else:
+                    self.logger.debug(f"Switched to game index {self.current_game_index}")
 
             if self.current_game:
                 self._draw_scorebug_layout(self.current_game, force_clear)

--- a/src/mlb_manager.py
+++ b/src/mlb_manager.py
@@ -918,6 +918,13 @@ class MLBLiveManager(BaseMLBManager, BaseballLive):
                 self.current_game_index = (self.current_game_index + 1) % len(self.live_games)
                 self.current_game = self.live_games[self.current_game_index]
                 self.last_game_switch = current_time
+                
+                # Log team switching
+                if self.current_game:
+                    away_abbr = self.current_game.get('away_abbr', 'UNK')
+                    home_abbr = self.current_game.get('home_abbr', 'UNK')
+                    self.logger.info(f"[MLB Live] Showing {away_abbr} vs {home_abbr}")
+                
                 # Force display update when switching games
                 # self.display(force_clear=True) # REMOVED: DisplayController handles this
                 self.last_display_update = current_time
@@ -1313,6 +1320,12 @@ class MLBRecentManager(BaseMLBManager, SportsRecent):
                 self.current_game = self.recent_games[self.current_game_index]
                 self.last_game_switch = current_time
                 force_clear = True  # Force clear when switching games
+                
+                # Log team switching
+                if self.current_game:
+                    away_abbr = self.current_game.get('away_abbr', 'UNK')
+                    home_abbr = self.current_game.get('home_abbr', 'UNK')
+                    self.logger.info(f"[MLB Recent] Showing {away_abbr} vs {home_abbr}")
             
             # Create and display the game image
             game_image = self._create_game_display(self.current_game)
@@ -1454,6 +1467,12 @@ class MLBUpcomingManager(BaseMLBManager, SportsUpcoming):
                 self.current_game = self.upcoming_games[self.current_game_index]
                 self.last_game_switch = current_time
                 force_clear = True  # Force clear when switching games
+                
+                # Log team switching
+                if self.current_game:
+                    away_abbr = self.current_game.get('away_abbr', 'UNK')
+                    home_abbr = self.current_game.get('home_abbr', 'UNK')
+                    self.logger.info(f"[MLB Upcoming] Showing {away_abbr} vs {home_abbr}")
             
             # Create and display the game image
             game_image = self._create_game_display(self.current_game)

--- a/src/nba_managers.py
+++ b/src/nba_managers.py
@@ -833,6 +833,12 @@ class NBARecentManager(BaseNBAManager):
                 self.current_game = self.recent_games[self.current_game_index]
                 self.last_game_switch = current_time
                 force_clear = True
+                
+                # Log team switching
+                if self.current_game:
+                    away_abbr = self.current_game.get('away_abbr', 'UNK')
+                    home_abbr = self.current_game.get('home_abbr', 'UNK')
+                    self.logger.info(f"[NBA Recent] Showing {away_abbr} vs {home_abbr}")
 
             # Draw the scorebug layout
             self._draw_scorebug_layout(self.current_game, force_clear)
@@ -927,6 +933,12 @@ class NBAUpcomingManager(BaseNBAManager):
                 self.current_game = self.upcoming_games[self.current_game_index]
                 self.last_game_switch = current_time
                 force_clear = True
+                
+                # Log team switching
+                if self.current_game:
+                    away_abbr = self.current_game.get('away_abbr', 'UNK')
+                    home_abbr = self.current_game.get('home_abbr', 'UNK')
+                    self.logger.info(f"[NBA Upcoming] Showing {away_abbr} vs {home_abbr}")
             
             # Draw the scorebug layout
             self._draw_scorebug_layout(self.current_game, force_clear)

--- a/src/ncaa_baseball_managers.py
+++ b/src/ncaa_baseball_managers.py
@@ -680,6 +680,13 @@ class NCAABaseballLiveManager(BaseNCAABaseballManager, BaseballLive):
                 self.current_game_index = (self.current_game_index + 1) % len(self.live_games)
                 self.current_game = self.live_games[self.current_game_index]
                 self.last_game_switch = current_time
+                
+                # Log team switching
+                if self.current_game:
+                    away_team = self.current_game.get('away_team', 'UNK')
+                    home_team = self.current_game.get('home_team', 'UNK')
+                    self.logger.info(f"[NCAABASEBALL Live] Showing {away_team} vs {home_team}")
+                
                 # Force display update when switching games
                 # self.display(force_clear=True) # REMOVED: DisplayController handles this
                 self.last_display_update = current_time # Track last successful update that *would* have displayed
@@ -966,6 +973,12 @@ class NCAABaseballRecentManager(BaseNCAABaseballManager, SportsRecent):
                 self.current_game = self.recent_games[self.current_game_index]
                 self.last_game_switch = current_time
                 force_clear = True
+                
+                # Log team switching
+                if self.current_game:
+                    away_team = self.current_game.get('away_team', 'UNK')
+                    home_team = self.current_game.get('home_team', 'UNK')
+                    logger.info(f"[NCAABASEBALL Recent] Showing {away_team} vs {home_team}")
             
             if self.current_game:
                 game_image = self._create_game_display(self.current_game)
@@ -1086,6 +1099,12 @@ class NCAABaseballUpcomingManager(BaseNCAABaseballManager, SportsUpcoming):
                 self.current_game = self.upcoming_games[self.current_game_index]
                 self.last_game_switch = current_time
                 force_clear = True
+                
+                # Log team switching
+                if self.current_game:
+                    away_team = self.current_game.get('away_team', 'UNK')
+                    home_team = self.current_game.get('home_team', 'UNK')
+                    logger.info(f"[NCAABASEBALL Upcoming] Showing {away_team} vs {home_team}")
             
             if self.current_game:
                 game_image = self._create_game_display(self.current_game)

--- a/src/ncaam_basketball_managers.py
+++ b/src/ncaam_basketball_managers.py
@@ -778,6 +778,12 @@ class NCAAMBasketballLiveManager(BaseNCAAMBasketballManager):
                              self.current_game_index = (self.current_game_index + 1) % len(self.live_games)
                              self.current_game = self.live_games[self.current_game_index]
                              self.last_game_switch = current_time
+                             
+                             # Log team switching
+                             if self.current_game:
+                                 away_abbr = self.current_game.get('away_abbr', 'UNK')
+                                 home_abbr = self.current_game.get('home_abbr', 'UNK')
+                                 self.logger.info(f"[NCAAMBASKETBALL Live] Showing {away_abbr} vs {home_abbr}")
 
 
                         # Only update display if we have new data and enough time has passed
@@ -934,6 +940,12 @@ class NCAAMBasketballRecentManager(BaseNCAAMBasketballManager):
                 self.current_game = self.recent_games[self.current_game_index]
                 self.last_game_switch = current_time
                 force_clear = True  # Force clear when switching games
+                
+                # Log team switching
+                if self.current_game:
+                    away_abbr = self.current_game.get('away_abbr', 'UNK')
+                    home_abbr = self.current_game.get('home_abbr', 'UNK')
+                    self.logger.info(f"[NCAAMBASKETBALL Recent] Showing {away_abbr} vs {home_abbr}")
 
             # If only one game, ensure it's set correctly
             elif len(self.recent_games) == 1:
@@ -1077,6 +1089,12 @@ class NCAAMBasketballUpcomingManager(BaseNCAAMBasketballManager):
                 self.current_game = self.upcoming_games[self.current_game_index]
                 self.last_game_switch = current_time
                 force_clear = True  # Force clear when switching games
+                
+                # Log team switching
+                if self.current_game:
+                    away_abbr = self.current_game.get('away_abbr', 'UNK')
+                    home_abbr = self.current_game.get('home_abbr', 'UNK')
+                    self.logger.info(f"[NCAAMBASKETBALL Upcoming] Showing {away_abbr} vs {home_abbr}")
 
             # If only one game, ensure it's set
             elif len(self.upcoming_games) == 1:

--- a/src/nhl_managers.py
+++ b/src/nhl_managers.py
@@ -676,13 +676,20 @@ class NHLLiveManager(BaseNHLManager):
                         self.live_games = []
                         self.current_game = None
                 
-                # Check if it's time to switch games
-                if len(self.live_games) > 1 and (current_time - self.last_game_switch) >= self.game_display_duration:
-                    self.current_game_index = (self.current_game_index + 1) % len(self.live_games)
-                    self.current_game = self.live_games[self.current_game_index]
-                    self.last_game_switch = current_time
-                    # self.display(force_clear=True) # REMOVED: DisplayController handles this
-                    self.last_display_update = current_time # Track time for potential display update
+            # Check if it's time to switch games
+            if len(self.live_games) > 1 and (current_time - self.last_game_switch) >= self.game_display_duration:
+                self.current_game_index = (self.current_game_index + 1) % len(self.live_games)
+                self.current_game = self.live_games[self.current_game_index]
+                self.last_game_switch = current_time
+                
+                # Log team switching
+                if self.current_game:
+                    away_abbr = self.current_game.get('away_abbr', 'UNK')
+                    home_abbr = self.current_game.get('home_abbr', 'UNK')
+                    self.logger.info(f"[NHL Live] Showing {away_abbr} vs {home_abbr}")
+                
+                # self.display(force_clear=True) # REMOVED: DisplayController handles this
+                self.last_display_update = current_time # Track time for potential display update
 
     def display(self, force_clear=False):
         """Display live game information."""
@@ -792,6 +799,12 @@ class NHLRecentManager(BaseNHLManager):
                 self.current_game = self.games_list[self.current_game_index]
                 self.last_game_switch = current_time
                 force_clear = True  # Force clear when switching games
+                
+                # Log team switching
+                if self.current_game:
+                    away_abbr = self.current_game.get('away_abbr', 'UNK')
+                    home_abbr = self.current_game.get('home_abbr', 'UNK')
+                    self.logger.info(f"[NHL Recent] Showing {away_abbr} vs {home_abbr}")
             
             # Draw the scorebug layout
             self._draw_scorebug_layout(self.current_game, force_clear)
@@ -925,6 +938,12 @@ class NHLUpcomingManager(BaseNHLManager):
                 self.current_game = self.upcoming_games[self.current_game_index]
                 self.last_game_switch = current_time
                 force_clear = True  # Force clear when switching games
+                
+                # Log team switching
+                if self.current_game:
+                    away_abbr = self.current_game.get('away_abbr', 'UNK')
+                    home_abbr = self.current_game.get('home_abbr', 'UNK')
+                    self.logger.info(f"[NHL Upcoming] Showing {away_abbr} vs {home_abbr}")
             
             # Draw the scorebug layout
             self._draw_scorebug_layout(self.current_game, force_clear)

--- a/src/soccer_managers.py
+++ b/src/soccer_managers.py
@@ -1089,6 +1089,12 @@ class SoccerRecentManager(BaseSoccerManager):
                 self.current_game = self.games_list[self.current_game_index]
                 self.last_game_switch = current_time
                 force_clear = True # Force clear when switching games
+                
+                # Log team switching
+                if self.current_game:
+                    away_abbr = self.current_game.get('away_abbr', 'UNK')
+                    home_abbr = self.current_game.get('home_abbr', 'UNK')
+                    self.logger.info(f"[SOCCER Recent] Showing {away_abbr} vs {home_abbr}")
 
             # Ensure current_game is set (it might be None initially)
             if not self.current_game and self.games_list:
@@ -1228,6 +1234,12 @@ class SoccerUpcomingManager(BaseSoccerManager):
                 self.current_game = self.upcoming_games[self.current_game_index]
                 self.last_game_switch = current_time
                 force_clear = True # Force clear when switching games
+                
+                # Log team switching
+                if self.current_game:
+                    away_abbr = self.current_game.get('away_abbr', 'UNK')
+                    home_abbr = self.current_game.get('home_abbr', 'UNK')
+                    self.logger.info(f"[SOCCER Upcoming] Showing {away_abbr} vs {home_abbr}")
 
             # Ensure current_game is set
             if not self.current_game and self.upcoming_games:


### PR DESCRIPTION
simple log messages about which team is being shown when. Helps to identify durations when there are longer displays (like AP Top 25)