### PR TITLE
feat(web): add shutdown button to Quick Actions

### DIFF
--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -1339,6 +1339,9 @@ def execute_system_action():
         elif action == 'reboot_system':
             result = subprocess.run(['sudo', 'reboot'],
                                  capture_output=True, text=True)
+        elif action == 'shutdown_system':
+            result = subprocess.run(['sudo', 'poweroff'],
+                                 capture_output=True, text=True)
         elif action == 'git_pull':
             # Use PROJECT_ROOT instead of hardcoded path
             project_dir = str(PROJECT_ROOT)

--- a/web_interface/templates/v3/partials/overview.html
+++ b/web_interface/templates/v3/partials/overview.html
@@ -124,6 +124,16 @@
             </button>
 
             <button hx-post="/api/v3/system/action"
+                    hx-vals='{"action": "shutdown_system"}'
+                    hx-confirm="Are you sure you want to shut down the system? This will power off the Raspberry Pi."
+                    hx-swap="none"
+                    hx-on:htmx:after-request="if (typeof showNotification !== 'undefined' && event.detail.xhr && event.detail.xhr.responseJSON) { showNotification(event.detail.xhr.responseJSON.message || 'System shutting down...', event.detail.xhr.responseJSON.status || 'info'); }"
+                    class="inline-flex items-center px-4 py-2 border border-transparent text-base font-semibold rounded-md text-white bg-red-800 hover:bg-red-900">
+                <i class="fas fa-power-off mr-2"></i>
+                Shutdown System
+            </button>
+
+            <button hx-post="/api/v3/system/action"
                     hx-vals='{"action": "restart_display_service"}'
                     hx-swap="none"
                     hx-on:htmx:after-request="if (typeof showNotification !== 'undefined' && event.detail.xhr && event.detail.xhr.responseJSON) { showNotification(event.detail.xhr.responseJSON.message || 'Display service restarted', event.detail.xhr.responseJSON.status || 'success'); }"


### PR DESCRIPTION
## Summary
- Add "Shutdown System" button to the Overview page Quick Actions section
- Uses `sudo poweroff` for graceful shutdown (permissions already configured in sudoers)
- Includes confirmation dialog before shutdown
- Styled with dark red color to differentiate from reboot button

## Test plan
- [ ] Navigate to Overview page in web UI
- [ ] Verify "Shutdown System" button appears after "Reboot System" button
- [ ] Click button and verify confirmation dialog appears
- [ ] (On Pi) Confirm button triggers graceful shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new remote-triggered host power-off path (`sudo poweroff`), which is operationally disruptive if misused or accidentally triggered; otherwise the change is small and localized.
> 
> **Overview**
> Adds a new **Shutdown System** quick action in the Overview page, with confirmation and distinct red styling, that triggers a backend system action.
> 
> Extends the `api_v3` system action handler to support `shutdown_system` by invoking `sudo poweroff` and returning the standard JSON response used by other system controls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9dd3c72563c439c7452cb824551639b806011be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Shutdown System quick action to system controls, placed alongside Reboot. The button shows a power-off icon, uses red styling, and requires confirmation to prevent accidental shutdown.
  * Enables remote system shutdown via the quick action and provides an on-screen notification with the outcome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->