### PR TITLE
Center time better

### DIFF
--- a/src/clock.py
+++ b/src/clock.py
@@ -28,6 +28,7 @@ class Clock:
         self.timezone = self._get_timezone()
         self.last_time = None
         self.last_date = None
+        self.ampm_padding = 4
         # Colors for different elements - using super bright colors
         self.COLORS = {
             'time': (255, 255, 255),    # Pure white for time
@@ -91,9 +92,9 @@ class Clock:
             display_height = self.display_manager.matrix.height
             
             # Center time based on full width of time + ampm
-            time_width = self.display_manager.font.getlength(f"{time_str} ")
+            time_width = self.display_manager.font.getlength(f"{time_str}")
             ampm_width = self.display_manager.font.getlength(f"{ampm}")
-            time_x = (display_width - (time_width + ampm_width)) // 2
+            time_x = (display_width - (time_width + self.ampm_padding + ampm_width)) // 2
             # Draw time (large, centered, near top)
             self.display_manager.draw_text(
                 time_str,
@@ -104,7 +105,7 @@ class Clock:
             )
             
             # Draw AM/PM (small, next to time)
-            ampm_x = time_x + time_width
+            ampm_x = time_x + self.ampm_padding + time_width
             self.display_manager.draw_text(
                 ampm,
                 x=ampm_x,


### PR DESCRIPTION
I noticed the full time string (with am/pm) wasn't fully centred. This fixes it.

I see you're working on a new plugins branch which includes a new clock, so this might be moot soon, but still good to have for now.

Before:

<img width="1036" height="267" alt="Screenshot 2025-12-05 at 3 47 15 PM" src="https://github.com/user-attachments/assets/d46baddf-f224-4e38-bb2c-bcaeb2894b4f" />

After:

<img width="1031" height="263" alt="Screenshot 2025-12-05 at 4 10 59 PM" src="https://github.com/user-attachments/assets/85ab838e-cb30-44e3-8444-7cdb8ddd963b" />

After (2-digit hour):

<img width="1029" height="262" alt="Screenshot 2025-12-05 at 4 11 31 PM" src="https://github.com/user-attachments/assets/9340e3a1-33cc-4948-8656-8fc87c9bf51e" />