### PR TITLE
fix(security): stop leaking Python tracebacks to HTTP clients

### DIFF
--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -406,13 +406,10 @@ def save_schedule_config():
 
         return success_response(message='Schedule configuration saved successfully')
     except Exception as e:
-        import logging
-        import traceback
-        error_msg = f"Error saving schedule config: {str(e)}\n{traceback.format_exc()}"
-        logging.error(error_msg)
+        logger.exception("[ScheduleConfig] Failed to save schedule configuration")
         return error_response(
             ErrorCode.CONFIG_SAVE_FAILED,
-            f"Error saving schedule configuration: {str(e)}",
+            "Error saving schedule configuration",
             details="Internal server error - check server logs",
             status_code=500
         )
@@ -627,13 +624,10 @@ def save_dim_schedule_config():
 
         return success_response(message='Dim schedule configuration saved successfully')
     except Exception as e:
-        import logging
-        import traceback
-        error_msg = f"Error saving dim schedule config: {str(e)}\n{traceback.format_exc()}"
-        logging.error(error_msg)
+        logger.exception("[DimScheduleConfig] Failed to save dim schedule configuration")
         return error_response(
             ErrorCode.CONFIG_SAVE_FAILED,
-            f"Error saving dim schedule configuration: {str(e)}",
+            "Error saving dim schedule configuration",
             details="Internal server error - check server logs",
             status_code=500
         )
@@ -978,13 +972,10 @@ def save_main_config():
 
         return success_response(message='Configuration saved successfully')
     except Exception as e:
-        import logging
-        import traceback
-        error_msg = f"Error saving config: {str(e)}\n{traceback.format_exc()}"
-        logging.error(error_msg)
+        logger.exception("[Config] Failed to save configuration")
         return error_response(
             ErrorCode.CONFIG_SAVE_FAILED,
-            f"Error saving configuration: {e}",
+            "Error saving configuration",
             details="Internal server error - check server logs",
             status_code=500
         )
@@ -1030,22 +1021,18 @@ def save_raw_main_config():
         logging.error(error_msg)
 
         # Extract more specific error message if it's a ConfigError
+        logger.exception("[RawConfig] Failed to save raw main config")
         if isinstance(e, ConfigError):
-            error_message = str(e)
-            if hasattr(e, 'config_path') and e.config_path:
-                error_message = f"{error_message} (config_path: {e.config_path})"
             return error_response(
                 ErrorCode.CONFIG_SAVE_FAILED,
-                error_message,
+                "Error saving raw main configuration",
                 details="Internal server error - check server logs",
-                context={'config_path': e.config_path} if hasattr(e, 'config_path') and e.config_path else None,
                 status_code=500
             )
         else:
-            error_message = str(e) if str(e) else "An unexpected error occurred while saving the configuration"
             return error_response(
                 ErrorCode.UNKNOWN_ERROR,
-                error_message,
+                "An unexpected error occurred while saving the configuration",
                 details="Internal server error - check server logs",
                 status_code=500
             )
@@ -1470,8 +1457,8 @@ def execute_system_action():
 
     except Exception as e:
         import traceback
-        logger.error(f"Error in execute_system_action: {str(e)}\n{traceback.format_exc()}")
-        return jsonify({'status': 'error', 'message': str(e)}), 500
+        logger.exception("[SystemAction] Unexpected error")
+        return jsonify({'status': 'error', 'message': 'Internal server error - check server logs'}), 500
 
 @api_v3.route('/display/current', methods=['GET'])
 def get_display_current():
@@ -1880,8 +1867,8 @@ def get_installed_plugins():
         return jsonify({'status': 'success', 'data': {'plugins': plugins}})
     except Exception as e:
         import traceback
-        logger.error(f"Error in get_installed_plugins: {str(e)}\n{traceback.format_exc()}")
-        return jsonify({'status': 'error', 'message': str(e)}), 500
+        logger.exception("[Plugins] Error listing installed plugins")
+        return jsonify({'status': 'error', 'message': 'Internal server error - check server logs'}), 500
 
 @api_v3.route('/plugins/health', methods=['GET'])
 def get_plugin_health():
