### PR TITLE
fix: post-audit follow-up code fixes (cache, fonts, icons, dev script)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -195,8 +195,9 @@ Located in: `src/cache_manager.py`
 **Key Methods:**
 - `get(key, max_age=300)`: Get cached value (returns None if missing/stale)
 - `set(key, value, ttl=None)`: Cache a value
-- `clear_cache(key=None)`: Remove a cache entry, or all entries if `key`
-  is omitted. There is no `delete()` method.
+- `delete(key)` / `clear_cache(key=None)`: Remove a single cache entry,
+  or (for `clear_cache` with no argument) every cached entry. `delete`
+  is an alias for `clear_cache(key)`.
 - `get_cached_data_with_strategy(key, data_type)`: Cache get with
   data-type-aware TTL strategy
 - `get_background_cached_data(key, sport_key)`: Cache get for the

--- a/docs/DEVELOPER_QUICK_REFERENCE.md
+++ b/docs/DEVELOPER_QUICK_REFERENCE.md
@@ -62,7 +62,7 @@ display_manager.defer_update(lambda: self.update_cache(), priority=0)
 # Basic caching
 cached = cache_manager.get("key", max_age=3600)
 cache_manager.set("key", data)
-cache_manager.clear_cache("key")  # there is no delete() method
+cache_manager.delete("key")       # alias for clear_cache(key)
 
 # Advanced caching
 data = cache_manager.get_cached_data_with_strategy("key", data_type="weather")

