### PR TITLE
Update Raspberry Pi OS instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ These are not required and you can probably rig up something basic with stuff yo
 # Preparing the Raspberry Pi
 1. Create RPI Image on a Micro-SD card (I use 16gb because I have it, size is not too important but I would use 8gb or more) using [Raspberry Pi Imager](https://www.raspberrypi.com/software/)
 2. Choose your Raspberry Pi (3B+ in my case) 
-3. For Operating System (OS), choose "Other", then choose Raspbian OS (Legacy, 64-bit) Lite  (This needs to be Debian Bookworm not Debian Trixie! Packages are broken on Trixie as of 10/2/25. I will try to get working as soon as requirements are met!) 
+3. For Operating System (OS), choose "Other", then choose Raspbian OS (64-bit) Lite 
 ![image](https://github.com/user-attachments/assets/e8e2e806-18a8-4175-9c25-0cefaae438ea)
 4. For Storage, choose your micro-sd card
 ![image](https://github.com/user-attachments/assets/05580e0a-86d5-4613-aadc-93207365c38f)


### PR DESCRIPTION
Removed mention of Debian Trixie and clarified OS version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation documentation to simplify OS selection guidance by removing compatibility notes for Debian versions. The OS option now clearly states "Raspbian OS (64-bit) Lite" without prior version-related caveats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->