### PR TITLE
fix(fonts): Remove missing cozette.bdf font reference

### DIFF
--- a/src/font_manager.py
+++ b/src/font_manager.py
@@ -63,8 +63,10 @@ class FontManager:
         self.common_fonts = {
             "press_start": "assets/fonts/PressStart2P-Regular.ttf",
             "four_by_six": "assets/fonts/4x6-font.ttf",
-            "five_by_seven": "assets/fonts/5x7.bdf",
-            "cozette_bdf": "assets/fonts/cozette.bdf"
+            "five_by_seven": "assets/fonts/5x7.bdf"
+            # Note: cozette_bdf removed - font file not available
+            # To re-enable: download cozette.bdf from https://github.com/the-moonwitch/Cozette
+            # and add: "cozette_bdf": "assets/fonts/cozette.bdf"
         }
         
         # Size tokens for convenience

--- a/web_interface/templates/v3/partials/fonts.html
+++ b/web_interface/templates/v3/partials/fonts.html
@@ -114,7 +114,6 @@
                     <option value="">Use default</option>
                     <option value="press_start">Press Start 2P</option>
                     <option value="four_by_six">4x6 Font</option>
-                    <option value="cozette_bdf">Cozette BDF</option>
                     <option value="matrix_light_6">Matrix Light 6</option>
                 </select>
             </div>
@@ -166,7 +165,6 @@
                         <select id="preview-family" class="form-control text-sm">
                             <option value="press_start">Press Start 2P</option>
                             <option value="four_by_six">4x6 Font</option>
-                            <option value="cozette_bdf">Cozette BDF</option>
                             <option value="matrix_light_6">Matrix Light 6</option>
                         </select>
                     </div>
@@ -663,7 +661,6 @@ function getFontDisplayName(fontKey) {
     const names = {
         'press_start': 'Press Start 2P',
         'four_by_six': '4x6 Font',
-        'cozette_bdf': 'Cozette BDF',
         'matrix_light_6': 'Matrix Light 6'
     };
     return names[fontKey] || fontKey;


### PR DESCRIPTION
- Removed cozette_bdf from common_fonts dictionary in font_manager.py
- Removed cozette_bdf option from web interface font selectors
- Resolves warning: 'Common font file not found: assets/fonts/cozette.bdf'
- Font can be re-enabled by adding the font file and re-adding to common_fonts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed Cozette BDF font option from the application due to unavailable font file. The font is no longer available in font selection menus and font preview settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->