--- a/docs/FONT_MANAGER.md
+++ b/docs/FONT_MANAGER.md
@@ -145,11 +145,19 @@ font = self.font_manager.resolve_font(
 > URIs documented below are resolved relative to the plugin's
 > install directory.
 >
-> The `/api/v3/fonts/overrides` endpoints and the **Fonts** tab in
-> the web UI are still **placeholder implementations** — manually
-> registered manager fonts do not yet flow into that tab. If you
-> need an override today, load the font directly in your plugin
-> and skip the override system.
+> The **Fonts** tab in the web UI that lists detected
+> manager-registered fonts is still a **placeholder
+> implementation** — fonts that managers register through
+> `register_manager_font()` do not yet appear there. The
+> programmatic per-element override workflow described in
+> [Manual Font Overrides](#manual-font-overrides) below
+> (`set_override()` / `remove_override()` / the
+> `config/font_overrides.json` store) **does** work today and is
+> the supported way to override a font for an element until the
+> Fonts tab is wired up. If you can't wait and need a workaround
+> right now, you can also just load the font directly with PIL
+> (or `freetype-py` for BDF) inside your plugin's `manager.py`
+> and skip the override system entirely.
 
 ### Plugin Font Registration
 

--- a/docs/FONT_MANAGER.md
+++ b/docs/FONT_MANAGER.md
@@ -138,29 +138,20 @@ font = self.font_manager.resolve_font(
 
 ## For Plugin Developers
 
-> ⚠️ **Status**: the plugin-font registration described below is
-> implemented in `src/font_manager.py:150` (`register_plugin_fonts()`)
-> but is **not currently wired into the plugin loader**. Adding a
-> `"fonts"` block to your plugin's `manifest.json` will silently have
-> no effect — the FontManager method exists but nothing calls it.
->
-> Until that's connected, plugin authors who need a custom font
-> should load it directly with PIL (or `freetype-py` for BDF) in
-> their plugin's `manager.py` — `FontManager.resolve_font(family=…,
-> size_px=…)` takes a **family name**, not a file path, so it can't
-> be used to pull a font from your plugin directory. The
-> `plugin://…` source URIs described below are only honored by
-> `register_plugin_fonts()` itself, which isn't wired up.
+> **Note**: plugins that ship their own fonts via a `"fonts"` block
+> in `manifest.json` are registered automatically during plugin load
+> (`src/plugin_system/plugin_manager.py` calls
+> `FontManager.register_plugin_fonts()`). The `plugin://…` source
+> URIs documented below are resolved relative to the plugin's
+> install directory.
 >
 > The `/api/v3/fonts/overrides` endpoints and the **Fonts** tab in
-> the web UI are currently **placeholder implementations** — they
-> return empty arrays and contain "would integrate with the actual
-> font system" comments. Manually registered manager fonts do
-> **not** yet flow into that tab. If you need an override today,
-> load the font directly in your plugin and skip the
-> override system.
+> the web UI are still **placeholder implementations** — manually
+> registered manager fonts do not yet flow into that tab. If you
+> need an override today, load the font directly in your plugin
+> and skip the override system.
 
-### Plugin Font Registration (planned)
+### Plugin Font Registration
 
 In your plugin's `manifest.json`:
 

--- a/docs/HOW_TO_RUN_TESTS.md
+++ b/docs/HOW_TO_RUN_TESTS.md
@@ -336,15 +336,10 @@ pytest --cov=src --cov-report=html
 
 ## Continuous Integration
 
-There is currently no CI test workflow in this repo — `pytest` runs
-locally but is not gated on PRs. The only GitHub Actions workflow is
-[`.github/workflows/security-audit.yml`](../.github/workflows/security-audit.yml),
-which runs bandit and semgrep on every push.
-
-If you'd like to add a test workflow, the recommended setup is a
-`.github/workflows/tests.yml` that runs `pytest` against the
-supported Python versions (3.10, 3.11, 3.12, 3.13 per
-`requirements.txt`). Open an issue or PR if you want to contribute it.
+The repo runs
+[`.github/workflows/security-audit.yml`](../.github/workflows/security-audit.yml)
+(bandit + semgrep) on every push. A pytest CI workflow is planned
+(`.github/workflows/tests.yml`) — see the PR adding it for details.
 
 ## Best Practices
 

--- a/docs/HOW_TO_RUN_TESTS.md
+++ b/docs/HOW_TO_RUN_TESTS.md
@@ -338,8 +338,13 @@ pytest --cov=src --cov-report=html
 
 The repo runs
 [`.github/workflows/security-audit.yml`](../.github/workflows/security-audit.yml)
-(bandit + semgrep) on every push. A pytest CI workflow is planned
-(`.github/workflows/tests.yml`) — see the PR adding it for details.
+(bandit + semgrep) on every push. A pytest CI workflow at
+`.github/workflows/tests.yml` is queued to land alongside this
+PR ([ChuckBuilds/LEDMatrix#307](https://github.com/ChuckBuilds/LEDMatrix/pull/307));
+the workflow file itself was held back from that PR because the
+push token lacked the GitHub `workflow` scope, so it needs to be
+committed separately by a maintainer. Once it's in, this section
+will be updated to describe what the job runs.
 
 ## Best Practices
 

--- a/docs/PLUGIN_CUSTOM_ICONS.md
+++ b/docs/PLUGIN_CUSTOM_ICONS.md
@@ -1,16 +1,5 @@
 # Plugin Custom Icons Guide
 
-> ⚠️ **Status:** the `icon` field in `manifest.json` is currently
-> **not honored by the v3 web interface**. Plugin tab icons are
-> hardcoded to `fas fa-puzzle-piece` in
-> `web_interface/templates/v3/base.html:515` and `:774`. The icon
-> field was originally read by a `getPluginIcon()` helper in the v2
-> templates, but that helper wasn't ported to v3. Setting `icon` in a
-> manifest is harmless (it's just ignored) so plugin authors can leave
-> it in place for when this regression is fixed.
->
-> Tracking issue: see the LEDMatrix repo for the open ticket.
-
 ## Overview
 
 Plugins can specify custom icons that appear next to their name in the web interface tabs. This makes your plugin instantly recognizable and adds visual polish to the UI.

--- a/docs/PLUGIN_CUSTOM_ICONS_FEATURE.md
+++ b/docs/PLUGIN_CUSTOM_ICONS_FEATURE.md
@@ -1,13 +1,12 @@
 # Plugin Custom Icons Feature
 
-> ⚠️ **Status:** this doc describes the v2 web interface
-> implementation of plugin custom icons. The feature **regressed when
-> the v3 web interface was built** — the `getPluginIcon()` helper
-> referenced below lived in `templates/index_v2.html` (which is now
-> archived) and was not ported to the v3 templates. Plugin tab icons
-> in v3 are hardcoded to `fas fa-puzzle-piece`
-> (`web_interface/templates/v3/base.html:515` and `:774`). The
-> `icon` field in `manifest.json` is currently silently ignored.
+> **Note:** this doc was originally written against the v2 web
+> interface. The v3 web interface now honors the same `icon` field
+> in `manifest.json` — the API passes it through at
+> `web_interface/blueprints/api_v3.py` and the three plugin-tab
+> render sites in `web_interface/templates/v3/base.html` read it
+> with a `fas fa-puzzle-piece` fallback. The guidance below still
+> applies; only the referenced template/helper names differ.
 
 ## What Was Implemented
 

--- a/scripts/dev/dev_plugin_setup.sh
+++ b/scripts/dev/dev_plugin_setup.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$SCRIPT_DIR"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 PLUGINS_DIR="$PROJECT_ROOT/plugins"
 CONFIG_FILE="$PROJECT_ROOT/dev_plugins.json"
 DEFAULT_DEV_DIR="$HOME/.ledmatrix-dev-plugins"

--- a/scripts/dev/plugins/of-the-day
+++ b/scripts/dev/plugins/of-the-day
@@ -1,1 +1,0 @@
-/home/chuck/.ledmatrix-dev-plugins/ledmatrix-of-the-day

--- a/src/base_odds_manager.py
+++ b/src/base_odds_manager.py
@@ -19,14 +19,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, Optional, List
 import pytz
 
-# Import the API counter function from web interface
-try:
-    from web_interface_v2 import increment_api_counter
-except ImportError:
-    # Fallback if web interface is not available
-    def increment_api_counter(kind: str, count: int = 1):
-        pass
-
 
 class BaseOddsManager:
     """
@@ -131,9 +123,7 @@ class BaseOddsManager:
             response = requests.get(url, timeout=self.request_timeout)
             response.raise_for_status()
             raw_data = response.json()
-            
-            # Increment API counter for odds data
-            increment_api_counter('odds', 1)
+
             self.logger.debug(f"Received raw odds data from ESPN: {json.dumps(raw_data, indent=2)}")
             
             odds_data = self._extract_espn_data(raw_data)

--- a/src/cache_manager.py
+++ b/src/cache_manager.py
@@ -320,21 +320,42 @@ class CacheManager:
         return None
 
     def clear_cache(self, key: Optional[str] = None) -> None:
-        """Clear cache for a specific key or all keys."""
-        if key:
-            # Clear specific key
-            self._memory_cache_component.clear(key)
-            self._disk_cache_component.clear(key)
-            self.logger.info("Cleared cache for key: %s", key)
-        else:
+        """Clear cache entries.
+
+        Pass a non-empty ``key`` to remove a single entry, or pass
+        ``None`` (the default) to clear every cached entry. An empty
+        string is rejected to prevent accidental whole-cache wipes
+        from callers that pass through unvalidated input.
+        """
+        if key is None:
             # Clear all keys
             memory_count = self._memory_cache_component.size()
             self._memory_cache_component.clear()
             self._disk_cache_component.clear()
             self.logger.info("Cleared all cache: %d memory entries", memory_count)
+            return
+
+        if not isinstance(key, str) or not key:
+            raise ValueError(
+                "clear_cache(key) requires a non-empty string; "
+                "pass key=None to clear all entries"
+            )
+
+        # Clear specific key
+        self._memory_cache_component.clear(key)
+        self._disk_cache_component.clear(key)
+        self.logger.info("Cleared cache for key: %s", key)
 
     def delete(self, key: str) -> None:
-        """Remove a single cache entry. Alias for ``clear_cache(key)``."""
+        """Remove a single cache entry.
+
+        Thin wrapper around :meth:`clear_cache` that **requires** a
+        non-empty string key — unlike ``clear_cache(None)`` it never
+        wipes every entry. Raises ``ValueError`` on ``None`` or an
+        empty string.
+        """
+        if key is None or not isinstance(key, str) or not key:
+            raise ValueError("delete(key) requires a non-empty string key")
         self.clear_cache(key)
 
     def list_cache_files(self) -> List[Dict[str, Any]]:

--- a/src/cache_manager.py
+++ b/src/cache_manager.py
@@ -333,6 +333,10 @@ class CacheManager:
             self._disk_cache_component.clear()
             self.logger.info("Cleared all cache: %d memory entries", memory_count)
 
+    def delete(self, key: str) -> None:
+        """Remove a single cache entry. Alias for ``clear_cache(key)``."""
+        self.clear_cache(key)
+
     def list_cache_files(self) -> List[Dict[str, Any]]:
         """List all cache files with metadata (key, age, size, path).
         

--- a/src/plugin_system/plugin_manager.py
+++ b/src/plugin_system/plugin_manager.py
@@ -365,15 +365,15 @@ class PluginManager:
             # the actual loading. Wired here so manifest declarations take
             # effect without requiring plugin code changes.
             font_manifest = manifest.get('fonts')
-            if font_manifest and self.display_manager is not None:
-                font_manager = getattr(self.display_manager, 'font_manager', None)
-                if font_manager is not None and hasattr(font_manager, 'register_plugin_fonts'):
-                    try:
-                        font_manager.register_plugin_fonts(plugin_id, font_manifest)
-                    except Exception as e:
-                        self.logger.warning(
-                            "Failed to register fonts for plugin %s: %s", plugin_id, e
-                        )
+            if font_manifest and self.font_manager is not None and hasattr(
+                self.font_manager, 'register_plugin_fonts'
+            ):
+                try:
+                    self.font_manager.register_plugin_fonts(plugin_id, font_manifest)
+                except Exception as e:
+                    self.logger.warning(
+                        "Failed to register fonts for plugin %s: %s", plugin_id, e
+                    )
 
             # Validate configuration
             if hasattr(plugin_instance, 'validate_config'):

--- a/src/plugin_system/plugin_manager.py
+++ b/src/plugin_system/plugin_manager.py
@@ -358,7 +358,23 @@ class PluginManager:
             
             # Store module
             self.plugin_modules[plugin_id] = module
-            
+
+            # Register plugin-shipped fonts with the FontManager (if any).
+            # Plugin manifests can declare a "fonts" block that ships custom
+            # fonts with the plugin; FontManager.register_plugin_fonts handles
+            # the actual loading. Wired here so manifest declarations take
+            # effect without requiring plugin code changes.
+            font_manifest = manifest.get('fonts')
+            if font_manifest and self.display_manager is not None:
+                font_manager = getattr(self.display_manager, 'font_manager', None)
+                if font_manager is not None and hasattr(font_manager, 'register_plugin_fonts'):
+                    try:
+                        font_manager.register_plugin_fonts(plugin_id, font_manifest)
+                    except Exception as e:
+                        self.logger.warning(
+                            "Failed to register fonts for plugin %s: %s", plugin_id, e
+                        )
+
             # Validate configuration
             if hasattr(plugin_instance, 'validate_config'):
                 try:

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -1824,6 +1824,7 @@ def get_installed_plugins():
                 'category': plugin_info.get('category', 'General'),
                 'description': plugin_info.get('description', 'No description available'),
                 'tags': plugin_info.get('tags', []),
+                'icon': plugin_info.get('icon', 'fas fa-puzzle-piece'),
                 'enabled': enabled,
                 'verified': verified,
                 'loaded': plugin_info.get('loaded', False),

--- a/web_interface/templates/v3/base.html
+++ b/web_interface/templates/v3/base.html
@@ -1961,10 +1961,15 @@
                                 this.updatePluginTabStates();
                             }
                         };
-                        const iconClass = this.escapeHtml(plugin.icon || 'fas fa-puzzle-piece');
-                        tabButton.innerHTML = `
-                            <i class="${iconClass}"></i>${this.escapeHtml(plugin.name || plugin.id)}
-                        `;
+                        // Build the <i class="..."> + label as DOM nodes so a
+                        // hostile plugin.icon (e.g. containing a quote) can't
+                        // break out of the attribute. escapeHtml only escapes
+                        // <, >, &, not ", so attribute-context interpolation
+                        // would be unsafe.
+                        const iconEl = document.createElement('i');
+                        iconEl.className = plugin.icon || 'fas fa-puzzle-piece';
+                        const labelNode = document.createTextNode(plugin.name || plugin.id);
+                        tabButton.replaceChildren(iconEl, labelNode);
 
                         // Insert before the closing </nav> tag
                         pluginTabsNav.appendChild(tabButton);

--- a/web_interface/templates/v3/base.html
+++ b/web_interface/templates/v3/base.html
@@ -512,7 +512,8 @@
                             }
                         }
                     };
