### PR TITLE
fix(install): prevent weather and music from auto-installing on fresh install

### DIFF
--- a/config/config_secrets.template.json
+++ b/config/config_secrets.template.json
@@ -1,17 +1,9 @@
 {
-    "ledmatrix-weather": {
-        "api_key": "YOUR_OPENWEATHERMAP_API_KEY"
-    },
     "youtube": {
         "api_key": "YOUR_YOUTUBE_API_KEY",
         "channel_id": "YOUR_YOUTUBE_CHANNEL_ID"
     },
-    "music": {
-        "SPOTIFY_CLIENT_ID": "YOUR_SPOTIFY_CLIENT_ID_HERE",
-        "SPOTIFY_CLIENT_SECRET": "YOUR_SPOTIFY_CLIENT_SECRET_HERE",
-        "SPOTIFY_REDIRECT_URI": "http://127.0.0.1:8888/callback"
-    },
     "github": {
         "api_token": "YOUR_GITHUB_PERSONAL_ACCESS_TOKEN"
     }
-} 
+}

--- a/first_time_install.sh
+++ b/first_time_install.sh
@@ -598,7 +598,15 @@ if [ ! -f "$PROJECT_ROOT_DIR/config/config_secrets.json" ]; then
     else
         echo "⚠ Template config/config_secrets.template.json not found; creating a minimal secrets file"
         cat > "$PROJECT_ROOT_DIR/config/config_secrets.json" <<'EOF'
-{}
+{
+    "youtube": {
+        "api_key": "YOUR_YOUTUBE_API_KEY",
+        "channel_id": "YOUR_YOUTUBE_CHANNEL_ID"
+    },
+    "github": {
+        "api_token": "YOUR_GITHUB_PERSONAL_ACCESS_TOKEN"
+    }
+}
 EOF
         # Check if service runs as root and set ownership accordingly
         SERVICE_USER="root"

--- a/first_time_install.sh
+++ b/first_time_install.sh
@@ -598,11 +598,7 @@ if [ ! -f "$PROJECT_ROOT_DIR/config/config_secrets.json" ]; then
     else
         echo "⚠ Template config/config_secrets.template.json not found; creating a minimal secrets file"
         cat > "$PROJECT_ROOT_DIR/config/config_secrets.json" <<'EOF'
-{
-  "weather": {
-    "api_key": "YOUR_OPENWEATHERMAP_API_KEY"
-  }
-}
+{}
 EOF
         # Check if service runs as root and set ownership accordingly
         SERVICE_USER="root"


### PR DESCRIPTION
## Summary

- Removes `ledmatrix-weather` and `music` credential stubs from `config_secrets.template.json`
- Clears the matching `weather` key from the inline fallback block in `first_time_install.sh`

## Root cause

`config_manager` deep-merges `config_secrets.json` into the main config on every load. Because the secrets template shipped `ledmatrix-weather` and `music` as top-level keys, they appeared as plugin config entries in the merged config. The state reconciler treated them as plugins referenced in config but not installed on disk, and auto-downloaded and installed both on the first web UI visit after a fresh install.

## Test plan

- [ ] Fresh install from `one-shot-install.sh` — confirm only `starlark-apps`, `web-ui-info` appear in `plugin-repos/` after boot
- [ ] Open web UI plugin page — confirm neither `ledmatrix-weather` nor `ledmatrix-music` are auto-installed
- [ ] Manually install `ledmatrix-weather` or `ledmatrix-music` via plugin store — confirm credentials can still be added to `config_secrets.json` and are picked up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed weather API and music service configuration sections from the configuration template.
  * Simplified default configuration file initialization to generate a minimal configuration structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->