### PR TITLE
fix(test): repair test infrastructure and mock fixtures

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+# Test package

--- a/test/test_config_validation_edge_cases.py
+++ b/test/test_config_validation_edge_cases.py
@@ -23,6 +23,7 @@ if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
 from src.config_manager import ConfigManager
+from src.exceptions import ConfigError
 from src.plugin_system.schema_manager import SchemaManager
 
 
@@ -30,35 +31,31 @@ class TestInvalidJson:
     """Test handling of invalid JSON in config files."""
 
     def test_invalid_json_syntax(self, tmp_path):
-        """Config with invalid JSON syntax should be handled gracefully."""
+        """Config with invalid JSON syntax should raise ConfigError."""
         config_file = tmp_path / "config.json"
         config_file.write_text("{ invalid json }")
 
-        with patch.object(ConfigManager, '_get_config_path', return_value=str(config_file)):
-            config_manager = ConfigManager(config_dir=str(tmp_path))
-            # Should not raise, should return empty or default config
-            config = config_manager.load_config()
-            assert isinstance(config, dict)
+        config_manager = ConfigManager(config_path=str(config_file))
+        with pytest.raises(ConfigError):
+            config_manager.load_config()
 
     def test_truncated_json(self, tmp_path):
-        """Config with truncated JSON should be handled gracefully."""
+        """Config with truncated JSON should raise ConfigError."""
         config_file = tmp_path / "config.json"
         config_file.write_text('{"plugin": {"enabled": true')  # Missing closing braces
 
-        with patch.object(ConfigManager, '_get_config_path', return_value=str(config_file)):
-            config_manager = ConfigManager(config_dir=str(tmp_path))
-            config = config_manager.load_config()
-            assert isinstance(config, dict)
+        config_manager = ConfigManager(config_path=str(config_file))
+        with pytest.raises(ConfigError):
+            config_manager.load_config()
 
     def test_empty_config_file(self, tmp_path):
-        """Empty config file should be handled gracefully."""
+        """Empty config file should raise ConfigError."""
         config_file = tmp_path / "config.json"
         config_file.write_text("")
 
-        with patch.object(ConfigManager, '_get_config_path', return_value=str(config_file)):
-            config_manager = ConfigManager(config_dir=str(tmp_path))
-            config = config_manager.load_config()
-            assert isinstance(config, dict)
+        config_manager = ConfigManager(config_path=str(config_file))
+        with pytest.raises(ConfigError):
+            config_manager.load_config()
 
 
 class TestTypeValidation:

--- a/test/test_display_controller.py
+++ b/test/test_display_controller.py
@@ -209,11 +209,12 @@ class TestDisplayControllerSchedule:
     def test_schedule_disabled(self, test_display_controller):
         """Test when schedule is disabled."""
         controller = test_display_controller
-        controller.config = {"schedule": {"enabled": False}}
-        
+        schedule_config = {"schedule": {"enabled": False}}
+        controller.config_service.get_config.return_value = schedule_config
+
         controller._check_schedule()
         assert controller.is_display_active is True
-        
+
     def test_active_hours(self, test_display_controller):
         """Test active hours check."""
         controller = test_display_controller
@@ -222,15 +223,16 @@ class TestDisplayControllerSchedule:
             mock_datetime.now.return_value.strftime.return_value.lower.return_value = "monday"
             mock_datetime.now.return_value.time.return_value = datetime.strptime("12:00", "%H:%M").time()
             mock_datetime.strptime = datetime.strptime
-            
-            controller.config = {
+
+            schedule_config = {
                 "schedule": {
                     "enabled": True,
                     "start_time": "09:00",
                     "end_time": "17:00"
                 }
             }
-            
+            controller.config_service.get_config.return_value = schedule_config
+
             controller._check_schedule()
             assert controller.is_display_active is True
 
@@ -242,15 +244,16 @@ class TestDisplayControllerSchedule:
             mock_datetime.now.return_value.strftime.return_value.lower.return_value = "monday"
             mock_datetime.now.return_value.time.return_value = datetime.strptime("20:00", "%H:%M").time()
             mock_datetime.strptime = datetime.strptime
-            
-            controller.config = {
+
+            schedule_config = {
                 "schedule": {
                     "enabled": True,
                     "start_time": "09:00",
                     "end_time": "17:00"
                 }
             }
-            
+            controller.config_service.get_config.return_value = schedule_config
+
             controller._check_schedule()
             assert controller.is_display_active is False
             

--- a/test/test_display_controller.py
+++ b/test/test_display_controller.py
@@ -210,15 +210,13 @@ class TestDisplayControllerSchedule:
         """Test when schedule is disabled."""
         controller = test_display_controller
         schedule_config = {"schedule": {"enabled": False}}
-        controller.config_service.get_config.return_value = schedule_config
-
-        controller._check_schedule()
-        assert controller.is_display_active is True
+        with patch.object(controller.config_service, 'get_config', return_value=schedule_config):
+            controller._check_schedule()
+            assert controller.is_display_active is True
 
     def test_active_hours(self, test_display_controller):
         """Test active hours check."""
         controller = test_display_controller
-        # Mock datetime to be within active hours
         with patch('src.display_controller.datetime') as mock_datetime:
             mock_datetime.now.return_value.strftime.return_value.lower.return_value = "monday"
             mock_datetime.now.return_value.time.return_value = datetime.strptime("12:00", "%H:%M").time()
@@ -231,15 +229,13 @@ class TestDisplayControllerSchedule:
                     "end_time": "17:00"
                 }
             }