-                    tabButton.innerHTML = `<i class="fas fa-puzzle-piece"></i>${(plugin.name || plugin.id).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}`;
+                    const iconClass = (plugin.icon || 'fas fa-puzzle-piece').replace(/"/g, '&quot;');
+                    tabButton.innerHTML = `<i class="${iconClass}"></i>${(plugin.name || plugin.id).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}`;
                     pluginTabsNav.appendChild(tabButton);
                 });
                 console.log('[GLOBAL] Updated plugin tabs directly:', plugins.length, 'tabs added');
@@ -771,7 +772,8 @@
                                 };
                                 const div = document.createElement('div');
                                 div.textContent = plugin.name || plugin.id;
-                                tabButton.innerHTML = `<i class="fas fa-puzzle-piece"></i>${div.innerHTML}`;
+                                const iconClass = (plugin.icon || 'fas fa-puzzle-piece').replace(/"/g, '&quot;');
+                                tabButton.innerHTML = `<i class="${iconClass}"></i>${div.innerHTML}`;
                                 pluginTabsNav.appendChild(tabButton);
                             });
                             console.log('[STUB] updatePluginTabs: Added', this.installedPlugins.length, 'plugin tabs');
@@ -1959,8 +1961,9 @@
                                 this.updatePluginTabStates();
                             }
                         };
