### PR TITLE
fix(web): Preserve API error messages in config save handlers

### DIFF
--- a/web_interface/templates/v3/partials/raw_json.html
+++ b/web_interface/templates/v3/partials/raw_json.html
@@ -218,19 +218,28 @@ function saveMainConfig() {
             },
             body: JSON.stringify(config)
         })
-        .then(response => {
-            // Check if response is OK before parsing JSON
-            if (!response.ok) {
-                // Try to parse error response as JSON, fallback to status text
-                return response.json().then(data => {
-                    throw new Error(data.message || response.statusText);
-                }).catch(() => {
-                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-                });
+        .then(async response => {
+            // Store status and statusText before parsing
+            const status = response.status;
+            const statusText = response.statusText;
+            
+            // Try to parse JSON response
+            let data;
+            try {
+                data = await response.json();
+            } catch (parseError) {
+                // If JSON parsing fails, throw generic HTTP error
+                throw new Error(`HTTP ${status}: ${statusText}`);
             }
-            return response.json();
-        })
-        .then(data => {
+            
+            // Handle non-OK responses
+            if (!response.ok) {
+                // Extract specific error message from API response if available
+                const errorMessage = data.message || data.status || statusText;
+                throw new Error(errorMessage);
+            }
+            
+            // Handle successful responses
             if (data.status === 'success') {
                 showNotification('config.json saved successfully!', 'success');
             } else {
@@ -238,6 +247,7 @@ function saveMainConfig() {
             }
         })
         .catch(error => {
+            // Preserve the error message that was intentionally thrown
             showNotification('Error saving config.json: ' + (error.message || 'An error occurred'), 'error');
         });
     } catch (e) {
@@ -265,19 +275,28 @@ function saveSecretsConfig() {
             },
             body: JSON.stringify(config)
         })
-        .then(response => {
-            // Check if response is OK before parsing JSON
-            if (!response.ok) {
-                // Try to parse error response as JSON, fallback to status text
-                return response.json().then(data => {
-                    throw new Error(data.message || response.statusText);
-                }).catch(() => {
-                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-                });
+        .then(async response => {
+            // Store status and statusText before parsing
+            const status = response.status;
+            const statusText = response.statusText;
+            
+            // Try to parse JSON response
+            let data;
+            try {
+                data = await response.json();
+            } catch (parseError) {
+                // If JSON parsing fails, throw generic HTTP error
+                throw new Error(`HTTP ${status}: ${statusText}`);
             }
-            return response.json();
-        })
-        .then(data => {
+            
+            // Handle non-OK responses
+            if (!response.ok) {
+                // Extract specific error message from API response if available
+                const errorMessage = data.message || data.status || statusText;
+                throw new Error(errorMessage);
+            }
+            
+            // Handle successful responses
             if (data.status === 'success') {
                 showNotification('config_secrets.json saved successfully!', 'success');
             } else {
@@ -285,6 +304,7 @@ function saveSecretsConfig() {
             }
         })
         .catch(error => {
+            // Preserve the error message that was intentionally thrown
             showNotification('Error saving config_secrets.json: ' + (error.message || 'An error occurred'), 'error');
         });
     } catch (e) {


### PR DESCRIPTION
- Refactor error handling to use async/await for clearer flow
- Store response status before JSON parsing to preserve context
- Extract specific error messages from API responses (data.message)
- Only use generic HTTP status messages when JSON parsing fails
- Ensure API error messages like validation failures are shown to users instead of generic 'HTTP 500: Internal Server Error'

Fixes issue where specific API error messages were being replaced with generic HTTP status messages in the catch handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for API requests by displaying detailed feedback derived from server responses, helping users understand what went wrong.
  * Enhanced notification system to provide clearer feedback regarding operation success and failure states across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->