### PR TITLE
fix(web): expose GitHub install handlers, simplify Alpine loader, explicit Flask threading

### DIFF
--- a/web_interface/app.py
+++ b/web_interface/app.py
@@ -710,4 +710,6 @@ def check_health_monitor():
             _threading.Thread(target=_run_startup_reconciliation, daemon=True).start()
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    # threaded=True is Flask's default since 1.0 but stated explicitly so that
+    # long-lived /api/v3/stream/* SSE connections don't starve other requests.
+    app.run(host='0.0.0.0', port=5000, debug=True, threaded=True)

--- a/web_interface/start.py
+++ b/web_interface/start.py
@@ -120,7 +120,11 @@ def main():
     
     # Run the web server with error handling for client disconnections
     try:
-        app.run(host='0.0.0.0', port=5000, debug=False)
+        # threaded=True is Flask's default since 1.0, but set it explicitly
+        # so it's self-documenting: the two /api/v3/stream/* SSE endpoints
+        # hold long-lived connections and would starve other requests under
+        # a single-threaded server.
+        app.run(host='0.0.0.0', port=5000, debug=False, threaded=True)
     except (OSError, BrokenPipeError) as e:
         # Suppress non-critical socket errors (client disconnections)
         if isinstance(e, OSError) and e.errno in (113, 32, 104):  # No route to host, Broken pipe, Connection reset

--- a/web_interface/static/v3/plugins_manager.js
+++ b/web_interface/static/v3/plugins_manager.js
@@ -7161,6 +7161,13 @@ window.getSchemaProperty = getSchemaProperty;
 window.escapeHtml = escapeHtml;
 window.escapeAttribute = escapeAttribute;
 
+// Expose GitHub install handlers. These must be assigned inside the IIFE —
+// from outside the IIFE, `typeof attachInstallButtonHandler` evaluates to
+// 'undefined' and the fallback path at the bottom of this file fires a
+// [FALLBACK] attachInstallButtonHandler not available on window warning.
+window.attachInstallButtonHandler = attachInstallButtonHandler;
+window.setupGitHubInstallHandlers = setupGitHubInstallHandlers;
+
 })(); // End IIFE
 
 // Functions to handle array-of-objects
@@ -7390,16 +7397,8 @@ if (typeof loadInstalledPlugins !== 'undefined') {
 if (typeof renderInstalledPlugins !== 'undefined') {
     window.renderInstalledPlugins = renderInstalledPlugins;
 }
-// Expose GitHub install handlers for debugging and manual testing
-if (typeof setupGitHubInstallHandlers !== 'undefined') {
-    window.setupGitHubInstallHandlers = setupGitHubInstallHandlers;
-    console.log('[GLOBAL] setupGitHubInstallHandlers exposed to window');
-}
-if (typeof attachInstallButtonHandler !== 'undefined') {
-    window.attachInstallButtonHandler = attachInstallButtonHandler;
-    console.log('[GLOBAL] attachInstallButtonHandler exposed to window');
-}
-// searchPluginStore is now exposed inside the IIFE after its definition
+// GitHub install handlers are now exposed inside the IIFE (see above).
+// searchPluginStore is also exposed inside the IIFE after its definition.
 
 // Verify critical functions are available
 if (_PLUGIN_DEBUG_EARLY) {

--- a/web_interface/templates/v3/base.html
+++ b/web_interface/templates/v3/base.html
@@ -784,56 +784,25 @@
         })();
     </script>
 
-    <!-- Alpine.js for reactive components -->
-    <!-- Use local file when in AP mode (192.168.4.x) to avoid CDN dependency -->
+    <!-- Alpine.js for reactive components.
+         Load the local copy first (always works, no CDN round-trip, no AP-mode
+         branch needed). `defer` on an HTML-parsed <script> is honored and runs
+         after DOM parse but before DOMContentLoaded, which is exactly what
+         Alpine wants — so no deferLoadingAlpine gymnastics are needed.
+         The inline rescue below only fires if the local file is missing. -->
+    <script defer src="{{ url_for('static', filename='v3/js/alpinejs.min.js') }}"></script>
     <script>
-        (function() {
-            // Prevent Alpine from auto-initializing by setting deferLoadingAlpine before it loads
-            window.deferLoadingAlpine = function(callback) {
-                // Wait for DOM to be ready
-                function waitForReady() {
-                    if (document.readyState === 'loading') {
-                        document.addEventListener('DOMContentLoaded', waitForReady);
-                        return;
-                    }
-                    
-                    // app() is already defined in head, so we can initialize Alpine
-                    if (callback && typeof callback === 'function') {
-                        callback();
-                    } else if (window.Alpine && typeof window.Alpine.start === 'function') {
-                        // If callback not provided but Alpine is available, start it
-                        try {
-                            window.Alpine.start();
-                        } catch (e) {
-                            // Alpine may already be initialized, ignore
-                            console.warn('Alpine start error (may already be initialized):', e);
-                        }
-                    }
-                }
-                
-                waitForReady();
-            };
-            
-            // Detect AP mode by IP address
-            const isAPMode = window.location.hostname === '192.168.4.1' || 
-                           window.location.hostname.startsWith('192.168.4.');
-            
-            const alpineSrc = isAPMode ? '/static/v3/js/alpinejs.min.js' : 'https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js';
-            const alpineFallback = isAPMode ? 'https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js' : '/static/v3/js/alpinejs.min.js';
-            
-            const script = document.createElement('script');
-            script.defer = true;
-            script.src = alpineSrc;
-            script.onerror = function() {
-                if (alpineSrc !== alpineFallback) {
-                    const fallback = document.createElement('script');
-                    fallback.defer = true;
-                    fallback.src = alpineFallback;
-                    document.head.appendChild(fallback);
-                }
-            };
-            document.head.appendChild(script);
-        })();
+        // Rescue: if the local Alpine didn't load for any reason, pull the CDN
+        // copy once on window load. This is a last-ditch fallback, not the
+        // primary path.
+        window.addEventListener('load', function() {
+            if (typeof window.Alpine === 'undefined') {
+                console.warn('[Alpine] Local file failed to load, falling back to CDN');
+                const s = document.createElement('script');
+                s.src = 'https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js';
+                document.head.appendChild(s);
+            }
+        });
     </script>
 
     <!-- CodeMirror for JSON editing - lazy loaded when needed -->


