### PR TITLE
fix(scripts): Return floats for JSON Schema type 'number' defaults

### DIFF
--- a/scripts/add_defaults_to_schemas.py
+++ b/scripts/add_defaults_to_schemas.py
@@ -38,13 +38,13 @@ def get_default_for_field(prop: Dict[str, Any]) -> Any:
         maximum = prop.get('maximum')
         
         if minimum is not None:
-            return minimum
+            return float(minimum)
         elif maximum is not None:
-            # Use a reasonable fraction of max (like 30% or minimum 1)
-            return max(1, int(maximum * 0.3))
+            # Use a reasonable fraction of max (like 30% or minimum 1.0)
+            return max(1.0, float(maximum) * 0.3)
         else:
-            # No constraints, use 0
-            return 0
+            # No constraints, use 0.0
+            return 0.0
     
     elif prop_type == 'integer':
         # Similar to number


### PR DESCRIPTION
## Description
Fixes issue where integers were being returned for JSON Schema type "number" which could break downstream validation.

## Changes
- Cast minimum to float when returning: `float(minimum)`
- Compute fractional defaults as floats: `max(1.0, float(maximum) * 0.3)`
- Return 0.0 as unconstrained default instead of 0

All branches in the `get_default_for_field()` function for type 'number' now consistently return floats.

## Type of Change
- [x] Bug fix (non-breaking change)

## Testing
- Verified all number type defaults return floats
- No linter errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced numeric field default value generation. Default values now properly apply float precision and better utilize minimum and maximum constraints when calculating appropriate defaults.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->