### PR TITLE
Fix: Suppress Werkzeug production warning in web interface

### DIFF
--- a/web_interface_v2.py
+++ b/web_interface_v2.py
@@ -1706,5 +1706,6 @@ if __name__ == '__main__':
         host='0.0.0.0',
         port=5001,
         debug=False,
-        use_reloader=False
+        use_reloader=False,
+        allow_unsafe_werkzeug=True
     )


### PR DESCRIPTION
- Add allow_unsafe_werkzeug=True parameter to socketio.run()
- Allows web UI to run cleanly when eventlet is not available
- Falls back gracefully to Werkzeug without production warnings