### PR TITLE
fix(nhl): Add missing games_list initialization in NHLRecentManager

### DIFF
--- a/src/nhl_managers.py
+++ b/src/nhl_managers.py
@@ -760,6 +760,7 @@ class NHLRecentManager(BaseNHLManager):
     def __init__(self, config: Dict[str, Any], display_manager: DisplayManager, cache_manager: CacheManager):
         super().__init__(config, display_manager, cache_manager)
         self.recent_games = []
+        self.games_list = []  # Filtered list for display (favorite teams)
         self.current_game_index = 0
         self.last_update = 0
         self.update_interval = self.nhl_config.get("recent_update_interval", 3600)  # Use config, default 1 hour


### PR DESCRIPTION
- Add self.games_list = [] to NHLRecentManager.__init__ method
- Fixes AttributeError when display method tries to access games_list
- Follows same pattern as other RecentManager classes