### PR TITLE
fix(logos): register NCAA lacrosse in logo downloader

### DIFF
--- a/src/logo_downloader.py
+++ b/src/logo_downloader.py
@@ -43,6 +43,9 @@ class LogoDownloader:
         'ncaaw': 'https://site.api.espn.com/apis/site/v2/sports/basketball/womens-college-basketball/teams',  # Alias for basketball plugin
         'ncaa_baseball': 'https://site.api.espn.com/apis/site/v2/sports/baseball/college-baseball/teams',
         'ncaam_hockey': 'https://site.api.espn.com/apis/site/v2/sports/hockey/mens-college-hockey/teams',
+        'ncaaw_hockey': 'https://site.api.espn.com/apis/site/v2/sports/hockey/womens-college-hockey/teams',
+        'ncaam_lacrosse': 'https://site.api.espn.com/apis/site/v2/sports/lacrosse/mens-college-lacrosse/teams',
+        'ncaaw_lacrosse': 'https://site.api.espn.com/apis/site/v2/sports/lacrosse/womens-college-lacrosse/teams',
         # Soccer leagues
         'soccer_eng.1': 'https://site.api.espn.com/apis/site/v2/sports/soccer/eng.1/teams',
         'soccer_esp.1': 'https://site.api.espn.com/apis/site/v2/sports/soccer/esp.1/teams',
@@ -73,6 +76,8 @@ class LogoDownloader:
         'ncaa_baseball': 'assets/sports/ncaa_logos',
         'ncaam_hockey': 'assets/sports/ncaa_logos',
         'ncaaw_hockey': 'assets/sports/ncaa_logos',
+        'ncaam_lacrosse': 'assets/sports/ncaa_logos',
+        'ncaaw_lacrosse': 'assets/sports/ncaa_logos',
         # Soccer leagues - all use the same soccer_logos directory
         'soccer_eng.1': 'assets/sports/soccer_logos',
         'soccer_esp.1': 'assets/sports/soccer_logos',


### PR DESCRIPTION
## Summary

