### PR TITLE
fix(security): use Path.relative_to() for path confinement

### DIFF
--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -6286,7 +6286,9 @@ def serve_plugin_static(plugin_id, file_path):
         requested_file = (plugin_dir / file_path).resolve()
 
         # Security check: ensure file is within plugin directory
-        if not str(requested_file).startswith(str(plugin_dir)):
+        try:
+            requested_file.relative_to(plugin_dir)
+        except ValueError:
             return jsonify({'status': 'error', 'message': 'Invalid file path'}), 403
 
         # Check if file exists


### PR DESCRIPTION
## Summary
- Replace `str(path).startswith(str(dir))` with `Path.relative_to()` in the plugin file viewer endpoint (`api_v3.py:6289`)
- `startswith()` can be bypassed when a directory name is a prefix of another (e.g., `/plugins/foo` vs `/plugins/foobar`)
- `Path.relative_to()` raises `ValueError` when the path is not a child, providing correct containment validation

## Test plan
- [ ] Access a valid plugin file via the file viewer → works normally
- [ ] Attempt path traversal (e.g., `../../etc/passwd`) → returns 403
- [ ] Plugin with a name that is a prefix of another (if applicable) → correctly scoped

Co-Authored-By: 5ymb01 <noreply@github.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security validation to prevent unauthorized access when serving plugin static files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->