### PR TITLE
Use current season for Leaderboard

### DIFF
--- a/src/leaderboard_manager.py
+++ b/src/leaderboard_manager.py
@@ -789,7 +789,7 @@ class LeaderboardManager:
                 'standings': top_teams,
                 'timestamp': time.time(),
                 'league': league_key,
-                'season': params['season'],
+                # 'season': params['season'],
                 'level': params['level']
             }
             self.cache_manager.save_cache(cache_key, cache_data)


### PR DESCRIPTION
Closes #126 

I removed the season selector and now it should just use the current/most recent season standings.