### PR TITLE
fix(web): dark mode for collapsible config section headers

### DIFF
--- a/web_interface/static/v3/app.css
+++ b/web_interface/static/v3/app.css
@@ -102,6 +102,7 @@ body {
 
 /* Utility classes */
 .bg-gray-50 { background-color: #f9fafb; }
+.bg-gray-100 { background-color: #f3f4f6; }
 .bg-white { background-color: #ffffff; }
 .bg-gray-900 { background-color: #111827; }
 .bg-green-500 { background-color: #10b981; }


### PR DESCRIPTION
## Summary
- Collapsible section headers in plugin config schemas (e.g., "Text Scrolling", "Title", "Artist") were unreadable in dark mode — light text on a light `bg-gray-100` background
- Added missing dark mode overrides for `bg-gray-100` and `hover:bg-gray-200` in the utility class override section of `app.css`

## Test plan
- [ ] Navigate to a plugin config page with nested collapsible sections (e.g., music plugin "Text Scrolling")
- [ ] Toggle dark mode and verify section header buttons have a dark background with readable light text
- [ ] Verify hover state provides visible feedback
- [ ] Verify light mode appearance is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved theme styling: added refined background color for light mode and matching hover rules.
  * Enhanced dark-mode overrides for background and hover states to align with other utilities.
  * Minor reordering of style rules for consistency, preserving existing color utilities and overall visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->