### PR TITLE
fix(cache): move odds key check before live/scoreboard in get_data_type_from_key

### DIFF
--- a/src/cache/cache_strategy.py
+++ b/src/cache/cache_strategy.py
@@ -206,8 +206,6 @@ class CacheStrategy:
 
         # Live sports data (only reached if key does NOT contain 'odds')
         if any(x in key_lower for x in ['live', 'current', 'scoreboard']):
-            if 'soccer' in key_lower:
-                return 'sports_live'  # Soccer live data is very time-sensitive
             return 'sports_live'
 
         # Weather data


### PR DESCRIPTION
## Summary

- **Bug 2 — cache key order bug in `get_data_type_from_key`:** Cache keys like `odds_espn_nba_game_123_live` contain the word `'live'`, so they were matched by the generic `['live', 'current', 'scoreboard']` branch first and returned `sports_live` (30s TTL) — the `'odds'` branch was never reached. This caused live odds to expire every 30 seconds instead of the intended 120 seconds (`odds_live`), hitting the ESPN odds API 4x more often than necessary and risking rate-limiting. Fixed by moving the `'odds'` check above the `'live'/'current'/'scoreboard'` check so the more-specific match wins.

No regressions: pure `live_*` / `scoreboard_*` keys (without `'odds'`) still route to `sports_live` as before. Pure `odds_*` keys without `'live'` still return `'odds'` (1800s TTL).

## Test plan

- [ ] In a Python REPL: `from src.cache.cache_strategy import CacheStrategy; print(CacheStrategy().get_data_type_from_key("odds_espn_nba_game_123_live"))` — should print `odds_live` (was `sports_live`)
- [ ] Verify `get_data_type_from_key("scoreboard_data_basketball_nba_20260223")` still returns `sports_live`
- [ ] Verify `get_data_type_from_key("odds_espn_nfl_game_456")` still returns `odds`
- [ ] During a live game, confirm odds cache fetch gaps in logs are ~120s not ~30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache logic to properly prioritize and distinguish between live and upcoming odds data.

* **Refactor**
  * Improved cache strategy decision-making by eliminating redundant checks and streamlining data type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->