### PR TITLE
fix(plugin_manager): prevent permanent ERROR state after update timeout

### DIFF
--- a/src/plugin_system/plugin_manager.py
+++ b/src/plugin_system/plugin_manager.py
@@ -747,8 +747,7 @@ class PluginManager:
                         }
                         self.logger.warning("Plugin %s update() failed; will retry after interval", plugin_id)
                         self.plugin_last_update[plugin_id] = failure_time
-                        self.state_manager.set_state(plugin_id, PluginState.ENABLED)
-                        self.state_manager.set_error_info(plugin_id, error_info)
+                        self.state_manager.set_state_with_error(plugin_id, PluginState.ENABLED, error_info, error=err)
                         if self.health_tracker:
                             self.health_tracker.record_failure(plugin_id, err)
                 except Exception as exc:  # pylint: disable=broad-except
@@ -761,8 +760,7 @@ class PluginManager:
                         'recoverable': True,
                     }
                     self.plugin_last_update[plugin_id] = failure_time
-                    self.state_manager.set_state(plugin_id, PluginState.ENABLED)
-                    self.state_manager.set_error_info(plugin_id, error_info)
+                    self.state_manager.set_state_with_error(plugin_id, PluginState.ENABLED, error_info, error=exc)
                     if self.health_tracker:
                         self.health_tracker.record_failure(plugin_id, exc)
 

--- a/src/plugin_system/plugin_manager.py
+++ b/src/plugin_system/plugin_manager.py
@@ -734,18 +734,35 @@ class PluginManager:
                         if self.health_tracker:
                             self.health_tracker.record_success(plugin_id)
                     else:
-                        # Execution failed (timeout or error) — update timestamp so the
-                        # plugin waits one full interval before retrying, but keep state
-                        # ENABLED so can_execute() returns True and recovery is automatic.
-                        self.plugin_last_update[plugin_id] = current_time
+                        # Execution failed (timeout or executor error) — stamp with the
+                        # actual failure time (not current_time captured before execution)
+                        # so the full interval elapses before the next retry.
+                        failure_time = time.time()
+                        err = Exception(f"Plugin {plugin_id} execution failed (timeout or executor error)")
+                        error_info = {
+                            'error': str(err),
+                            'error_type': 'ExecutionFailure',
+                            'timestamp': failure_time,
+                            'recoverable': True,
+                        }
+                        self.logger.warning("Plugin %s update() failed; will retry after interval", plugin_id)
+                        self.plugin_last_update[plugin_id] = failure_time
                         self.state_manager.set_state(plugin_id, PluginState.ENABLED)
+                        self.state_manager.set_error_info(plugin_id, error_info)
                         if self.health_tracker:
-                            self.health_tracker.record_failure(plugin_id, Exception("Plugin execution failed"))
+                            self.health_tracker.record_failure(plugin_id, err)
                 except Exception as exc:  # pylint: disable=broad-except
+                    failure_time = time.time()
                     self.logger.exception("Error updating plugin %s: %s", plugin_id, exc)
-                    # Same as the failure path above: stay ENABLED and wait one interval.
-                    self.plugin_last_update[plugin_id] = current_time
+                    error_info = {
+                        'error': str(exc),
+                        'error_type': type(exc).__name__,
+                        'timestamp': failure_time,
+                        'recoverable': True,
+                    }
+                    self.plugin_last_update[plugin_id] = failure_time
                     self.state_manager.set_state(plugin_id, PluginState.ENABLED)
+                    self.state_manager.set_error_info(plugin_id, error_info)
                     if self.health_tracker:
                         self.health_tracker.record_failure(plugin_id, exc)
 

--- a/src/plugin_system/plugin_manager.py
+++ b/src/plugin_system/plugin_manager.py
@@ -677,6 +677,44 @@ class PluginManager:
         # Default: 60 seconds
         return 60.0
 