+                        const iconClass = this.escapeHtml(plugin.icon || 'fas fa-puzzle-piece');
                         tabButton.innerHTML = `
-                            <i class="fas fa-puzzle-piece"></i>${this.escapeHtml(plugin.name || plugin.id)}
+                            <i class="${iconClass}"></i>${this.escapeHtml(plugin.name || plugin.id)}
                         `;
 
                         // Insert before the closing </nav> tag


### PR DESCRIPTION
## Summary

Fixes six code bugs surfaced by the systematic doc-vs-code crosschecks
done during the docs refresh effort in #306. Those findings were
intentionally deferred out of #306 (a docs-only PR) and tracked for
this follow-up.

The seventh bug from that audit (lacrosse-scoreboard display-mode
collision with hockey-scoreboard) is a plugin-repo change and lives
in a companion PR against `ledmatrix-plugins`.

### Bugs fixed

1. **`cache_manager.delete()` AttributeError** — two callers
   (`src/common/api_helper.py:287`,
   `src/plugin_system/resource_monitor.py:343`) already called
   `cache_manager.delete(key)`, but `CacheManager` only defined
   `clear_cache(key=None)`. Added a `delete()` alias that forwards
   to `clear_cache(key)`. Reverts the "no `delete()` method"
   wording in `docs/DEVELOPER_QUICK_REFERENCE.md` and `.cursorrules`.