Fixes the lacrosse-scoreboard plugin's "missing layout + missing
school logos" symptom on hardware. Single-file change in
\`src/logo_downloader.py\` adds two NCAA lacrosse rows (and one
missing women's hockey row) to the canonical sport_key registry.

## Root cause

The lacrosse-scoreboard plugin renders broken on the LED matrix:
school logos never appear, and the scoreboard collapses to a tiny
\"Logo Error\" text instead of the normal logo-centric scorebug
that hockey, basketball, football, and baseball all draw.

Tracing the rendering pipeline shows the apparent
\"two issues\" (no layout + no logos) are **one bug**:

1. \`plugins/lacrosse-scoreboard/ncaam_lacrosse_managers.py:29\` and
   \`ncaaw_lacrosse_managers.py:29\` set
   \`sport_key=\"ncaam_lacrosse\"\` / \`\"ncaaw_lacrosse\"\` —
   matching the same naming pattern hockey uses
   (\`ncaam_hockey\`, \`ncaaw_hockey\`).
2. The plugin's vendored \`sports.py:71-80\` then asks the main
   \`src/logo_downloader.py\`:
   \`MainLogoDownloader().get_logo_directory(sport_key)\` to
   resolve where logo PNGs live on disk — exactly the same
   pattern every other sports plugin uses.
3. \`LOGO_DIRECTORIES\` had no entries for \`ncaam_lacrosse\` or
   \`ncaaw_lacrosse\`. \`get_logo_directory()\` fell through at
   line 165 to the safe fallback
   \`f'assets/sports/{league}_logos'\` =
   \`assets/sports/ncaam_lacrosse_logos\`, **a directory that does
   not exist** and is **not** the shared \`ncaa_logos/\` directory
   where every other NCAA sport stores its logos.
4. With the directory pointing nowhere, every per-team
   \`_load_and_resize_logo()\` call returned \`None\`. Both
   \`SportsRecent._draw_scorebug_layout()\` (line 1191) and
   \`SportsUpcoming._draw_scorebug_layout()\` (line 1698) bail out
   on missing logos and draw the literal text \"Logo Error\"
   before returning. That is the user-visible symptom.

The plugin's \`sports.py\` is otherwise nearly identical to
hockey's (a \`diff\` shows only 3 lines different — all about
\`period >= 4\` for lacrosse quarters vs \`period >= 3\` for
hockey periods). The layout code is fine; it just never gets
executed because logo loading fails first.

## Pattern verification

Every sports plugin in \`ledmatrix-plugins/plugins/\` follows the
same vendored architecture and resolves \`sport_key\` through the
main \`LogoDownloader\`. Every NCAA \`sport_key\` was already in
\`LOGO_DIRECTORIES\` — except lacrosse:

| Plugin     | sport_key            | Was in registry? |
|------------|----------------------|------------------|
| football   | \`nfl\`                | ✓                |
| football   | \`ncaa_fb\`            | ✓                |
| basketball | \`nba\`                | ✓                |
| basketball | \`wnba\`               | ✓                |
| basketball | \`ncaam\`              | ✓                |
| basketball | \`ncaaw\`              | ✓                |
| baseball   | \`mlb\`                | ✓                |
| baseball   | \`ncaa_baseball\`      | ✓                |
| hockey     | \`nhl\`                | ✓                |
| hockey     | \`ncaam_hockey\`       | ✓                |
| hockey     | \`ncaaw_hockey\`       | ✓ (LOGO_DIR only — see below) |
| **lacrosse** | **\`ncaam_lacrosse\`** | **✗ THIS BUG**  |
| **lacrosse** | **\`ncaaw_lacrosse\`** | **✗ THIS BUG**  |

## Changes

\`src/logo_downloader.py\` only:

- \`API_ENDPOINTS\`: add \`ncaam_lacrosse\`, \`ncaaw_lacrosse\`,
  and (drive-by) \`ncaaw_hockey\` — the women's hockey entry was
  already in \`LOGO_DIRECTORIES\` but its corresponding ESPN URL
  was missing, leaving \`fetch_teams_data('ncaaw_hockey')\`
  silently broken.
- \`LOGO_DIRECTORIES\`: add \`ncaam_lacrosse\` and
  \`ncaaw_lacrosse\` pointing at the existing shared
  \`assets/sports/ncaa_logos\` directory.

5 lines added, 0 removed. No structural changes, no plugin-side
edits, no version bumps, no asset commits.

## Why no plugin-side change

The plugin's \`sports.py\` already imports the main
\`LogoDownloader\` and asks it to resolve the directory. Once
the registry has the right answer, every sport plugin (current
and future) gets it for free. This is the canonical pattern —
adding lacrosse here makes it a first-class peer.

## Why no prefetch script

Existing NCAA football/hockey schools that also play lacrosse
(DUKE, UVA, MD, NAVY, ARMY, YALE, SYR, …) are **already**
present in \`assets/sports/ncaa_logos/\` and get picked up
immediately on first render with zero downloads. Lacrosse-only
schools (JHU, Loyola, Princeton, Cornell, Stony Brook, …)
download lazily into the shared directory the first time they
appear in an ESPN scoreboard payload, via the existing
\`download_missing_logo(logo_url=…)\` path the plugin already
exercises at runtime.

## Verification done locally

1. **Directory resolution** (no network):
   \`\`\`
   ncaam_lacrosse       -> .../assets/sports/ncaa_logos
   ncaaw_lacrosse       -> .../assets/sports/ncaa_logos
   ncaam_hockey         -> .../assets/sports/ncaa_logos
   ncaaw_hockey         -> .../assets/sports/ncaa_logos
   \`\`\`
   All four collapse to the shared NCAA directory.

2. **Lazy single-team download** with a real ESPN logo URL
   (Johns Hopkins, team_id=120):
   \`\`\`
   downloaded: True | exists: True | size: 40787
   \`\`\`
   Real PNG (~40KB), saved to \`assets/sports/ncaa_logos/\`,
   then cleaned up.

## Test plan

- [ ] Pi pulls main, restarts \`ledmatrix\` service
- [ ] Enable \`lacrosse-scoreboard\` with at least one in-season
      favorite team
- [ ] Confirm the scoreboard shows the **logo-centric layout**
      (home/away logos at the edges, score in the center,
      period/clock on top, records at the bottom) instead of the
      \"Logo Error\" fallback
- [ ] Confirm at least one school logo renders for a team that
      *isn't* already in \`ncaa_logos/\` from the football days
      (e.g. JHU, Loyola, Princeton, Cornell) — proving the lazy
      download path is now live
- [ ] Confirm \`journalctl -u ledmatrix -f\` logs
      \`Logo directory for sport_key='ncaam_lacrosse': …/ncaa_logos\`
      (the existing INFO log at \`sports.py:75\`) instead of the
      old \`…/ncaam_lacrosse_logos\` fallback path

## Out of scope

- Bulk-prefetching every NCAA lacrosse logo via a script (lazy
  download covers it)
- Refactoring the lacrosse plugin to drop its vendored
  \`sports.py\` / \`game_renderer.py\` in favor of the main
  \`src/base_classes/\` (hockey doesn't either; that's a separate
  architectural cleanup)
- The latent \`milb\` (Minor League Baseball) registry gap
  surfaced while verifying the pattern — same shape of bug, but
  separate report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for downloading team logos for three additional NCAA leagues: women's hockey, men's lacrosse, and women's lacrosse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->