+    def _record_update_failure(
+        self,
+        plugin_id: str,
+        exc: Optional[Exception] = None,
+    ) -> None:
+        """Apply the standard failure-recovery path for a plugin update.
+
+        Stamps plugin_last_update with the actual failure time so the full
+        configured interval elapses before the next retry, then transitions
+        the plugin back to ENABLED (not ERROR) with structured error context
+        so automatic recovery happens on the next scheduled cycle.
+
+        Args:
+            plugin_id: Plugin identifier
+            exc: The exception that caused the failure, if any.  When None a
+                 synthetic ExecutionFailure exception is constructed from the
+                 timeout/executor-error path.
+        """
+        failure_time = time.time()
+        if exc is not None:
+            err: Exception = exc
+            error_type = type(exc).__name__
+        else:
+            err = Exception(f"Plugin {plugin_id} execution failed (timeout or executor error)")
+            error_type = 'ExecutionFailure'
+
+        error_info = {
+            'error': str(err),
+            'error_type': error_type,
+            'timestamp': failure_time,
+            'recoverable': True,
+        }
+        self.logger.warning("Plugin %s update() failed; will retry after interval", plugin_id)
+        self.plugin_last_update[plugin_id] = failure_time
+        self.state_manager.set_state_with_error(plugin_id, PluginState.ENABLED, error_info, error=err)
+        if self.health_tracker:
+            self.health_tracker.record_failure(plugin_id, err)
+
     def run_scheduled_updates(self, current_time: Optional[float] = None) -> None:
         """
         Trigger plugin updates based on their defined update intervals.
@@ -734,35 +772,10 @@ class PluginManager:
                         if self.health_tracker:
                             self.health_tracker.record_success(plugin_id)
                     else:
-                        # Execution failed (timeout or executor error) — stamp with the
-                        # actual failure time (not current_time captured before execution)
-                        # so the full interval elapses before the next retry.
-                        failure_time = time.time()
-                        err = Exception(f"Plugin {plugin_id} execution failed (timeout or executor error)")
-                        error_info = {
-                            'error': str(err),
-                            'error_type': 'ExecutionFailure',
-                            'timestamp': failure_time,
-                            'recoverable': True,
-                        }
-                        self.logger.warning("Plugin %s update() failed; will retry after interval", plugin_id)
-                        self.plugin_last_update[plugin_id] = failure_time
-                        self.state_manager.set_state_with_error(plugin_id, PluginState.ENABLED, error_info, error=err)
-                        if self.health_tracker:
-                            self.health_tracker.record_failure(plugin_id, err)
+                        self._record_update_failure(plugin_id)
                 except Exception as exc:  # pylint: disable=broad-except
-                    failure_time = time.time()
                     self.logger.exception("Error updating plugin %s: %s", plugin_id, exc)
-                    error_info = {
-                        'error': str(exc),
-                        'error_type': type(exc).__name__,
-                        'timestamp': failure_time,
-                        'recoverable': True,
-                    }
-                    self.plugin_last_update[plugin_id] = failure_time
-                    self.state_manager.set_state_with_error(plugin_id, PluginState.ENABLED, error_info, error=exc)
-                    if self.health_tracker:
-                        self.health_tracker.record_failure(plugin_id, exc)
+                    self._record_update_failure(plugin_id, exc=exc)
 
     def update_all_plugins(self) -> None:
         """
@@ -788,14 +801,12 @@ class PluginManager:
                 if success:
                     self.plugin_last_update[plugin_id] = time.time()
                     self.state_manager.record_update(plugin_id)
-                    # Update state back to ENABLED
                     self.state_manager.set_state(plugin_id, PluginState.ENABLED)
                 else:
-                    # Execution failed
-                    self.state_manager.set_state(plugin_id, PluginState.ERROR)
+                    self._record_update_failure(plugin_id)
             except Exception as exc:  # pylint: disable=broad-except
                 self.logger.exception("Error updating plugin %s: %s", plugin_id, exc)
-                self.state_manager.set_state(plugin_id, PluginState.ERROR, error=exc)
+                self._record_update_failure(plugin_id, exc=exc)
     
     def get_plugin_health_metrics(self) -> Dict[str, Any]:
         """

--- a/src/plugin_system/plugin_manager.py
+++ b/src/plugin_system/plugin_manager.py
@@ -734,14 +734,18 @@ class PluginManager:
                         if self.health_tracker:
                             self.health_tracker.record_success(plugin_id)
                     else:
-                        # Execution failed (timeout or error)
-                        self.state_manager.set_state(plugin_id, PluginState.ERROR)
+                        # Execution failed (timeout or error) — update timestamp so the
+                        # plugin waits one full interval before retrying, but keep state
+                        # ENABLED so can_execute() returns True and recovery is automatic.
+                        self.plugin_last_update[plugin_id] = current_time
+                        self.state_manager.set_state(plugin_id, PluginState.ENABLED)
                         if self.health_tracker:
                             self.health_tracker.record_failure(plugin_id, Exception("Plugin execution failed"))
                 except Exception as exc:  # pylint: disable=broad-except
                     self.logger.exception("Error updating plugin %s: %s", plugin_id, exc)
-                    self.state_manager.set_state(plugin_id, PluginState.ERROR, error=exc)
-                    # Record failure
+                    # Same as the failure path above: stay ENABLED and wait one interval.
+                    self.plugin_last_update[plugin_id] = current_time
+                    self.state_manager.set_state(plugin_id, PluginState.ENABLED)
                     if self.health_tracker:
                         self.health_tracker.record_failure(plugin_id, exc)
 

--- a/src/plugin_system/plugin_state.py
+++ b/src/plugin_system/plugin_state.py
@@ -136,13 +136,29 @@ class PluginStateManager:
         """
         return self._state_history.get(plugin_id, [])
     