2. **`scripts/dev/dev_plugin_setup.sh` `PROJECT_ROOT`** — line 9
   set `PROJECT_ROOT="$SCRIPT_DIR"`, so `PLUGINS_DIR` resolved to
   `scripts/dev/plugins/` instead of the repo's `plugins/`. Walked
   up two levels and removed the stray
   `scripts/dev/plugins/of-the-day` symlink left over from earlier
   runs.

3. **Plugin custom icons regressed from v2 to v3** —
   `web_interface/blueprints/api_v3.py` built the
   `/plugins/installed` response without the manifest's `icon`
   field, and `web_interface/templates/v3/base.html` hardcoded
   `fas fa-puzzle-piece` in all three plugin-tab render sites.
   Pass `icon` through the API and read it from the templates
   with a puzzle-piece fallback. Reverts the "currently broken"
   banners in `docs/PLUGIN_CUSTOM_ICONS.md` and
   `docs/PLUGIN_CUSTOM_ICONS_FEATURE.md`.

4. **`register_plugin_fonts()` never wired up** —
   `src/font_manager.py:150` defined
   `register_plugin_fonts(plugin_id, font_manifest)` but no caller
   existed, so a `"fonts"` block in `manifest.json` was a silent
   no-op. Wired the call into `PluginManager.load_plugin()` right
   after `plugin_loader.load_plugin()` returns. Reverts the "not
   currently wired" warning in `docs/FONT_MANAGER.md`.

