### PR TITLE
Use EST for Active Games and 1 Day lookback

### DIFF
--- a/src/base_classes/sports.py
+++ b/src/base_classes/sports.py
@@ -497,11 +497,14 @@ class SportsCore(ABC):
     def _fetch_todays_games(self) -> Optional[Dict]:
         """Fetch only today's games for live updates (not entire season)."""
         try:
-            now = datetime.now()
+            tz = pytz.timezone("EST")
+            now = datetime.now(tz)
+            yesterday = now - timedelta(days=1)
             formatted_date = now.strftime("%Y%m%d")
+            formatted_date_yesterday = yesterday.strftime("%Y%m%d")
             # Fetch todays games only
             url = f"https://site.api.espn.com/apis/site/v2/sports/{self.sport}/{self.league}/scoreboard"
-            response = self.session.get(url, params={"dates": formatted_date, "limit": 1000}, headers=self.headers, timeout=10)
+            response = self.session.get(url, params={"dates": f"{formatted_date_yesterday}-{formatted_date}", "limit": 1000}, headers=self.headers, timeout=10)
             response.raise_for_status()
             data = response.json()
             events = data.get('events', [])


### PR DESCRIPTION
closes #127 

Hardcodes to EST timezone for active games and adds a 1 day lookback to support games that cross midnight