### PR TITLE
fix: prevent /tmp permission corruption breaking system updates

### DIFF
--- a/src/display_manager.py
+++ b/src/display_manager.py
@@ -816,8 +816,12 @@ class DisplayManager:
                 get_assets_file_mode
             )
             snapshot_path_obj = Path(self._snapshot_path)
-            if snapshot_path_obj.parent:
-                ensure_directory_permissions(snapshot_path_obj.parent, get_assets_dir_mode())
+            # Only ensure permissions on non-system directories
+            # Never modify /tmp permissions - it has special system permissions (1777)
+            # that must not be changed or it breaks apt and other system tools
+            parent_dir = snapshot_path_obj.parent
+            if parent_dir and str(parent_dir) != '/tmp':
+                ensure_directory_permissions(parent_dir, get_assets_dir_mode())
             # Write atomically: temp then replace
             tmp_path = f"{self._snapshot_path}.tmp"
             self.image.save(tmp_path, format='PNG')


### PR DESCRIPTION
Issue: LEDMatrix was changing /tmp permissions from 1777 (drwxrwxrwt) to 2775 (drwxrwsr-x), breaking apt update and other system tools.

Root cause: display_manager.py's _write_snapshot_if_due() called ensure_directory_permissions() on /tmp when writing snapshots to /tmp/led_matrix_preview.png. This removed the sticky bit and world-writable permissions that /tmp requires.

Fix:
- Added PROTECTED_SYSTEM_DIRECTORIES safelist to permission_utils.py to prevent modifying permissions on /tmp and other system directories
- Added explicit check in display_manager.py to skip /tmp
- Defense-in-depth approach prevents similar issues in other code paths

The sticky bit (1xxx) is critical for /tmp - it prevents users from deleting files they don't own. Without world-writable permissions, regular users cannot create temp files.

Fixes #202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system stability by adding safeguards to prevent permission modifications on critical system directories
  * Temporary and system directories are now properly excluded from permission changes during snapshot operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->