### PR TITLE
fix(config): deduplicate uniqueItems arrays before schema validation

### DIFF
--- a/src/web_interface/validators.py
+++ b/src/web_interface/validators.py
@@ -215,3 +215,49 @@ def sanitize_plugin_config(config: dict) -> dict:
     
     return sanitized
 
+
+def dedup_unique_arrays(cfg: dict, schema_node: dict) -> None:
+    """Recursively deduplicate arrays with uniqueItems constraint.
+
+    Walks the JSON Schema tree alongside the config dict and removes
+    duplicate entries from any array whose schema specifies
+    ``uniqueItems: true``, preserving insertion order (first occurrence
+    kept).  Also recurses into:
+
+    - Object properties containing nested objects or arrays
+    - Array elements whose ``items`` schema is an object with its own
+      properties (so nested uniqueItems constraints are enforced)
+
+    This is intended to run **after** form-data normalisation but
+    **before** JSON Schema validation, to prevent spurious validation
+    failures when config merging introduces duplicates (e.g. a stock
+    symbol already present in the saved config is submitted again from
+    the web form).
+
+    Args:
+        cfg: The plugin configuration dict to mutate in-place.
+        schema_node: The corresponding JSON Schema node (must contain
+            a ``properties`` mapping at the current level).
+    """
+    props = schema_node.get('properties', {})
+    for key, prop_schema in props.items():
+        if key not in cfg:
+            continue
+        prop_type = prop_schema.get('type')
+        if prop_type == 'array' and isinstance(cfg[key], list):
+            # Deduplicate this array if uniqueItems is set
+            if prop_schema.get('uniqueItems'):
+                seen: list = []
+                for item in cfg[key]:
+                    if item not in seen:
+                        seen.append(item)
+                cfg[key] = seen
+            # Recurse into array elements if items schema is an object
+            items_schema = prop_schema.get('items', {})
+            if isinstance(items_schema, dict) and items_schema.get('type') == 'object':
+                for element in cfg[key]:
+                    if isinstance(element, dict):
+                        dedup_unique_arrays(element, items_schema)
+        elif prop_type == 'object' and isinstance(cfg[key], dict):
+            dedup_unique_arrays(cfg[key], prop_schema)
+

--- a/test/web_interface/test_dedup_unique_arrays.py
+++ b/test/web_interface/test_dedup_unique_arrays.py
@@ -1,34 +1,16 @@
-"""Tests for _dedup_unique_arrays in save_plugin_config.
+"""Tests for dedup_unique_arrays used by save_plugin_config.
 
 Validates that arrays with uniqueItems: true in the JSON schema have
 duplicates removed before validation, preventing spurious validation
 failures when form merging introduces duplicate entries.
