### PR TITLE
fix: reduce scroll catch-up steps to limit jitter

### DIFF
--- a/src/common/scroll_helper.py
+++ b/src/common/scroll_helper.py
@@ -240,7 +240,7 @@ class ScrollHelper:
                 # Move pixels (can move multiple steps if lag occurred, but cap to prevent huge jumps)
                 steps = int(time_since_last_step / self.scroll_delay)
                 # Cap at reasonable number to prevent huge jumps from lag
-                max_steps = max(1, int(0.1 / self.scroll_delay))  # Allow up to 0.1s of catch-up
+                max_steps = max(1, int(0.04 / self.scroll_delay))  # Limit to 0.04s (2 steps at 50 FPS) for smoother scrolling
                 steps = min(steps, max_steps)
                 pixels_to_move = self.scroll_speed * steps
                 # Update last_step_time, preserving fractional delay for smooth timing


### PR DESCRIPTION
## Summary
Reduce max_steps from 0.1s to 0.04s of catch-up time (from 5 to 2 steps at 50 FPS) to fix jittery scrolling.

## Problem
When the system lags, the previous catch-up logic allowed jumping up to 5 pixels at once, causing visible jitter on the LED matrix display.

## Solution
Limit catch-up to 2 steps maximum, providing smoother scrolling while still allowing for minor timing corrections.

## Test plan
- [ ] Observe scrolling on LED matrix display
- [ ] Verify smoother scrolling with reduced jitter

🤖 Generated with [Claude Code](https://claude.com/claude-code)