@@ -6064,8 +6051,8 @@ def upload_plugin_asset():
         })
 
     except Exception as e:
-        import traceback
-        return jsonify({'status': 'error', 'message': str(e)}), 500
+        logger.exception("[API] Unexpected error")
+        return jsonify({'status': 'error', 'message': 'Internal server error - check server logs'}), 500
 
 @api_v3.route('/plugins/of-the-day/json/upload', methods=['POST'])
 def upload_of_the_day_json():
@@ -6214,8 +6201,8 @@ def upload_of_the_day_json():
         })
 
     except Exception as e:
-        import traceback
-        return jsonify({'status': 'error', 'message': str(e)}), 500
+        logger.exception("[API] Unexpected error")
+        return jsonify({'status': 'error', 'message': 'Internal server error - check server logs'}), 500
 
 @api_v3.route('/plugins/of-the-day/json/delete', methods=['POST'])
 def delete_of_the_day_json():
@@ -6261,8 +6248,8 @@ def delete_of_the_day_json():
         })
 
     except Exception as e:
-        import traceback
-        return jsonify({'status': 'error', 'message': str(e)}), 500
+        logger.exception("[API] Unexpected error")
+        return jsonify({'status': 'error', 'message': 'Internal server error - check server logs'}), 500
 
 @api_v3.route('/plugins/<plugin_id>/static/<path:file_path>', methods=['GET'])
 def serve_plugin_static(plugin_id, file_path):
@@ -6307,8 +6294,8 @@ def serve_plugin_static(plugin_id, file_path):
         return Response(content, mimetype=content_type)
 
     except Exception as e:
-        import traceback
-        return jsonify({'status': 'error', 'message': str(e)}), 500
+        logger.exception("[API] Unexpected error")
+        return jsonify({'status': 'error', 'message': 'Internal server error - check server logs'}), 500
 
 
 @api_v3.route('/plugins/calendar/upload-credentials', methods=['POST'])
@@ -6479,8 +6466,8 @@ def delete_plugin_asset():
         return jsonify({'status': 'success', 'message': 'Image deleted successfully'})
 
     except Exception as e:
-        import traceback
-        return jsonify({'status': 'error', 'message': str(e)}), 500
+        logger.exception("[API] Unexpected error")
+        return jsonify({'status': 'error', 'message': 'Internal server error - check server logs'}), 500
 
 @api_v3.route('/plugins/assets/list', methods=['GET'])
 def list_plugin_assets():
@@ -6507,8 +6494,8 @@ def list_plugin_assets():
         return jsonify({'status': 'success', 'data': {'assets': assets}})
 
     except Exception as e:
-        import traceback
-        return jsonify({'status': 'error', 'message': str(e)}), 500
+        logger.exception("[API] Unexpected error")
+        return jsonify({'status': 'error', 'message': 'Internal server error - check server logs'}), 500
 
 @api_v3.route('/logs', methods=['GET'])
 def get_logs():

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -1012,15 +1012,7 @@ def save_raw_main_config():
     except json.JSONDecodeError as e:
         return jsonify({'status': 'error', 'message': f'Invalid JSON: {str(e)}'}), 400
     except Exception as e:
-        import logging
-        import traceback
         from src.exceptions import ConfigError
