### PR TITLE
Remove breaking changes and migration details

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,6 @@
 
 -----------------------------------------------------------------------------------
 
-## ⚠️ Breaking Changes
-
-**Important for users upgrading from older versions:**
-
-Script paths have been reorganized. If you have automation, cron jobs, or custom tooling that references old script paths, you **must** update them. See the [Migration Guide](MIGRATION_GUIDE.md) for details.
-
-**Quick Reference:**
-- Installation scripts moved: `install_service.sh` → `scripts/install/install_service.sh`
-- Permission scripts moved: `fix_cache_permissions.sh` → `scripts/fix_perms/fix_cache_permissions.sh`
-
-**Full migration instructions:** See [MIGRATION_GUIDE.md](MIGRATION_GUIDE.md)
-
------------------------------------------------------------------------------------
-
 ## Core Features
 
 <details>
@@ -339,7 +325,7 @@ This single script installs services, dependencies, configures permissions and s
 
 ### Initial Setup
 
-The system uses a template-based configuration approach to avoid Git conflicts during updates:
+Edit the project via the web interface at http://ledpi:5000  or for manual control:
 
 1. **First-time setup**: The previous "First_time_install.sh" script should've already copied the template to create your config.json:
 
@@ -347,20 +333,13 @@ The system uses a template-based configuration approach to avoid Git conflicts d
    ```bash
    sudo nano config/config.json
    ```
-or edit via web interface at http://ledpi:5000
+or 
 
 3. **Having Issues?**: Run the First Time Script again:
   ```bash
   sudo ./first_time_install.sh
   ```
 
-
-### API Keys and Secrets
-
-For sensitive settings like API keys:
-1. Copy the secrets template: `cp config/config_secrets.template.json config/config_secrets.json`
-2. Edit `config/config_secrets.json` with your API keys via `sudo nano config/config_secrets.json`
-3. Ctrl + X to exit, Y to overwrite, Enter to Confirm
 
 ### Automatic Configuration Migration
 


### PR DESCRIPTION
Removed breaking changes section and related migration instructions from the README.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines the README by removing outdated sections and simplifying setup guidance.
> 
> - Removes the top-level "Breaking Changes" banner and migration quick reference
> - Drops the "API Keys and Secrets" subsection while retaining automatic config migration details
> - Simplifies the "Configuration" section to emphasize using the web UI (`http://ledpi:5000`) with concise manual fallback steps
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fd6144f13f6fb3bf196a4d90193e53908fca22f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined setup process to use the web interface for configuration instead of shell scripts and manual setup steps.
  * Removed Breaking Changes section and API key configuration subsection.
  * Updated migration and automatic-configuration guidance for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->