### PR TITLE
fix(web): resolve ReferenceError in single-file upload handler

### DIFF
--- a/web_interface/static/v3/js/widgets/file-upload.js
+++ b/web_interface/static/v3/js/widgets/file-upload.js
@@ -221,6 +221,7 @@
             }
             notifyFn(`Upload error: ${error.message}`, 'error');
         } finally {
+            const fileInput = document.getElementById(`${fieldId}_file_input`);
             if (fileInput) fileInput.value = '';
         }
     };


### PR DESCRIPTION
## Summary
- Fix `ReferenceError: fileInput is not defined` thrown from `handleSingleFileUpload`'s `finally` block in `web_interface/static/v3/js/widgets/file-upload.js`
- The variable was left over from an earlier refactor to `getConfigSourceElement(fieldId)`; the finally block now resolves the input by id so it can be cleared when present
- Surfaced when uploading OAuth `credentials.json` for the Google Calendar plugin — upload succeeded server-side but the UI showed a generic "An unexpected error occurred" toast

## Test plan
- [ ] Hard-reload web UI, open Google Calendar plugin config, upload a valid `credentials.json` — expect green success status, no console error
- [ ] Re-upload the same file to confirm the input is cleared and a second upload works
- [ ] Upload an invalid extension / oversized file — early-return error paths still notify correctly
- [ ] Drag-and-drop a JSON file on the drop zone — routes through the same handler without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file input cleanup logic to ensure proper reset after file uploads, preventing issues with subsequent upload operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->