### PR DESCRIPTION
## Summary

A user reported that the Plugin Manager button (and, they said, "every button") was unresponsive in Safari after a fresh install. Their screenshots actually showed Alpine.js running fine end-to-end — the real problems are a narrow handler-exposure bug, some latent brittleness in the Alpine loader, and an implicit reliance on Flask's default threading for SSE. Fixing all three in one pass.

- **`plugins_manager.js` — `attachInstallButtonHandler` never exposed on `window`** (the bug the reporter's console actually shows). The function is declared at line 5756 *inside* the main IIFE that closes at line 7164. The `typeof` guards meant to copy it to `window` sat *outside* the IIFE at lines 7394-7401, so `typeof attachInstallButtonHandler` always evaluated to `'undefined'` and the assignment was silently skipped. The "Install from GitHub URL" button therefore had no click handler and `[FALLBACK] attachInstallButtonHandler not available on window` fired on every page load. Fixed by assigning `window.attachInstallButtonHandler` and `window.setupGitHubInstallHandlers` *inside* the IIFE, and removing the dead outside-the-IIFE guards.
- **`base.html` — simplified Alpine.js loader.** Replaced the ~50-line dynamic-script + `deferLoadingAlpine` + `isAPMode` branching block with a single `<script defer src="{{ url_for('static', filename='v3/js/alpinejs.min.js') }}"></script>` plus a small `window.load` rescue that only pulls the unpkg CDN copy if `window.Alpine` is still undefined. `script.defer = true` on a dynamically-inserted `<script>` was a no-op (dynamic scripts are always async), the `deferLoadingAlpine` wrapper was cargo-culted, and the AP-mode branch reached out to unpkg unnecessarily on LAN installs even though `alpinejs.min.js` already ships in the repo at `web_interface/static/v3/js/`.
- **`start.py` / `app.py` — explicit `threaded=True` on `app.run(...)`.** Not a behavior change (Flask has defaulted to `threaded=True` since 1.0), but makes it self-documenting. The two long-lived `/api/v3/stream/*` SSE endpoints would starve every other request under a single-threaded dev server, and this guards against future regressions if someone disables threading.

## Not changed (intentional)

- The Alpine loader rewrite does **not** alter the working behavior observed in the reporter's screenshots — their Alpine was already initializing fine. This is cleanup, not "the fix".
- The `[RENDER] installed-plugins-grid not yet available, deferring render until plugin tab loads` warning at `plugins_manager.js:1378` is **expected** behavior (the grid lives inside an HTMX-lazy-loaded tab) and is left in place. Can be downgraded to `pluginLog` in a separate noise-cleanup PR if desired.
- `systemd/ledmatrix-web.service` sets `Environment=USE_THREADING=1`, but that env var is never read anywhere in the repo. Left as-is since it's dead config and touching the systemd template affects install scripts.

## Does this fix the reporter's symptom?

Partially. Fix #1 will silence the `[FALLBACK]` warning they're seeing and restore the GitHub "Install from URL" button. But their claim was "Plugin Manager button or any button won't work", and since the screenshots prove Alpine's click layer is healthy on their machine, the "any button" part is almost certainly something environment-specific (Safari version, a stuck overlay, an uncaught exception scrolled out of the console) that can't be diagnosed from the screenshots alone. A follow-up diagnostic message has been sent to collect more data from them.

## Test plan

- [ ] `git pull`, hard-reload (Cmd+Opt+R in Safari), confirm the Plugin Manager tab still opens and renders.
- [ ] In the browser console, confirm `typeof window.attachInstallButtonHandler === 'function'` and `typeof window.setupGitHubInstallHandlers === 'function'`.
- [ ] Confirm the `[FALLBACK] attachInstallButtonHandler not available on window` warning no longer appears in the console.
- [ ] Paste a GitHub plugin URL into the "Install from URL" form on the Plugin Store tab and confirm the submit button actually fires its handler.
- [ ] In the Network tab, confirm `alpinejs.min.js` loads from `/static/v3/js/` (200) and no request goes to `unpkg.com`.
- [ ] Confirm `window.Alpine` is defined and tab switching still works across Overview / Settings / Logs / Plugin Manager.
- [ ] Regression-check in Chrome and Firefox.
- [ ] If accessible, regression-check in AP mode (`192.168.4.1`) — the local-first loader should work identically there.
- [ ] Watch the two `/api/v3/stream/*` SSE connections in the Network tab for several minutes under load — confirm they stay open (Connected indicator green) and don't interrupt other requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)