### PR TITLE
fix(web): use window.installedPlugins for bulk update button

### DIFF
--- a/web_interface/static/v3/js/plugins/install_manager.js
+++ b/web_interface/static/v3/js/plugins/install_manager.js
@@ -81,10 +81,9 @@ const PluginInstallManager = {
     /**
      * Update all plugins.
      *
-     * @param {Function} onProgress - Optional callback(index, total, pluginId) for progress updates
      * @returns {Promise<Array>} Update results
      */
-    async updateAll(onProgress) {
+    async updateAll() {
         if (!window.PluginStateManager || !window.PluginStateManager.installedPlugins) {
             throw new Error('Installed plugins not loaded');
         }
@@ -92,20 +91,13 @@ const PluginInstallManager = {
         const plugins = window.PluginStateManager.installedPlugins;
         const results = [];
 
-        for (let i = 0; i < plugins.length; i++) {
-            const plugin = plugins[i];
-            if (onProgress) onProgress(i + 1, plugins.length, plugin.id);
+        for (const plugin of plugins) {
             try {
-                const result = await window.PluginAPI.updatePlugin(plugin.id);
+                const result = await this.update(plugin.id);
                 results.push({ pluginId: plugin.id, success: true, result });
             } catch (error) {
                 results.push({ pluginId: plugin.id, success: false, error });
             }
-        }
-
-        // Reload plugin list once at the end
-        if (window.PluginStateManager) {
-            await window.PluginStateManager.loadInstalledPlugins();
         }
 
         return results;
@@ -117,6 +109,5 @@ if (typeof module !== 'undefined' && module.exports) {
     module.exports = PluginInstallManager;
 } else {
     window.PluginInstallManager = PluginInstallManager;
-    window.updateAllPlugins = (onProgress) => PluginInstallManager.updateAll(onProgress);
 }
 


### PR DESCRIPTION
## Summary
- Fixes the "Check & Update All" button which was broken by #249
- #249 overrode `window.updateAllPlugins` with a version using `PluginStateManager.installedPlugins`, which is never populated on page load (empty array)
- `base.html` already had a working version using `window.installedPlugins` (reliably populated by `plugins_manager.js`), but the override masked it
- Reverts `install_manager.js` back to original
- Rewrites `runUpdateAllPlugins` to iterate `window.installedPlugins` directly and call the API endpoint without any middleman function
- Adds per-plugin progress in button text ("Updating 3/10...")
- Shows summary notification on completion ("3 updated, 5 already up to date, 1 failed")

## Test plan
- [ ] Open Plugin Manager tab
- [ ] Click "Check & Update All"
- [ ] Verify button shows per-plugin progress
- [ ] Verify summary notification appears when done
- [ ] Verify button re-enables after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin updates now run sequentially so failures don't stop remaining updates.
  * Improved error handling and clearer notifications when controls are missing or no plugins are installed.
  * Per-plugin progress and aggregated results summary added for clearer visibility.

* **Improvements**
  * Update button shows per-plugin progress (e.g., Updating i/total) and UI reliably restores after completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->