### PR TITLE
feat(config): add led_rgb_sequence option to config template

### DIFF
--- a/config/config.template.json
+++ b/config/config.template.json
@@ -108,6 +108,7 @@
             "disable_hardware_pulsing": false,
             "inverse_colors": false,
             "show_refresh_rate": false,
+            "led_rgb_sequence": "RGB",
             "limit_refresh_rate_hz": 100
         },
         "runtime": {


### PR DESCRIPTION
## Summary
- Adds the `led_rgb_sequence` configuration option to the matrix config template
- This allows users to specify the RGB sequence for their LED panels (e.g., RGB, RBG, GRB, etc.)

## Test plan
- [ ] Verify config loads correctly with the new option
- [ ] Test with different RGB sequence values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LED RGB sequence configuration option for display hardware settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->