### PR TITLE
fix(plugins): Remove compatible_versions requirement from single plug…

### DIFF
--- a/src/plugin_system/store_manager.py
+++ b/src/plugin_system/store_manager.py
@@ -974,7 +974,7 @@ class PluginStoreManager:
                 }
             
             # Validate manifest has required fields
-            required_fields = ['id', 'name', 'class_name', 'compatible_versions']
+            required_fields = ['id', 'name', 'class_name']
             missing_fields = [field for field in required_fields if field not in manifest]
             if missing_fields:
                 return {
@@ -982,7 +982,7 @@ class PluginStoreManager:
                     'error': f'Manifest missing required fields: {", ".join(missing_fields)}'
                 }
             
-            # Validate version fields consistency
+            # Validate version fields consistency (warnings only, not required)
             validation_errors = self._validate_manifest_version_fields(manifest)
             if validation_errors:
                 self.logger.warning(f"Manifest version field validation warnings for {plugin_id}: {', '.join(validation_errors)}")


### PR DESCRIPTION
…in install

Remove compatible_versions from required fields in install_from_url method to match install_plugin behavior. This allows installing plugins from URLs without manifest version requirements, consistent with store plugin installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified plugin installation from URLs by removing strict version compatibility requirements.
  * Version validation now displays as a non-blocking warning, allowing installations to proceed more flexibly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->