### PR TITLE
fix(perf): cache fonts in sport base classes to avoid disk I/O per frame

### DIFF
--- a/src/base_classes/baseball.py
+++ b/src/base_classes/baseball.py
@@ -329,7 +329,7 @@ class Baseball(SportsCore):
             return
         
         series_summary = game.get("series_summary", "")
-        font = ImageFont.truetype("assets/fonts/4x6-font.ttf", 6)
+        font = self.fonts.get('detail', ImageFont.load_default())
         bbox = draw_overlay.textbbox((0, 0), series_summary, font=self.fonts['time'])
         height = bbox[3] - bbox[1]
         shots_y = (self.display_height - height) // 2

--- a/src/base_classes/basketball.py
+++ b/src/base_classes/basketball.py
@@ -201,14 +201,7 @@ class BasketballLive(Basketball, SportsLive):
 
             # Draw records or rankings if enabled
             if self.show_records or self.show_ranking:
-                try:
-                    record_font = ImageFont.truetype("assets/fonts/4x6-font.ttf", 6)
-                    self.logger.debug(f"Loaded 6px record font successfully")
-                except IOError:
-                    record_font = ImageFont.load_default()
-                    self.logger.warning(
-                        f"Failed to load 6px font, using default font (size: {record_font.size})"
-                    )
+                record_font = self.fonts.get('detail', ImageFont.load_default())
 
                 # Get team abbreviations
                 away_abbr = game.get("away_abbr", "")

--- a/src/base_classes/football.py
+++ b/src/base_classes/football.py
@@ -308,13 +308,8 @@ class FootballLive(Football, SportsLive):
 
             # Draw records or rankings if enabled
             if self.show_records or self.show_ranking:
-                try:
-                    record_font = ImageFont.truetype("assets/fonts/4x6-font.ttf", 6)
-                    self.logger.debug(f"Loaded 6px record font successfully")
-                except IOError:
-                    record_font = ImageFont.load_default()
-                    self.logger.warning(f"Failed to load 6px font, using default font (size: {record_font.size})")
-                
+                record_font = self.fonts.get('detail', ImageFont.load_default())
+
                 # Get team abbreviations
                 away_abbr = game.get('away_abbr', '')
                 home_abbr = game.get('home_abbr', '')

--- a/src/base_classes/hockey.py
+++ b/src/base_classes/hockey.py
@@ -255,7 +255,7 @@ class HockeyLive(Hockey, SportsLive):
 
             # Shots on Goal
             if self.show_shots_on_goal:
-                shots_font = ImageFont.truetype("assets/fonts/4x6-font.ttf", 6)
+                shots_font = self.fonts.get('detail', ImageFont.load_default())
                 home_shots = str(game.get("home_shots", "0"))
                 away_shots = str(game.get("away_shots", "0"))
                 shots_text = f"{away_shots}   SHOTS   {home_shots}"
@@ -276,14 +276,7 @@ class HockeyLive(Hockey, SportsLive):
 
             # Draw records or rankings if enabled
             if self.show_records or self.show_ranking:
-                try:
-                    record_font = ImageFont.truetype("assets/fonts/4x6-font.ttf", 6)
-                    self.logger.debug(f"Loaded 6px record font successfully")
-                except IOError:
-                    record_font = ImageFont.load_default()
-                    self.logger.warning(
-                        f"Failed to load 6px font, using default font (size: {record_font.size})"
-                    )
+                record_font = self.fonts.get('detail', ImageFont.load_default())
 
                 # Get team abbreviations
                 away_abbr = game.get("away_abbr", "")

--- a/src/base_classes/sports.py
+++ b/src/base_classes/sports.py
@@ -863,13 +863,8 @@ class SportsUpcoming(SportsCore):
 
             # Draw records or rankings if enabled
             if self.show_records or self.show_ranking:
-                try:
-                    record_font = ImageFont.truetype("assets/fonts/4x6-font.ttf", 6)
-                    self.logger.debug(f"Loaded 6px record font successfully")
-                except IOError:
-                    record_font = ImageFont.load_default()
-                    self.logger.warning(f"Failed to load 6px font, using default font (size: {record_font.size})")
-                
+                record_font = self.fonts.get('detail', ImageFont.load_default())
+
                 # Get team abbreviations
                 away_abbr = game.get('away_abbr', '')
                 home_abbr = game.get('home_abbr', '')
@@ -1172,13 +1167,8 @@ class SportsRecent(SportsCore):
 
             # Draw records or rankings if enabled
             if self.show_records or self.show_ranking:
-                try:
-                    record_font = ImageFont.truetype("assets/fonts/4x6-font.ttf", 6)
-                    self.logger.debug(f"Loaded 6px record font successfully")
-                except IOError:
-                    record_font = ImageFont.load_default()
-                    self.logger.warning(f"Failed to load 6px font, using default font (size: {record_font.size})")
-                
+                record_font = self.fonts.get('detail', ImageFont.load_default())
+
                 # Get team abbreviations
                 away_abbr = game.get('away_abbr', '')
                 home_abbr = game.get('home_abbr', '')


### PR DESCRIPTION
## Summary
- Replace 7 `ImageFont.truetype("assets/fonts/4x6-font.ttf", 6)` calls in display methods with cached `self.fonts.get('detail', ImageFont.load_default())` lookups
- The `detail` font (4x6 at size 6) is already loaded once in `_load_fonts()` — reloading it on every `display()` call causes unnecessary disk I/O at ~30-50 FPS on Raspberry Pi
- Affects 5 files: `sports.py` (2 instances), `football.py` (1), `hockey.py` (2), `basketball.py` (1), `baseball.py` (1)

## Rationale
On a Raspberry Pi with SD card storage, `ImageFont.truetype()` triggers a file open + read on every frame. At 50 FPS, that's 350 unnecessary file operations per second across all sport plugins. Using the already-cached `self.fonts['detail']` eliminates this overhead completely.

## Test plan
- [ ] Sport scoreboards render records/rankings correctly (font appears identical)
- [ ] Hockey shots-on-goal display renders correctly
- [ ] Baseball series summary renders correctly
- [ ] No `ImageFont.truetype()` calls remain in display methods (only in `_load_fonts()`)
- [ ] FPS remains stable or improves on Pi

Co-Authored-By: 5ymb01 <noreply@github.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>