### PR TITLE
fix: narrow bare except blocks to specific exception types

### DIFF
--- a/src/layout_manager.py
+++ b/src/layout_manager.py
@@ -238,7 +238,7 @@ class LayoutManager:
         # Format the text
         try:
             text = format_str.format(value=value)
-        except:
+        except (ValueError, TypeError, KeyError, IndexError):
             text = str(value)
         
         self.display_manager.draw_text(text, x, y, color)

--- a/src/logo_downloader.py
+++ b/src/logo_downloader.py
@@ -237,7 +237,7 @@ class LogoDownloader:
                 logger.error(f"Downloaded file for {team_abbreviation} is not a valid image or conversion failed: {e}")
                 try:
                     os.remove(filepath)  # Remove invalid file
-                except:
+                except OSError:
                     pass
                 return False
             
@@ -642,10 +642,10 @@ class LogoDownloader:
             # Try to load a font, fallback to default
             try:
                 font = ImageFont.truetype("assets/fonts/PressStart2P-Regular.ttf", 12)
-            except:
+            except (OSError, IOError):
                 try:
                     font = ImageFont.load_default()
-                except:
+                except (OSError, IOError):
                     font = None
             
             # Draw team abbreviation

--- a/web_interface/app.py
+++ b/web_interface/app.py
@@ -442,7 +442,7 @@ def system_status_generator():
                 try:
                     with open('/sys/class/thermal/thermal_zone0/temp', 'r') as f:
                         cpu_temp = round(float(f.read()) / 1000.0, 1)
-                except:
+                except (OSError, ValueError):
                     pass
                     
             except ImportError:
@@ -456,7 +456,7 @@ def system_status_generator():
                 result = subprocess.run(['systemctl', 'is-active', 'ledmatrix'], 
                                       capture_output=True, text=True, timeout=2)
                 service_active = result.stdout.strip() == 'active'
-            except:
+            except (subprocess.SubprocessError, OSError):
                 pass
             
             status = {
@@ -492,7 +492,7 @@ def display_preview_generator():
         parallel = main_config.get('display', {}).get('hardware', {}).get('parallel', 1)
         width = cols * chain_length
         height = rows * parallel
-    except:
+    except (KeyError, TypeError, ValueError):
         width = 128
         height = 64
     


### PR DESCRIPTION
## Summary
- Replace 6 bare `except:` blocks with targeted exception types across 3 files
- `src/logo_downloader.py`: `OSError` for file removal failure, `(OSError, IOError)` for font loading fallback
- `src/layout_manager.py`: `(ValueError, TypeError, KeyError, IndexError)` for `str.format()` failures
- `web_interface/app.py`: `(OSError, ValueError)` for CPU temp reading, `(SubprocessError, OSError)` for systemctl check, `(KeyError, TypeError, ValueError)` for config parsing fallback

## Rationale
Bare `except:` catches `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` — which should always propagate. Narrowing to specific types prevents masking unexpected failures while preserving the intended fallback behavior.

## Test plan
- [ ] `grep -rn "except:" src/logo_downloader.py src/layout_manager.py web_interface/app.py` — zero bare excepts
- [ ] Web UI SSE stats stream still reports CPU temp on Pi
- [ ] Display controller renders layouts with format strings correctly
- [ ] Logo generation fallback fonts still work when PressStart2P is missing

Co-Authored-By: 5ymb01 <noreply@github.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling by refining exception management specificity across data processing, file operations, and system monitoring components. These targeted changes enhance application stability, strengthen error detection capabilities, and improve overall system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->