### PR TITLE
fix(web-ui-info): syntax error and init order crash on fresh install

### DIFF
--- a/plugin-repos/web-ui-info/manager.py
+++ b/plugin-repos/web-ui-info/manager.py
@@ -35,24 +35,24 @@ class WebUIInfoPlugin(BasePlugin):
         """Initialize the Web UI Info plugin."""
         super().__init__(plugin_id, config, display_manager, cache_manager, plugin_manager)
         
+        # AP mode cache (must be initialized before _get_local_ip)
+        self._ap_mode_cached = False
+        self._ap_mode_cache_time = 0.0
+        self._ap_mode_cache_ttl = 60.0
+
         # Get device hostname
         try:
             self.device_id = socket.gethostname()
         except Exception as e:
             self.logger.warning(f"Could not get hostname: {e}, using 'localhost'")
             self.device_id = "localhost"
-        
+
         # Get device IP address
         self.device_ip = self._get_local_ip()
-        
+
         # IP refresh tracking
         self.last_ip_refresh = time.time()
-        self.ip_refresh_interval = 300.0  # Refresh IP every 5 minutes
-
-        # AP mode cache
-        self._ap_mode_cached = False
-        self._ap_mode_cache_time = 0.0
-        self._ap_mode_cache_ttl = 60.0  # Cache AP mode check for 60 seconds
+        self.ip_refresh_interval = 300.0
 
         # Rotation state
         self.current_display_mode = "hostname"  # "hostname" or "ip"
@@ -200,9 +200,7 @@ class WebUIInfoPlugin(BasePlugin):
                                 elif current_interface == "wlan0":
                                     self.logger.debug(f"Found WiFi IP: {ip} on {current_interface}")
                                     return ip
-            except Exception:
-                pass
-            
+
             # Last resort: try hostname resolution (often returns 127.0.0.1)
             try:
                 ip = socket.gethostbyname(socket.gethostname())


### PR DESCRIPTION
## Summary
- Fixes SyntaxError from orphaned `except Exception:` with no matching `try` — the module couldn't import at all, so the default plugin silently failed to load on every fresh install
- Fixes AttributeError where `_get_local_ip()` was called in `__init__` before AP mode cache fields were initialized — even with the syntax fix, the plugin would crash on instantiation

Both bugs caused a blank display on fresh installs since `web-ui-info` is the only plugin enabled by default in `config.template.json`.

## Test plan
- [x] Verified locally: plugin instantiates, renders image at 128x32
- [x] Verified on devpi: plugin instantiates, renders image at 128x64
- [ ] Fresh install on a clean Pi — plugin should load and display the web UI URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling during IP address resolution to provide better visibility into network connectivity issues

* **Refactor**
  * Reorganized initialization sequence to enhance reliability of AP-mode detection
  * Streamlined IP resolution fallback logic for more predictable behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->