### PR TITLE
fix(odds): Resolve incorrect sport and league parameters in _fetch_od…

### DIFF
--- a/src/base_classes/football.py
+++ b/src/base_classes/football.py
@@ -45,8 +45,10 @@ class Football(SportsCore):
     def _fetch_game_odds(self, _: Dict) -> None:
         pass
 
-    def _fetch_odds(self, game: Dict, league: str) -> None:
-        super()._fetch_odds(game, "football", league)
+    def _fetch_odds(self, game: Dict) -> None:
+        # Football base class - should be overridden by specific leagues (NFL, NCAA FB)
+        self.logger.warning(f"_fetch_odds not implemented for football sport: {self.sport_key}")
+        pass
 
     def _extract_game_details(self, game_event: Dict) -> Optional[Dict]:
         """Extract relevant game details from ESPN NCAA FB API response."""

--- a/src/base_classes/hockey.py
+++ b/src/base_classes/hockey.py
@@ -40,8 +40,10 @@ class Hockey(SportsCore):
         """Get hockey sport configuration."""
         return self.SPORT_CONFIG.copy()
 
-    def _fetch_odds(self, game: Dict, league: str) -> None:
-        super()._fetch_odds(game, "hockey", league)
+    def _fetch_odds(self, game: Dict) -> None:
+        # Hockey base class - should be overridden by specific leagues (NHL, NCAA Hockey)
+        self.logger.warning(f"_fetch_odds not implemented for hockey sport: {self.sport_key}")
+        pass
 
 
     def _extract_game_details(self, game_event: Dict) -> Optional[Dict]:

--- a/src/base_classes/sports.py
+++ b/src/base_classes/sports.py
@@ -324,7 +324,7 @@ class SportsCore:
                     
                     # Fetch odds if enabled
                     if self.show_odds:
-                        self._fetch_odds(game_details, self.sport_key, self.sport_key)
+                        self._fetch_odds(game_details)
                     
                     processed_games.append(game_details)
             
@@ -442,8 +442,22 @@ class SportsCore:
         except Exception as e:
             self.logger.error(f"Error fetching odds for game {game.get('id', 'N/A')}: {e}")
 
-    def _fetch_odds(self, game: Dict, sport: str, league: str) -> None:
-        """Fetch odds for a specific game if conditions are met."""
+    def _fetch_odds(self, game: Dict) -> None:
+        """Fetch odds for a specific game if conditions are met.
+        
+        This method should be overridden by sport-specific classes to provide
+        the correct sport and league parameters for odds fetching.
+        """
+        # Default implementation - should be overridden by sport-specific classes
+        self.logger.warning(f"_fetch_odds not implemented for sport: {self.sport_key}")
+        pass
+
+    def _fetch_odds_with_params(self, game: Dict, sport: str, league: str) -> None:
+        """Helper method to fetch odds with specific sport and league parameters.
+        
+        This method can be used by sport-specific classes to fetch odds with
+        the correct parameters.
+        """
         # Check if odds should be shown for this sport
         if not self.show_odds:
             return

--- a/src/ncaa_fb_managers.py
+++ b/src/ncaa_fb_managers.py
@@ -196,8 +196,8 @@ class BaseNCAAFBManager(Football): # Renamed class
             return self._fetch_ncaa_fb_api_data(use_cache=True)
 
 
-    def _fetch_football_odds(self, game: Dict) -> None:
-        super()._fetch_odds(game, "college-football")
+    def _fetch_odds(self, game: Dict) -> None:
+        super()._fetch_odds_with_params(game, "football", "college-football")
 
 class NCAAFBLiveManager(BaseNCAAFBManager, FootballLive): # Renamed class
     """Manager for live NCAA FB games.""" # Updated docstring

--- a/src/ncaam_hockey_managers.py
+++ b/src/ncaam_hockey_managers.py
@@ -105,7 +105,7 @@ class BaseNCAAMHockeyManager(Hockey): # Renamed class
         return False
 
     def _fetch_odds(self, game: Dict) -> None:
-        super()._fetch_odds(game, "mens-college-hockey")
+        super()._fetch_odds_with_params(game, "hockey", "mens-college-hockey")
     
     def _fetch_ncaa_fb_api_data(self, use_cache: bool = True) -> Optional[Dict]:
         """

--- a/src/nfl_managers.py
+++ b/src/nfl_managers.py
@@ -40,8 +40,8 @@ class BaseNFLManager(Football): # Renamed class
         self.logger.info(f"Display modes - Recent: {self.recent_enabled}, Upcoming: {self.upcoming_enabled}, Live: {self.live_enabled}")
 
 
-    def _fetch_football_odds(self, game: Dict) -> None:
-        super()._fetch_odds(game, "nfl")
+    def _fetch_odds(self, game: Dict) -> None:
+        super()._fetch_odds_with_params(game, "football", "nfl")
     
     def _fetch_nfl_api_data(self, use_cache: bool = True) -> Optional[Dict]:
         """


### PR DESCRIPTION
…ds calls

- Fixed SportsCore._fetch_data() to call _fetch_odds(game) instead of _fetch_odds(game, sport_key, sport_key)
- Updated _fetch_odds method signature to accept only game parameter
- Added _fetch_odds_with_params helper method for sport-specific implementations
- Updated sport-specific managers to use correct sport and league parameters:
  - NFL: football/nfl
  - NCAA Football: football/college-football
  - NCAA Hockey: hockey/mens-college-hockey
- Ensures odds are fetched with correct ESPN API endpoints

Fixes #79