### PR TITLE
perf(store): cache GitHub API calls for faster plugin store loading

### DIFF
--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -1737,6 +1737,9 @@ def get_installed_plugins():
         # Get all installed plugin info from the plugin manager
         all_plugin_info = api_v3.plugin_manager.get_all_plugin_info()
 
+        # Load config once before the loop (not per-plugin)
+        full_config = api_v3.config_manager.load_config() if api_v3.config_manager else {}
+
         # Format for the web interface
         plugins = []
         for plugin_info in all_plugin_info:
@@ -1758,7 +1761,6 @@ def get_installed_plugins():
             # Read from config file first, fall back to plugin instance if config doesn't have the key
             enabled = None
             if api_v3.config_manager:
-                full_config = api_v3.config_manager.load_config()
                 plugin_config = full_config.get(plugin_id, {})
                 # Check if 'enabled' key exists in config (even if False)
                 if 'enabled' in plugin_config:
@@ -1773,8 +1775,8 @@ def get_installed_plugins():
                     # Default to True if no config key and plugin not loaded (matches BasePlugin default)
                     enabled = True
 
-            # Get verified status from store registry (if available)
-            store_info = api_v3.plugin_store_manager.get_plugin_info(plugin_id)
+            # Get verified status from store registry (no GitHub API calls needed)
+            store_info = api_v3.plugin_store_manager.get_registry_info(plugin_id)
             verified = store_info.get('verified', False) if store_info else False
 
             # Get local git info for installed plugin (actual installed commit)

--- a/web_interface/blueprints/pages_v3.py
+++ b/web_interface/blueprints/pages_v3.py
@@ -186,6 +186,9 @@ def _load_plugins_partial():
                 # Get all installed plugin info
                 all_plugin_info = pages_v3.plugin_manager.get_all_plugin_info()
 
+                # Load config once before the loop (not per-plugin)
+                full_config = pages_v3.config_manager.load_config() if pages_v3.config_manager else {}
+
                 # Format for the web interface
                 for plugin_info in all_plugin_info:
                     plugin_id = plugin_info.get('id')
@@ -206,7 +209,6 @@ def _load_plugins_partial():
                     # Read from config file first, fall back to plugin instance if config doesn't have the key
                     enabled = None
                     if pages_v3.config_manager:
-                        full_config = pages_v3.config_manager.load_config()
                         plugin_config = full_config.get(plugin_id, {})
                         # Check if 'enabled' key exists in config (even if False)
                         if 'enabled' in plugin_config:
@@ -221,8 +223,8 @@ def _load_plugins_partial():
                             # Default to True if no config key and plugin not loaded (matches BasePlugin default)
                             enabled = True
 
-                    # Get verified status from store registry
-                    store_info = pages_v3.plugin_store_manager.get_plugin_info(plugin_id)
+                    # Get verified status from store registry (no GitHub API calls needed)
+                    store_info = pages_v3.plugin_store_manager.get_registry_info(plugin_id)
                     verified = store_info.get('verified', False) if store_info else False
 
                     last_updated = plugin_info.get('last_updated')


### PR DESCRIPTION
## Summary
The plugin store pages were extremely slow (10-30 seconds) due to excessive GitHub API calls:

- **Installed plugins endpoint**: Called `get_plugin_info()` for each plugin (3 GitHub API calls each) just to read `verified` — which is already in the cached registry. Now uses new `get_registry_info()` (zero API calls)
- **`_get_latest_commit_info()`**: No cache. All 31 monorepo plugins share the same repo URL, causing **31 identical API calls**. Now cached for 5 minutes (keyed by `repo:branch`)
- **`_fetch_manifest_from_github()`**: No cache. 31 calls per store load. Now cached for 5 minutes
- **`load_config()`**: Called inside the plugin loop (once per plugin) in both `api_v3.py` and `pages_v3.py`. Hoisted outside the loop
- **Install/update safety**: These operations pass `force_refresh=True` to bypass caches and always get the real latest commit SHA from GitHub

### Expected improvement
| Scenario | Before | After |
|----------|--------|-------|
| Installed plugins | ~6-15s | ~50ms |
| Store list (first load) | ~13-30s | ~1-2s |
| Store list (cached) | ~13-30s | ~50ms |

## Test plan
- [ ] Open Plugin Manager tab — installed plugins should load near-instantly
- [ ] Switch to Store tab — should load in 1-2s instead of 10-30s
- [ ] Refresh Store tab — should be near-instant (cached)
- [ ] Verify installed plugins show: name, version, enabled, verified badge, last updated, commit info
- [ ] Verify store plugins show: stars, last updated, commit info, description
- [ ] Push a plugin update to GitHub, then click Update on the Pi — should pick up the new commit immediately
- [ ] Install a new plugin — should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Plugin metadata is now cached to improve load times and reduce API requests.
  * Cache automatically refreshes at configurable intervals.

* **New Features**
  * Added ability to force refresh plugin information on demand.

* **Improvements**
  * Plugin lookups now use registry-based retrieval for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->