-            controller.config_service.get_config.return_value = schedule_config
-
-            controller._check_schedule()
-            assert controller.is_display_active is True
+            with patch.object(controller.config_service, 'get_config', return_value=schedule_config):
+                controller._check_schedule()
+                assert controller.is_display_active is True
 
     def test_inactive_hours(self, test_display_controller):
         """Test inactive hours check."""
         controller = test_display_controller
-        # Mock datetime to be outside active hours
         with patch('src.display_controller.datetime') as mock_datetime:
             mock_datetime.now.return_value.strftime.return_value.lower.return_value = "monday"
             mock_datetime.now.return_value.time.return_value = datetime.strptime("20:00", "%H:%M").time()
@@ -252,9 +248,8 @@ class TestDisplayControllerSchedule:
                     "end_time": "17:00"
                 }
             }
-            controller.config_service.get_config.return_value = schedule_config
-
-            controller._check_schedule()
-            assert controller.is_display_active is False
+            with patch.object(controller.config_service, 'get_config', return_value=schedule_config):
+                controller._check_schedule()
+                assert controller.is_display_active is False
             
 from datetime import datetime

--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -29,7 +29,11 @@ def mock_config_manager():
     }
     mock.get_config_path.return_value = 'config/config.json'
     mock.get_secrets_path.return_value = 'config/config_secrets.json'
-    mock.get_raw_file_content.return_value = {'weather': {'api_key': 'test'}}
+    mock.get_raw_file_content.return_value = {
+        'display': {'brightness': 50},
+        'plugins': {},
+        'timezone': 'UTC'
+    }
     mock.save_config_atomic.return_value = MagicMock(
         status=MagicMock(value='success'),
         message=None
@@ -104,7 +108,7 @@ class TestConfigAPI:
         assert data.get('status') == 'success'
         assert 'data' in data
         assert 'display' in data['data']
-        mock_config_manager.load_config.assert_called_once()
+        mock_config_manager.get_raw_file_content.assert_called_once_with('main')
     
     def test_save_main_config(self, client, mock_config_manager):
         """Test saving main configuration."""

--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -391,17 +391,21 @@ class TestPluginsAPI:
     
     def test_get_plugin_config(self, client, mock_config_manager):
         """Test getting plugin configuration."""
+        # Plugin configs live at top-level keys (not under 'plugins')
         mock_config_manager.load_config.return_value = {
-            'plugins': {
-                'weather': {
-                    'enabled': True,
-                    'api_key': 'test_key'
-                }
+            'weather': {
+                'enabled': True,
+                'api_key': 'test_key'
             }
         }
-        
+
+        # Ensure schema manager returns serializable values
+        from web_interface.blueprints.api_v3 import api_v3
+        api_v3.schema_manager.generate_default_config.return_value = {'enabled': False}
+        api_v3.schema_manager.merge_with_defaults.side_effect = lambda config, defaults: {**defaults, **config}
+
         response = client.get('/api/v3/plugins/config?plugin_id=weather')
-        
+
         assert response.status_code == 200
         data = json.loads(response.data)
         assert 'enabled' in data or 'config' in data or 'data' in data

--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -29,11 +29,13 @@ def mock_config_manager():
     }
     mock.get_config_path.return_value = 'config/config.json'
     mock.get_secrets_path.return_value = 'config/config_secrets.json'
-    mock.get_raw_file_content.return_value = {
+    mock_config = {
         'display': {'brightness': 50},
         'plugins': {},
         'timezone': 'UTC'
     }
+    mock.load_config.return_value = mock_config
+    mock.get_raw_file_content.return_value = mock_config
     mock.save_config_atomic.return_value = MagicMock(
         status=MagicMock(value='success'),
         message=None
@@ -108,7 +110,7 @@ class TestConfigAPI:
         assert data.get('status') == 'success'
         assert 'data' in data
         assert 'display' in data['data']
-        mock_config_manager.get_raw_file_content.assert_called_once_with('main')
+        mock_config_manager.load_config.assert_called_once()
     
     def test_save_main_config(self, client, mock_config_manager):
         """Test saving main configuration."""


### PR DESCRIPTION
## Summary
- Fix `ConfigManager` test mocks to use `config_path` parameter instead of patching private `_get_config_path` method
- Update `DisplayController` schedule tests to use `config_service.get_config()` mock instead of setting `controller.config` directly
- Fix `test_web_api.py` to correctly mock `plugin_manager` methods
- Add missing `test/__init__.py` for proper test package discovery

## Test plan
- [ ] `pytest test/test_config_validation_edge_cases.py` passes
- [ ] `pytest test/test_display_controller.py` passes
- [ ] `pytest test/test_web_api.py` passes
- [ ] Full test suite: `pytest --no-cov -x`

Co-Authored-By: 5ymb01 <noreply@github.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test package marker to enable package import.
  * Strengthened config-validation tests to expect errors for malformed or empty JSON and to use the manager for loading.
  * Updated display-controller tests to read configuration via the config service rather than assigning it directly.
  * Aligned web API test fixtures and mocks with the loader’s full configuration shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->