### PR TITLE
fix(plugins): plugin manager tab doesn't always load on first visit

### DIFF
--- a/web_interface/static/v3/plugins_manager.js
+++ b/web_interface/static/v3/plugins_manager.js
@@ -1165,9 +1165,10 @@ function initializePluginPageWhenReady() {
         if (target.id === 'plugins-content' ||
             target.querySelector('#installed-plugins-grid')) {
             console.log('HTMX swap detected for plugins, initializing...');
-            // Reset initialization flag to allow re-initialization after HTMX swap
+            // Reset all initialization flags so the fresh empty DOM gets populated
             window.pluginManager.initialized = false;
             window.pluginManager.initializing = false;
+            pluginsInitialized = false;
             initTimer = setTimeout(attemptInit, 100);
         }
     }, { once: false }); // Allow multiple swaps
@@ -5127,7 +5128,7 @@ function refreshPlugins() {
     pluginStoreCache = null;
     cacheTimestamp = null;
 
-    loadInstalledPlugins();
+    refreshInstalledPlugins(); // invalidates cache before fetching
     // Fetch latest metadata from GitHub when refreshing
     searchPluginStore(true);
     showNotification('Plugins refreshed with latest metadata from GitHub', 'success');

--- a/web_interface/static/v3/plugins_manager.js
+++ b/web_interface/static/v3/plugins_manager.js
@@ -1168,6 +1168,7 @@ function initializePluginPageWhenReady() {
             // Reset all initialization flags so the fresh empty DOM gets populated
             window.pluginManager.initialized = false;
             window.pluginManager.initializing = false;
+            window.pluginManager._reswap = true; // signal: use cached store, don't re-fetch GitHub
             pluginsInitialized = false;
             initTimer = setTimeout(attemptInit, 100);
         }
@@ -1212,9 +1213,13 @@ function initializePlugins() {
         console.warn('[INIT] checkGitHubAuthStatus not available yet');
     }
 
-    // Load both installed plugins and plugin store
+    // Load both installed plugins and plugin store.
+    // On HTMX re-swaps use cached store data (fetchCommitInfo=false) to avoid
+    // re-hitting GitHub on every tab switch; only fetch fresh on first load.
+    const isReswap = !!window.pluginManager._reswap;
+    window.pluginManager._reswap = false;
     loadInstalledPlugins();
-    searchPluginStore(true); // Load plugin store with fresh metadata from GitHub
+    searchPluginStore(!isReswap);
 
     // Setup search functionality (with guard against duplicate listeners)
     const searchInput = document.getElementById('plugin-search');


### PR DESCRIPTION
## Root cause

HTMX's `revealed` trigger fires each time the plugins tab becomes visible. Alpine's `x-show` toggles `display:none` on the parent div on every tab switch, which re-triggers the IntersectionObserver. Each re-reveal fetches a fresh empty HTML skeleton via `hx-swap="innerHTML"`.

The `htmx:afterSwap` handler reset `window.pluginManager.initialized` and `window.pluginManager.initializing`, but **not** `pluginsInitialized` (the guard inside `initializePlugins()`). So after the first successful init, every subsequent HTMX re-swap would:
1. Replace the DOM with a fresh empty skeleton
2. Trigger `initializePlugins()` which immediately returned at the `pluginsInitialized` guard
3. `loadInstalledPlugins()` and `searchPluginStore()` were never called
4. Fresh empty DOM stayed empty — plugins tab appeared blank

## Changes

- `htmx:afterSwap` handler now also resets `pluginsInitialized = false`, so data is always re-fetched into the fresh DOM. Existing caches (3s for installed plugins, 5min for store) handle fast tab revisits with no extra API traffic.
- `refreshPlugins()` now calls `refreshInstalledPlugins()` (the existing helper that explicitly invalidates the cache) instead of bare `loadInstalledPlugins()`, which could silently skip the fetch if the 3-second cache was still valid.

## Test plan

- [ ] Open Plugin Manager tab — installed plugins and store load correctly on first visit
- [ ] Switch to another tab, then back to Plugin Manager — plugins reload from cache immediately (no blank state)
- [ ] Repeat tab-switch 3–4 times — consistent every time
- [ ] Click "Refresh Plugins" — both installed list and store reload with fresh data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plugin manager page refresh to ensure proper initialization
  * Improved plugin refresh functionality to eliminate stale data display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->