### PR TITLE
fix: remove plugin-specific calendar duration from config template

### DIFF
--- a/config/config.template.json
+++ b/config/config.template.json
@@ -113,9 +113,7 @@
         "runtime": {
             "gpio_slowdown": 3
         },
-        "display_durations": {
-            "calendar": 30
-        },
+        "display_durations": {},
         "use_short_date_format": true,
         "vegas_scroll": {
             "enabled": false,


### PR DESCRIPTION
## Summary
- Removed hardcoded `calendar: 30` from `display_durations` in the config template
- Plugin display durations should be added dynamically when plugins are installed, not hardcoded in the template

## Test plan
- [ ] Verify new installs work without calendar in display_durations
- [ ] Verify existing configs with calendar duration still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused calendar display duration configuration setting from default configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->