### PR TITLE
Modify README for BETA Plugins branch usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,11 +239,12 @@ cd LEDMatrix
 ```
 
 REMOVE ME BEFORE PR:
-To use the Plugins branch type:
+To use the BETA Plugins branch (things will be broken!) on Rasbian 13 Trixie type:
 ```bash
 git checkout plugins
 git pull
 ```
+otherwise continue to the next step for the stable older version (that only works on Rasbian 12!)
 
 4. First-time installation (recommended)
 


### PR DESCRIPTION
Updated instructions for using the BETA Plugins branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates README to clarify using the BETA `plugins` branch on Raspbian 13 (Trixie) and note the stable version works only on Raspbian 12.
> 
> - **Documentation (README)**:
>   - **Installation/Branch Instructions**:
>     - Clarifies using the BETA `plugins` branch on Raspbian 13 Trixie with a stability warning.
>     - Notes the stable older version currently works only on Raspbian 12.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b18a3ed4393eeb5495cea9d59aa69e6691915954. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->