### PR TITLE
fix(web): wire up "Check & Update All" plugins button

### DIFF
--- a/web_interface/static/v3/js/plugins/install_manager.js
+++ b/web_interface/static/v3/js/plugins/install_manager.js
@@ -80,26 +80,34 @@ const PluginInstallManager = {
     
     /**
      * Update all plugins.
-     * 
+     *
+     * @param {Function} onProgress - Optional callback(index, total, pluginId) for progress updates
      * @returns {Promise<Array>} Update results
      */
-    async updateAll() {
+    async updateAll(onProgress) {
         if (!window.PluginStateManager || !window.PluginStateManager.installedPlugins) {
             throw new Error('Installed plugins not loaded');
         }
-        
+
         const plugins = window.PluginStateManager.installedPlugins;
         const results = [];
-        
-        for (const plugin of plugins) {
+
+        for (let i = 0; i < plugins.length; i++) {
+            const plugin = plugins[i];
+            if (onProgress) onProgress(i + 1, plugins.length, plugin.id);
             try {
-                const result = await this.update(plugin.id);
+                const result = await window.PluginAPI.updatePlugin(plugin.id);
                 results.push({ pluginId: plugin.id, success: true, result });
             } catch (error) {
                 results.push({ pluginId: plugin.id, success: false, error });
             }
         }
-        
+
+        // Reload plugin list once at the end
+        if (window.PluginStateManager) {
+            await window.PluginStateManager.loadInstalledPlugins();
+        }
+
         return results;
     }
 };
@@ -109,5 +117,6 @@ if (typeof module !== 'undefined' && module.exports) {
     module.exports = PluginInstallManager;
 } else {
     window.PluginInstallManager = PluginInstallManager;
+    window.updateAllPlugins = (onProgress) => PluginInstallManager.updateAll(onProgress);
 }
 


### PR DESCRIPTION
## Summary
- `window.updateAllPlugins` was never assigned, so the "Check & Update All" button always failed with "Bulk update handler unavailable"
- Wired the global to `PluginInstallManager.updateAll()` which already existed but was unused
- Added per-plugin progress feedback in the button text (e.g., "Updating 3/10...")
- Shows a summary notification on completion (e.g., "3 updated, 5 already up to date, 1 failed")
- Optimized `updateAll()` to call the API directly and reload the plugin list once at the end, instead of reloading after every single plugin

## Test plan
- [ ] Open Plugin Manager tab in the web UI
- [ ] Click "Check & Update All" button
- [ ] Verify the button shows per-plugin progress (e.g., "Updating 2/10...")
- [ ] Verify a summary notification appears when done
- [ ] Verify button re-enables after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time progress updates during bulk plugin updates showing current position (e.g., "Updating 2/5").
  * Enhanced update result notifications with summary details—displays counts of successful, already-current, and failed plugins with appropriate alert levels based on outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->