+
+Tests import the production function from src.web_interface.validators
+to ensure they exercise the real code path.
 """
 
 import pytest
 
-
-def _dedup_unique_arrays(cfg: dict, schema_node: dict) -> None:
-    """Mirror of the inline function in api_v3.save_plugin_config."""
-    props = schema_node.get('properties', {})
-    for key, prop_schema in props.items():
-        if key not in cfg:
-            continue
-        prop_type = prop_schema.get('type')
-        if prop_type == 'array' and isinstance(cfg[key], list):
-            if prop_schema.get('uniqueItems'):
-                seen: list = []
-                for item in cfg[key]:
-                    if item not in seen:
-                        seen.append(item)
-                cfg[key] = seen
-            items_schema = prop_schema.get('items', {})
-            if isinstance(items_schema, dict) and items_schema.get('type') == 'object':
-                for element in cfg[key]:
-                    if isinstance(element, dict):
-                        _dedup_unique_arrays(element, items_schema)
-        elif prop_type == 'object' and isinstance(cfg[key], dict):
-            _dedup_unique_arrays(cfg[key], prop_schema)
+from src.web_interface.validators import dedup_unique_arrays as _dedup_unique_arrays
 
 
 class TestDedupUniqueArrays:

--- a/test/web_interface/test_dedup_unique_arrays.py
+++ b/test/web_interface/test_dedup_unique_arrays.py
@@ -1,0 +1,276 @@
+"""Tests for _dedup_unique_arrays in save_plugin_config.
+
+Validates that arrays with uniqueItems: true in the JSON schema have
+duplicates removed before validation, preventing spurious validation
+failures when form merging introduces duplicate entries.
+"""
+
+import pytest
+
+
+def _dedup_unique_arrays(cfg: dict, schema_node: dict) -> None:
+    """Mirror of the inline function in api_v3.save_plugin_config."""
+    props = schema_node.get('properties', {})
+    for key, prop_schema in props.items():
+        if key not in cfg:
+            continue
+        prop_type = prop_schema.get('type')
+        if prop_type == 'array' and isinstance(cfg[key], list):
+            if prop_schema.get('uniqueItems'):
+                seen: list = []
+                for item in cfg[key]:
+                    if item not in seen:
+                        seen.append(item)
+                cfg[key] = seen
+            items_schema = prop_schema.get('items', {})
+            if isinstance(items_schema, dict) and items_schema.get('type') == 'object':
+                for element in cfg[key]:
+                    if isinstance(element, dict):
+                        _dedup_unique_arrays(element, items_schema)
+        elif prop_type == 'object' and isinstance(cfg[key], dict):
+            _dedup_unique_arrays(cfg[key], prop_schema)
+
+
+class TestDedupUniqueArrays:
+    """Test suite for uniqueItems array deduplication."""
+
+    def test_flat_array_with_duplicates(self) -> None:
+        """Duplicates in a top-level uniqueItems array are removed."""
+        cfg = {"stock_symbols": ["AAPL", "GOOGL", "FNMA", "TSLA", "FNMA"]}
+        schema = {
+            "properties": {
+                "stock_symbols": {
+                    "type": "array",
+                    "uniqueItems": True,
+                    "items": {"type": "string"},
+                }
+            }
+        }
+        _dedup_unique_arrays(cfg, schema)
+        assert cfg["stock_symbols"] == ["AAPL", "GOOGL", "FNMA", "TSLA"]
+
+    def test_flat_array_preserves_order(self) -> None:
+        """First occurrence of each item is kept, order preserved."""
+        cfg = {"tags": ["b", "a", "c", "a", "b"]}
+        schema = {
+            "properties": {
+                "tags": {
+                    "type": "array",
+                    "uniqueItems": True,
+                    "items": {"type": "string"},
+                }
+            }
+        }
+        _dedup_unique_arrays(cfg, schema)
+        assert cfg["tags"] == ["b", "a", "c"]
+
+    def test_no_duplicates_unchanged(self) -> None:
+        """Array without duplicates is not modified."""
+        cfg = {"items": ["a", "b", "c"]}
+        schema = {
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "uniqueItems": True,
+                    "items": {"type": "string"},
+                }
+            }
+        }
+        _dedup_unique_arrays(cfg, schema)
+        assert cfg["items"] == ["a", "b", "c"]
+
+    def test_array_without_unique_items_not_deduped(self) -> None:
+        """Arrays without uniqueItems constraint keep duplicates."""
+        cfg = {"items": ["a", "a", "b"]}
+        schema = {
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                }
+            }
+        }
+        _dedup_unique_arrays(cfg, schema)
+        assert cfg["items"] == ["a", "a", "b"]
+
+    def test_nested_object_with_unique_array(self) -> None:
+        """Dedup works for uniqueItems arrays inside nested objects."""
+        cfg = {
+            "feeds": {
+                "stock_symbols": ["AAPL", "FNMA", "NVDA", "FNMA"]
+            }
+        }
+        schema = {
+            "properties": {
+                "feeds": {
+                    "type": "object",
+                    "properties": {
+                        "stock_symbols": {
+                            "type": "array",
+                            "uniqueItems": True,
+                            "items": {"type": "string"},
+                        }
+                    },
+                }
+            }
+        }
+        _dedup_unique_arrays(cfg, schema)
+        assert cfg["feeds"]["stock_symbols"] == ["AAPL", "FNMA", "NVDA"]
+
+    def test_array_of_objects_with_nested_unique_arrays(self) -> None:
+        """Dedup recurses into array elements that are objects."""
+        cfg = {
+            "servers": [
+                {"tags": ["web", "prod", "web"]},
+                {"tags": ["db", "staging"]},
+            ]
+        }
+        schema = {
+            "properties": {
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "tags": {
+                                "type": "array",
+                                "uniqueItems": True,
+                                "items": {"type": "string"},
+                            }
+                        },
+                    },
+                }
+            }
+        }
+        _dedup_unique_arrays(cfg, schema)
+        assert cfg["servers"][0]["tags"] == ["web", "prod"]
+        assert cfg["servers"][1]["tags"] == ["db", "staging"]
+
+    def test_missing_key_in_config_skipped(self) -> None:
+        """Schema properties not present in config are silently skipped."""
+        cfg = {"other": "value"}
+        schema = {
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "uniqueItems": True,
+                    "items": {"type": "string"},
+                }
+            }
+        }
+        _dedup_unique_arrays(cfg, schema)
+        assert cfg == {"other": "value"}
+
+    def test_empty_array(self) -> None:
+        """Empty arrays are handled without error."""
+        cfg = {"items": []}
+        schema = {
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "uniqueItems": True,
+                    "items": {"type": "string"},
+                }
+            }
+        }
+        _dedup_unique_arrays(cfg, schema)
+        assert cfg["items"] == []
+
+    def test_integer_duplicates(self) -> None:
+        """Dedup works for non-string types (integers)."""
+        cfg = {"ports": [80, 443, 80, 8080, 443]}
+        schema = {
+            "properties": {
+                "ports": {
+                    "type": "array",
+                    "uniqueItems": True,
+                    "items": {"type": "integer"},
+                }
+            }
+        }
+        _dedup_unique_arrays(cfg, schema)
+        assert cfg["ports"] == [80, 443, 8080]
+
+    def test_deeply_nested_objects(self) -> None:
+        """Dedup works through multiple levels of nesting."""
+        cfg = {
+            "level1": {
+                "level2": {
+                    "values": ["x", "y", "x"]
+                }
+            }
+        }
+        schema = {
+            "properties": {
+                "level1": {
+                    "type": "object",
+                    "properties": {
+                        "level2": {
+                            "type": "object",
+                            "properties": {
+                                "values": {
+                                    "type": "array",
+                                    "uniqueItems": True,
+                                    "items": {"type": "string"},
+                                }
+                            },
+                        }
+                    },
+                }
+            }
+        }
+        _dedup_unique_arrays(cfg, schema)
+        assert cfg["level1"]["level2"]["values"] == ["x", "y"]
+
+    def test_stock_news_real_world_schema(self) -> None:
+        """End-to-end test matching the actual stock-news plugin config shape."""
+        cfg = {
+            "enabled": True,
+            "global": {
+                "display_duration": 30.0,
+                "scroll_speed": 1.0,
+            },
+            "feeds": {
+                "news_source": "google_news",
+                "stock_symbols": [
+                    "AAPL", "GOOGL", "MSFT", "FNMA",
+                    "NVDA", "TSLA", "META", "AMD", "FNMA",
+                ],
+                "text_color": [0, 255, 0],
+            },
+            "display_duration": 15,
+        }
+        schema = {
+            "properties": {
+                "enabled": {"type": "boolean"},
+                "global": {
+                    "type": "object",
+                    "properties": {
+                        "display_duration": {"type": "number"},
+                        "scroll_speed": {"type": "number"},
+                    },
+                },
+                "feeds": {
+                    "type": "object",
+                    "properties": {
+                        "news_source": {"type": "string"},
+                        "stock_symbols": {
+                            "type": "array",
+                            "uniqueItems": True,
+                            "items": {"type": "string"},
+                        },
+                        "text_color": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                        },
+                    },
+                },
+                "display_duration": {"type": "number"},
+            }
+        }
+        _dedup_unique_arrays(cfg, schema)
+        assert cfg["feeds"]["stock_symbols"] == [
+            "AAPL", "GOOGL", "MSFT", "FNMA", "NVDA", "TSLA", "META", "AMD"
+        ]
+        # text_color has no uniqueItems, should be untouched
+        assert cfg["feeds"]["text_color"] == [0, 255, 0]

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -4616,18 +4616,33 @@ def save_plugin_config():
         # This prevents validation failures when form merging introduces duplicates
         # (e.g., existing config has ['AAPL','FNMA'] and form adds 'FNMA' again)
         def _dedup_unique_arrays(cfg: dict, schema_node: dict) -> None:
-            """Recursively deduplicate arrays with uniqueItems constraint."""
+            """Recursively deduplicate arrays with uniqueItems constraint.
+
+            Handles three schema patterns:
+            - object properties containing uniqueItems arrays
+            - object properties containing nested objects (recurse)
+            - array items that are objects with their own properties (recurse
+              into each element)
+            """
             props = schema_node.get('properties', {})
             for key, prop_schema in props.items():
                 if key not in cfg:
                     continue
                 prop_type = prop_schema.get('type')
-                if prop_type == 'array' and prop_schema.get('uniqueItems') and isinstance(cfg[key], list):
-                    seen: list = []
-                    for item in cfg[key]:
-                        if item not in seen:
-                            seen.append(item)
-                    cfg[key] = seen
+                if prop_type == 'array' and isinstance(cfg[key], list):
+                    # Deduplicate this array if uniqueItems is set
+                    if prop_schema.get('uniqueItems'):
+                        seen: list = []
+                        for item in cfg[key]:
+                            if item not in seen:
+                                seen.append(item)
+                        cfg[key] = seen
+                    # Recurse into array elements if items schema is an object
+                    items_schema = prop_schema.get('items', {})
+                    if isinstance(items_schema, dict) and items_schema.get('type') == 'object':
+                        for element in cfg[key]:
+                            if isinstance(element, dict):
+                                _dedup_unique_arrays(element, items_schema)
                 elif prop_type == 'object' and isinstance(cfg[key], dict):
                     _dedup_unique_arrays(cfg[key], prop_schema)
 

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -4615,39 +4615,9 @@ def save_plugin_config():
         # Deduplicate arrays where schema specifies uniqueItems: true
         # This prevents validation failures when form merging introduces duplicates
         # (e.g., existing config has ['AAPL','FNMA'] and form adds 'FNMA' again)
-        def _dedup_unique_arrays(cfg: dict, schema_node: dict) -> None:
-            """Recursively deduplicate arrays with uniqueItems constraint.
-
-            Handles three schema patterns:
-            - object properties containing uniqueItems arrays
-            - object properties containing nested objects (recurse)
-            - array items that are objects with their own properties (recurse
-              into each element)
-            """
-            props = schema_node.get('properties', {})
-            for key, prop_schema in props.items():
-                if key not in cfg:
-                    continue
-                prop_type = prop_schema.get('type')
-                if prop_type == 'array' and isinstance(cfg[key], list):
-                    # Deduplicate this array if uniqueItems is set
-                    if prop_schema.get('uniqueItems'):
-                        seen: list = []
-                        for item in cfg[key]:
-                            if item not in seen:
-                                seen.append(item)
-                        cfg[key] = seen
-                    # Recurse into array elements if items schema is an object
-                    items_schema = prop_schema.get('items', {})
-                    if isinstance(items_schema, dict) and items_schema.get('type') == 'object':
-                        for element in cfg[key]:
-                            if isinstance(element, dict):
-                                _dedup_unique_arrays(element, items_schema)
-                elif prop_type == 'object' and isinstance(cfg[key], dict):
-                    _dedup_unique_arrays(cfg[key], prop_schema)
-
         if schema:
-            _dedup_unique_arrays(plugin_config, schema)
+            from src.web_interface.validators import dedup_unique_arrays
+            dedup_unique_arrays(plugin_config, schema)
 
         # Validate configuration against schema before saving
         if schema:

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -4612,6 +4612,28 @@ def save_plugin_config():
             seed_value = plugin_config['rotation_settings']['random_seed']
             logger.debug(f"After normalization, random_seed value: {repr(seed_value)}, type: {type(seed_value)}")
 
+        # Deduplicate arrays where schema specifies uniqueItems: true
+        # This prevents validation failures when form merging introduces duplicates
+        # (e.g., existing config has ['AAPL','FNMA'] and form adds 'FNMA' again)
+        def _dedup_unique_arrays(cfg: dict, schema_node: dict) -> None:
+            """Recursively deduplicate arrays with uniqueItems constraint."""
+            props = schema_node.get('properties', {})
+            for key, prop_schema in props.items():
+                if key not in cfg:
+                    continue
+                prop_type = prop_schema.get('type')
+                if prop_type == 'array' and prop_schema.get('uniqueItems') and isinstance(cfg[key], list):
+                    seen: list = []
+                    for item in cfg[key]:
+                        if item not in seen:
+                            seen.append(item)
+                    cfg[key] = seen
+                elif prop_type == 'object' and isinstance(cfg[key], dict):
+                    _dedup_unique_arrays(cfg[key], prop_schema)
+
+        if schema:
+            _dedup_unique_arrays(plugin_config, schema)
+
         # Validate configuration against schema before saving
         if schema:
             # Log what we're validating for debugging


### PR DESCRIPTION
## Summary
- When saving plugin config via web UI, form data merges with existing config. If a user adds an array item that already exists (e.g. stock symbol `FNMA` already in the list), the merged array contains duplicates.
- Schemas with `uniqueItems: true` then reject the config via JSON Schema validation, making it impossible to save any changes.
- Adds a recursive dedup pass after normalization/filtering but before validation that walks the schema tree, finds arrays with the `uniqueItems` constraint, and removes duplicates while preserving order.

## Reproduction
1. Install the `stock-news` plugin (its `stock_symbols` array has `uniqueItems: true`)
2. Add any symbol that's already in the list
3. Click Save → **"Configuration validation failed"**

## Test plan
- [ ] Save stock-news config with duplicate symbol in `stock_symbols` — should succeed
- [ ] Save stock-news config with no duplicates — should still succeed (no regression)
- [ ] Verify dedup preserves insertion order (first occurrence kept)
- [ ] Verify nested `uniqueItems` arrays are also handled (recursive walk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin configuration saving now automatically removes duplicate items from arrays marked as unique (including nested arrays and arrays of objects), preserving first-seen order before schema validation to prevent validation failures.

* **Tests**
  * Added unit tests covering flat and nested deduplication, order preservation, empty arrays, non-string primitives, missing keys, and real-world config scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->