-
-        # Log the full error for debugging
-        error_msg = f"Error saving raw main config: {str(e)}\n{traceback.format_exc()}"
-        logging.error(error_msg)
-
-        # Extract more specific error message if it's a ConfigError
         logger.exception("[RawConfig] Failed to save raw main config")
         if isinstance(e, ConfigError):
             return error_response(
@@ -1059,24 +1051,22 @@ def save_raw_secrets_config():
     except json.JSONDecodeError as e:
         return jsonify({'status': 'error', 'message': f'Invalid JSON: {str(e)}'}), 400
     except Exception as e:
-        import logging
-        import traceback
         from src.exceptions import ConfigError
-
-        # Log the full error for debugging
-        error_msg = f"Error saving raw secrets config: {str(e)}\n{traceback.format_exc()}"
-        logging.error(error_msg)
-
-        # Extract more specific error message if it's a ConfigError
+        logger.exception("[RawSecrets] Failed to save raw secrets config")
         if isinstance(e, ConfigError):
-            # ConfigError has a message attribute and may have context
-            error_message = str(e)
-            if hasattr(e, 'config_path') and e.config_path:
-                error_message = f"{error_message} (config_path: {e.config_path})"
+            return error_response(
+                ErrorCode.CONFIG_SAVE_FAILED,
+                "Error saving raw secrets configuration",
+                details="Internal server error - check server logs",
+                status_code=500
+            )
         else:
-            error_message = str(e) if str(e) else "An unexpected error occurred while saving the configuration"
-
-        return jsonify({'status': 'error', 'message': error_message}), 500
+            return error_response(
+                ErrorCode.UNKNOWN_ERROR,
+                "An unexpected error occurred while saving the configuration",
+                details="Internal server error - check server logs",
+                status_code=500
+            )
 
 @api_v3.route('/system/status', methods=['GET'])
 def get_system_status():

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -413,7 +413,7 @@ def save_schedule_config():
         return error_response(
             ErrorCode.CONFIG_SAVE_FAILED,
             f"Error saving schedule configuration: {str(e)}",
-            details=traceback.format_exc(),
+            details="Internal server error - check server logs",
             status_code=500
         )
 
@@ -634,7 +634,7 @@ def save_dim_schedule_config():
         return error_response(
             ErrorCode.CONFIG_SAVE_FAILED,
             f"Error saving dim schedule configuration: {str(e)}",
-            details=traceback.format_exc(),
+            details="Internal server error - check server logs",
             status_code=500
         )
 
@@ -985,7 +985,7 @@ def save_main_config():
         return error_response(
             ErrorCode.CONFIG_SAVE_FAILED,
             f"Error saving configuration: {e}",
-            details=traceback.format_exc(),
+            details="Internal server error - check server logs",
             status_code=500
         )
 
@@ -1037,7 +1037,7 @@ def save_raw_main_config():
             return error_response(
                 ErrorCode.CONFIG_SAVE_FAILED,
                 error_message,
-                details=traceback.format_exc(),
+                details="Internal server error - check server logs",
                 context={'config_path': e.config_path} if hasattr(e, 'config_path') and e.config_path else None,
                 status_code=500
             )
@@ -1046,7 +1046,7 @@ def save_raw_main_config():
             return error_response(
                 ErrorCode.UNKNOWN_ERROR,
                 error_message,
-                details=traceback.format_exc(),
+                details="Internal server error - check server logs",
                 status_code=500
             )
 
@@ -1470,10 +1470,8 @@ def execute_system_action():
 
     except Exception as e:
         import traceback
-        error_details = traceback.format_exc()
-        print(f"Error in execute_system_action: {str(e)}")
-        print(error_details)
-        return jsonify({'status': 'error', 'message': str(e), 'details': error_details}), 500
+        logger.error(f"Error in execute_system_action: {str(e)}\n{traceback.format_exc()}")
+        return jsonify({'status': 'error', 'message': str(e)}), 500
 
 @api_v3.route('/display/current', methods=['GET'])
 def get_display_current():
@@ -1882,10 +1880,8 @@ def get_installed_plugins():
         return jsonify({'status': 'success', 'data': {'plugins': plugins}})
     except Exception as e:
         import traceback
-        error_details = traceback.format_exc()
-        print(f"Error in get_installed_plugins: {str(e)}")
-        print(error_details)
-        return jsonify({'status': 'error', 'message': str(e), 'details': error_details}), 500
+        logger.error(f"Error in get_installed_plugins: {str(e)}\n{traceback.format_exc()}")
+        return jsonify({'status': 'error', 'message': str(e)}), 500
 
 @api_v3.route('/plugins/health', methods=['GET'])
 def get_plugin_health():
@@ -6069,7 +6065,7 @@ def upload_plugin_asset():
 
     except Exception as e:
         import traceback
-        return jsonify({'status': 'error', 'message': str(e), 'traceback': traceback.format_exc()}), 500
+        return jsonify({'status': 'error', 'message': str(e)}), 500
 
 @api_v3.route('/plugins/of-the-day/json/upload', methods=['POST'])
 def upload_of_the_day_json():
@@ -6219,7 +6215,7 @@ def upload_of_the_day_json():
 
     except Exception as e:
         import traceback
-        return jsonify({'status': 'error', 'message': str(e), 'traceback': traceback.format_exc()}), 500
+        return jsonify({'status': 'error', 'message': str(e)}), 500
 
 @api_v3.route('/plugins/of-the-day/json/delete', methods=['POST'])
 def delete_of_the_day_json():
@@ -6266,7 +6262,7 @@ def delete_of_the_day_json():
 
     except Exception as e:
         import traceback
-        return jsonify({'status': 'error', 'message': str(e), 'traceback': traceback.format_exc()}), 500
+        return jsonify({'status': 'error', 'message': str(e)}), 500
 
 @api_v3.route('/plugins/<plugin_id>/static/<path:file_path>', methods=['GET'])
 def serve_plugin_static(plugin_id, file_path):
@@ -6312,7 +6308,7 @@ def serve_plugin_static(plugin_id, file_path):
 
     except Exception as e:
         import traceback
-        return jsonify({'status': 'error', 'message': str(e), 'traceback': traceback.format_exc()}), 500
+        return jsonify({'status': 'error', 'message': str(e)}), 500
 
 
 @api_v3.route('/plugins/calendar/upload-credentials', methods=['POST'])
@@ -6484,7 +6480,7 @@ def delete_plugin_asset():
 
     except Exception as e:
         import traceback
-        return jsonify({'status': 'error', 'message': str(e), 'traceback': traceback.format_exc()}), 500
+        return jsonify({'status': 'error', 'message': str(e)}), 500
 
 @api_v3.route('/plugins/assets/list', methods=['GET'])
 def list_plugin_assets():
@@ -6512,7 +6508,7 @@ def list_plugin_assets():
 
     except Exception as e:
         import traceback
-        return jsonify({'status': 'error', 'message': str(e), 'traceback': traceback.format_exc()}), 500
+        return jsonify({'status': 'error', 'message': str(e)}), 500
 
 @api_v3.route('/logs', methods=['GET'])
 def get_logs():


### PR DESCRIPTION
## Summary
- Remove 13 instances where `traceback.format_exc()` was sent in API JSON responses to HTTP clients
- 5 `error_response(details=traceback.format_exc())` → generic "Internal server error - check server logs"
- 6 `jsonify({'traceback': traceback.format_exc()})` → removed `traceback` key from response
- 2 `jsonify({'details': error_details})` → replaced with `logger.error()` server-side logging
- Debug-mode traceback display in `app.py` error handlers is preserved (guarded by `app.debug`)

## Rationale
Leaking Python tracebacks to HTTP clients exposes internal file paths, library versions, and code structure. This information can aid attackers in crafting targeted exploits. Server-side logging via `logger.error()` preserves debugging capability without client exposure.

## Test plan
- [ ] `grep -n "details=traceback\|'traceback': traceback\|'details': error_details" web_interface/blueprints/api_v3.py` — zero matches
- [ ] Trigger a 500 error via API → response contains `message` but no `traceback` or `details` with stack frames
- [ ] Check server logs still contain full traceback for debugging

Co-Authored-By: 5ymb01 <noreply@github.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API error responses now return a consistent, generic message for unexpected failures, preventing exposure of internal error details.
  * Error handling across endpoints has been standardized so clients receive uniform 500 responses for server errors.

* **Chores**
  * Server-side logging enhanced to record errors without leaking internal traces to responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->