### PR TITLE
fix(logos): Add ncaam/ncaaw sport key aliases for basketball plugin

### DIFF
--- a/src/logo_downloader.py
+++ b/src/logo_downloader.py
@@ -37,6 +37,9 @@ class LogoDownloader:
         'ncaa_fb_all': 'https://site.api.espn.com/apis/site/v2/sports/football/college-football/teams',  # Includes FCS
         'fcs': 'https://site.api.espn.com/apis/site/v2/sports/football/college-football/teams',  # FCS teams from same endpoint
         'ncaam_basketball': 'https://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/teams',
+        'ncaam': 'https://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/teams',  # Alias for basketball plugin
+        'ncaaw_basketball': 'https://site.api.espn.com/apis/site/v2/sports/basketball/womens-college-basketball/teams',
+        'ncaaw': 'https://site.api.espn.com/apis/site/v2/sports/basketball/womens-college-basketball/teams',  # Alias for basketball plugin
         'ncaa_baseball': 'https://site.api.espn.com/apis/site/v2/sports/baseball/college-baseball/teams',
         'ncaam_hockey': 'https://site.api.espn.com/apis/site/v2/sports/hockey/mens-college-hockey/teams',
         # Soccer leagues
@@ -63,6 +66,9 @@ class LogoDownloader:
         'ncaa_fb_all': 'assets/sports/ncaa_logos',
         'fcs': 'assets/sports/ncaa_logos',
         'ncaam_basketball': 'assets/sports/ncaa_logos',
+        'ncaam': 'assets/sports/ncaa_logos',  # Alias for basketball plugin
+        'ncaaw_basketball': 'assets/sports/ncaa_logos',
+        'ncaaw': 'assets/sports/ncaa_logos',  # Alias for basketball plugin
         'ncaa_baseball': 'assets/sports/ncaa_logos',
         'ncaam_hockey': 'assets/sports/ncaa_logos',
         'ncaaw_hockey': 'assets/sports/ncaa_logos',


### PR DESCRIPTION
## Summary
- Fixes NCAA basketball logo resolution issue where logos weren't being found
- Basketball plugin uses `sport_key="ncaam"` and `"ncaaw"`, but `LogoDownloader` only had `"ncaam_basketball"` mapped
- This caused `get_logo_directory()` to fall back to `assets/sports/ncaam_logos` (non-existent) instead of `assets/sports/ncaa_logos`

## Changes
Added aliases to both `LOGO_DIRECTORIES` and `API_ENDPOINTS` in `src/logo_downloader.py`:
- `ncaam` -> `assets/sports/ncaa_logos`
- `ncaaw` -> `assets/sports/ncaa_logos`
- `ncaaw_basketball` -> `assets/sports/ncaa_logos` (for consistency)

## Test plan
- [ ] Run basketball scoreboard plugin with NCAA games
- [ ] Verify logs show correct logo directory: `assets/sports/ncaa_logos`
- [ ] Confirm NCAA team logos display correctly
- [ ] Verify football scoreboard still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for NCAA basketball leagues, enabling logo downloads for men's college basketball and women's college basketball teams.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->