5. **Dead `web_interface_v2` import pattern (LEDMatrix half)** —
   `src/base_odds_manager.py` had a `try/except` importing
   `web_interface_v2.increment_api_counter`, falling back to a
   no-op stub. The `web_interface_v2` module doesn't exist
   anywhere in the v3 codebase and no API-metrics dashboard
   reads the counter. Deleted the import block and the single
   call site. The plugins-repo half of this cleanup is in the
   companion `ledmatrix-plugins` PR.

### Not included in this PR

- **CI pytest workflow** (bug 7 from the plan) — the new
  `.github/workflows/tests.yml` is ready locally but my OAuth
  token lacks the `workflow` scope, so the push was rejected.
  The file is waiting on disk (`/var/home/chuck/Github/LEDMatrix/.github/workflows/tests.yml`)
  — I can hand you the contents to drop in, or you can push it
  yourself from a shell with the `workflow` scope. I left the
  \"Continuous Integration\" section in `docs/HOW_TO_RUN_TESTS.md`
  wording as \"planned\" until the workflow actually lands.

- **Lacrosse-scoreboard display-mode rename** (bug 6) — ships in
  the companion `ledmatrix-plugins` PR.

## Verification done locally

- \`CacheManager.delete(key)\` round-trips with set/get
- \`base_odds_manager\` imports clean without the v2 module
- \`dev_plugin_setup.sh\` \`PROJECT_ROOT\` resolves to repo root
- \`api_v3.py\`, \`plugin_manager.py\` compile clean
- \`dev_plugin_setup.sh\` passes \`bash -n\`

## Test plan

- [ ] Restart the display service and confirm no \`ImportError:
  web_interface_v2\` warnings in \`journalctl -u ledmatrix\`.
- [ ] Install a plugin with a custom \`icon\` field in its
  manifest (e.g. hockey-scoreboard with \`fas fa-hockey-puck\`),
  restart the web service, confirm the plugin tab in the second
  nav row shows the custom icon.
- [ ] Add a \`"fonts"\` block to a test plugin's \`manifest.json\`,
  restart the display service, confirm the font manager logs
  \`"Successfully registered font ... for plugin ..."\`.
- [ ] Run \`bash scripts/dev/dev_plugin_setup.sh status\` and
  confirm it operates against the repo's \`plugins/\` directory,
  not \`scripts/dev/plugins/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cache Manager `delete()` alias for targeted cache removal.
  * Plugin fonts are now registered automatically during plugin load.
  * Plugin icons from manifests are shown in the v3 web UI.

* **Improvements**
  * Safer and more robust plugin icon rendering to avoid HTML injection issues.

* **Documentation**
  * Updated Cache Manager docs, plugin font/icon guidance, and CI/testing notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->