-    def get_error_info(self, plugin_id: str) -> Optional[Dict[str, Any]]:
+    def set_error_info(self, plugin_id: str, error_info: Dict[str, Any]) -> None:
         """
-        Get error information for a plugin in ERROR state.
-        
+        Persist structured error context without changing plugin state.
+
+        Used for recoverable failures (e.g. update timeout) where the plugin
+        stays ENABLED but the error details should remain queryable.
+
         Args:
             plugin_id: Plugin identifier
-            
+            error_info: Arbitrary dict describing the error
+        """
+        self._error_info[plugin_id] = error_info
+
+    def get_error_info(self, plugin_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Get error information for a plugin.
+
+        Returns the stored error dict whether the plugin is in ERROR state or
+        still ENABLED after a recoverable failure.
+
+        Args:
+            plugin_id: Plugin identifier
+
         Returns:
             Error information dict or None
         """

--- a/src/plugin_system/plugin_state.py
+++ b/src/plugin_system/plugin_state.py
@@ -5,6 +5,7 @@ Manages plugin state machine (loaded → enabled → running → error)
 with state transitions and queries.
 """
 
+import threading
 from enum import Enum
 from typing import Optional, Dict, Any
 from datetime import datetime
@@ -34,6 +35,7 @@ class PluginStateManager:
             logger: Optional logger instance
         """
         self.logger = logger or get_logger(__name__)
+        self._lock = threading.RLock()
         self._states: Dict[str, PluginState] = {}
         self._state_history: Dict[str, list] = {}
         self._error_info: Dict[str, Dict[str, Any]] = {}
@@ -148,6 +150,51 @@ class PluginStateManager:
             error_info: Arbitrary dict describing the error
         """
         self._error_info[plugin_id] = error_info
+
+    def set_state_with_error(
+        self,
+        plugin_id: str,
+        state: PluginState,
+        error_info: Dict[str, Any],
+        error: Optional[Exception] = None,
+    ) -> None:
+        """Set plugin state and persist error context atomically.
+
+        Unlike calling set_state() then set_error_info() separately, this
+        method holds ``_lock`` for both writes so no reader can observe the
+        new state without the accompanying error context.
+
+        Intentionally does not clear ``_error_info`` the way set_state() does
+        for non-ERROR transitions — this is the recoverable-failure path where
+        the error dict is the entire point.
+
+        Args:
+            plugin_id: Plugin identifier
+            state: New state
+            error_info: Structured error dict to persist alongside the state
+            error: Optional exception recorded in the transition history
+        """
+        with self._lock:
+            old_state = self._states.get(plugin_id, PluginState.UNLOADED)
+            self._states[plugin_id] = state
+
+            if plugin_id not in self._state_history:
+                self._state_history[plugin_id] = []
+            self._state_history[plugin_id].append({
+                'timestamp': datetime.now(),
+                'from': old_state.value,
+                'to': state.value,
+                'error': str(error) if error else None,
+            })
+
+            self._error_info[plugin_id] = error_info
+
+            self.logger.debug(
+                "Plugin %s state transition: %s → %s (recoverable error stored)",
+                plugin_id,
+                old_state.value,
+                state.value,
+            )
 
     def get_error_info(self, plugin_id: str) -> Optional[Dict[str, Any]]:
         """

--- a/src/plugin_system/plugin_state.py
+++ b/src/plugin_system/plugin_state.py
@@ -50,44 +50,44 @@ class PluginStateManager:
     ) -> None:
         """
         Set plugin state and record transition.
-        
+
         Args:
             plugin_id: Plugin identifier
             state: New state
             error: Optional error if transitioning to ERROR state
         """
-        old_state = self._states.get(plugin_id, PluginState.UNLOADED)
-        self._states[plugin_id] = state
-        
-        # Record state transition
-        if plugin_id not in self._state_history:
-            self._state_history[plugin_id] = []
-        
-        transition = {
-            'timestamp': datetime.now(),
-            'from': old_state.value,
-            'to': state.value,
-            'error': str(error) if error else None
-        }
-        self._state_history[plugin_id].append(transition)
-        
-        # Store error info if transitioning to ERROR state
-        if state == PluginState.ERROR and error:
-            self._error_info[plugin_id] = {
-                'error': str(error),
-                'error_type': type(error).__name__,
-                'timestamp': datetime.now()
+        with self._lock:
+            old_state = self._states.get(plugin_id, PluginState.UNLOADED)
+            self._states[plugin_id] = state
+
+            if plugin_id not in self._state_history:
+                self._state_history[plugin_id] = []
+
+            transition = {
+                'timestamp': datetime.now(),
+                'from': old_state.value,
+                'to': state.value,
+                'error': str(error) if error else None
             }
-        elif state != PluginState.ERROR:
-            # Clear error info when leaving ERROR state
-            self._error_info.pop(plugin_id, None)
-        
-        self.logger.debug(
-            "Plugin %s state transition: %s → %s",
-            plugin_id,
-            old_state.value,
-            state.value
-        )
+            self._state_history[plugin_id].append(transition)
+
+            # Store error info if transitioning to ERROR state
+            if state == PluginState.ERROR and error:
+                self._error_info[plugin_id] = {
+                    'error': str(error),
+                    'error_type': type(error).__name__,
+                    'timestamp': datetime.now()
+                }
+            elif state != PluginState.ERROR:
+                # Clear error info when leaving ERROR state
+                self._error_info.pop(plugin_id, None)
+
+            self.logger.debug(
+                "Plugin %s state transition: %s → %s",
+                plugin_id,
+                old_state.value,
+                state.value
+            )
     
     def get_state(self, plugin_id: str) -> PluginState:
         """
@@ -149,7 +149,8 @@ class PluginStateManager:
             plugin_id: Plugin identifier
             error_info: Arbitrary dict describing the error
         """
-        self._error_info[plugin_id] = error_info
+        with self._lock:
+            self._error_info[plugin_id] = dict(error_info)
 
     def set_state_with_error(
         self,
@@ -187,7 +188,7 @@ class PluginStateManager:
                 'error': str(error) if error else None,
             })
 
-            self._error_info[plugin_id] = error_info
+            self._error_info[plugin_id] = dict(error_info)
 
             self.logger.debug(
                 "Plugin %s state transition: %s → %s (recoverable error stored)",
@@ -201,15 +202,18 @@ class PluginStateManager:
         Get error information for a plugin.
 
         Returns the stored error dict whether the plugin is in ERROR state or
-        still ENABLED after a recoverable failure.
+        still ENABLED after a recoverable failure. Returns a shallow copy so
+        callers cannot mutate the stored snapshot.
 
         Args:
             plugin_id: Plugin identifier
 
         Returns:
-            Error information dict or None
+            Copy of the error information dict, or None
         """
-        return self._error_info.get(plugin_id)
+        with self._lock:
+            info = self._error_info.get(plugin_id)
+            return dict(info) if info is not None else None
     
     def record_update(self, plugin_id: str) -> None:
         """Record that plugin update() was called."""


### PR DESCRIPTION
## Summary

- When `execute_update()` returns `False` (timeout or unhandled exception), the plugin was set to `PluginState.ERROR` with no recovery mechanism — `can_execute()` returns `False` for `ERROR` state, permanently silencing the plugin's `update()` method
- Instead, update `plugin_last_update` on failure so the plugin waits one configured interval before retrying, and keep state `ENABLED` so `can_execute()` returns `True`

## Root cause (confirmed on devpi)

The weather plugin was showing 3-day-old forecast data. Investigation found:
- Cache file timestamp: `2026-04-25 07:35` — 3 days old despite the service running continuously
- Zero weather update log messages in 11 hours of journal
- The weather plugin's `_update_radar()` fetches up to 12 RainViewer tiles sequentially (each `timeout=10s`, worst case 120s), exceeding the executor's default 30s timeout
- On the second successful weather API call (when `forecast_data` gets lat/lon and radar fetching starts for the first time), the update timed out → `ERROR` state → permanent silence on all subsequent calls

This bug affects **any** plugin that ever times out on a slow network call — once it hits `ERROR`, it never recovers until a service restart.

## Test plan

- [x] Deployed to devpi, restarted service — `"Weather data updated for Tampa: 72.48°"` appeared in logs within seconds, cache file updated with today's timestamp
- [ ] Confirm that a plugin in a simulated timeout recovers on the next interval cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plugins that fail during scheduled updates now remain enabled and are retried instead of being disabled.
  * Recoverable failures and exceptions are handled consistently to ensure reliable retries.
  * Error events store structured details (type, message, timestamp, recoverable) and retain that context even when plugins stay enabled.
  * State and error updates are applied atomically and guarded for thread safety to prevent inconsistent status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->