### PR TITLE
chore(deps): update rpi-rgb-led-matrix to latest upstream for Pi 5 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "rpi-rgb-led-matrix-master"]
 	path = rpi-rgb-led-matrix-master
 	url = https://github.com/hzeller/rpi-rgb-led-matrix.git
+	branch = master

--- a/config/config.template.json
+++ b/config/config.template.json
@@ -112,7 +112,8 @@
             "limit_refresh_rate_hz": 100
         },
         "runtime": {
-            "gpio_slowdown": 3
+            "gpio_slowdown": 3,
+            "rp1_rio": 0
         },
         "display_durations": {},
         "use_short_date_format": true,

--- a/first_time_install.sh
+++ b/first_time_install.sh
@@ -271,7 +271,7 @@ apt_update
 
 # Install required system packages
 echo "Installing Python packages and dependencies..."
-apt_install python3-pip python3-venv python3-dev python3-pil python3-pil.imagetk build-essential python3-setuptools python3-wheel cython3 scons cmake ninja-build
+apt_install python3-pip python3-venv python-dev-is-python3 python3-pil python3-pil.imagetk build-essential python3-setuptools python3-wheel cmake ninja-build
 
 # Install additional system dependencies that might be needed
 echo "Installing additional system dependencies..."
@@ -821,20 +821,13 @@ else
         fi
         
         pushd "$PROJECT_ROOT_DIR/rpi-rgb-led-matrix-master" >/dev/null
-        echo "Building rpi-rgb-led-matrix Python bindings..."
-        # Build the library first, then Python bindings
-        # The build-python target depends on the library being built
-        if ! make build-python; then
-            echo "✗ Failed to build rpi-rgb-led-matrix Python bindings"
-            echo "  Make sure you have the required build tools installed:"
-            echo "  sudo apt install -y build-essential python3-dev cython3 scons"
-            popd >/dev/null
-            exit 1
-        fi
-        cd bindings/python
-        echo "Installing rpi-rgb-led-matrix Python package via pip..."
+        echo "Installing rpi-rgb-led-matrix Python package (scikit-build-core + cmake)..."
+        echo "  Build deps required: python-dev-is-python3 cmake"
+        echo "  This compiles C++ — may take 2-5 minutes on Pi 4/5..."
         if ! python3 -m pip install --break-system-packages .; then
             echo "✗ Failed to install rpi-rgb-led-matrix Python package"
+            echo "  Ensure build tools are installed:"
+            echo "  sudo apt install -y python-dev-is-python3 cmake build-essential"
             popd >/dev/null
             exit 1
         fi

--- a/first_time_install.sh
+++ b/first_time_install.sh
@@ -795,7 +795,7 @@ else
         # Try to initialize submodule if .gitmodules exists
         if [ -f "$PROJECT_ROOT_DIR/.gitmodules" ] && grep -q "rpi-rgb-led-matrix" "$PROJECT_ROOT_DIR/.gitmodules"; then
             echo "Initializing rpi-rgb-led-matrix submodule..."
-            if ! git submodule update --init --remote --recursive rpi-rgb-led-matrix-master 2>&1; then
+            if ! git submodule update --init --recursive rpi-rgb-led-matrix-master 2>&1; then
                 echo "⚠ Submodule init failed, cloning directly from GitHub..."
                 git clone https://github.com/hzeller/rpi-rgb-led-matrix.git rpi-rgb-led-matrix-master
             fi
@@ -814,7 +814,7 @@ else
             cd "$PROJECT_ROOT_DIR"
             rm -rf rpi-rgb-led-matrix-master
             if [ -f "$PROJECT_ROOT_DIR/.gitmodules" ] && grep -q "rpi-rgb-led-matrix" "$PROJECT_ROOT_DIR/.gitmodules"; then
-                git submodule update --init --remote --recursive rpi-rgb-led-matrix-master
+                git submodule update --init --recursive rpi-rgb-led-matrix-master
             else
                 git clone https://github.com/hzeller/rpi-rgb-led-matrix.git rpi-rgb-led-matrix-master
             fi

--- a/first_time_install.sh
+++ b/first_time_install.sh
@@ -795,7 +795,7 @@ else
         # Try to initialize submodule if .gitmodules exists
         if [ -f "$PROJECT_ROOT_DIR/.gitmodules" ] && grep -q "rpi-rgb-led-matrix" "$PROJECT_ROOT_DIR/.gitmodules"; then
             echo "Initializing rpi-rgb-led-matrix submodule..."
-            if ! git submodule update --init --recursive rpi-rgb-led-matrix-master 2>&1; then
+            if ! git submodule update --init --remote --recursive rpi-rgb-led-matrix-master 2>&1; then
                 echo "⚠ Submodule init failed, cloning directly from GitHub..."
                 git clone https://github.com/hzeller/rpi-rgb-led-matrix.git rpi-rgb-led-matrix-master
             fi
@@ -814,7 +814,7 @@ else
             cd "$PROJECT_ROOT_DIR"
             rm -rf rpi-rgb-led-matrix-master
             if [ -f "$PROJECT_ROOT_DIR/.gitmodules" ] && grep -q "rpi-rgb-led-matrix" "$PROJECT_ROOT_DIR/.gitmodules"; then
-                git submodule update --init --recursive rpi-rgb-led-matrix-master
+                git submodule update --init --remote --recursive rpi-rgb-led-matrix-master
             else
                 git clone https://github.com/hzeller/rpi-rgb-led-matrix.git rpi-rgb-led-matrix-master
             fi

--- a/src/display_manager.py
+++ b/src/display_manager.py
@@ -103,7 +103,14 @@ class DisplayManager:
             # Pi 5 only: 0=PIO/RP1 coprocessor (default, less CPU),
             # 1=RIO/Registered IO (faster; gpio_slowdown effect is inverted in this mode)
             if 'rp1_rio' in runtime_config:
-                options.rp1_rio = runtime_config.get('rp1_rio')
+                if hasattr(options, 'rp1_rio'):
+                    options.rp1_rio = runtime_config.get('rp1_rio')
+                else:
+                    logger.warning(
+                        "rp1_rio is set in config but the current RGBMatrixOptions "
+                        "implementation does not support it (RGBMatrixEmulator or older "
+                        "library version) — value will be ignored"
+                    )
             
             logger.info(f"Initializing RGB Matrix with settings: rows={options.rows}, cols={options.cols}, chain_length={options.chain_length}, parallel={options.parallel}, hardware_mapping={options.hardware_mapping}")
             

--- a/src/display_manager.py
+++ b/src/display_manager.py
@@ -100,6 +100,10 @@ class DisplayManager:
                 options.pwm_dither_bits = hardware_config.get('pwm_dither_bits')
             if 'inverse_colors' in hardware_config:
                 options.inverse_colors = hardware_config.get('inverse_colors')
+            # Pi 5 only: 0=PIO/RP1 coprocessor (default, less CPU),
+            # 1=RIO/Registered IO (faster; gpio_slowdown effect is inverted in this mode)
+            if 'rp1_rio' in runtime_config:
+                options.rp1_rio = runtime_config.get('rp1_rio')
             
             logger.info(f"Initializing RGB Matrix with settings: rows={options.rows}, cols={options.cols}, chain_length={options.chain_length}, parallel={options.parallel}, hardware_mapping={options.hardware_mapping}")
             


### PR DESCRIPTION
## Summary

Updates the `rpi-rgb-led-matrix-master/` git submodule from `2cfff2a` (6 months old) to the current upstream master, and configures it to **track the upstream `master` branch** going forward so future updates require only `git submodule update --remote` rather than manual SHA management.

### Why now

- **Pi 5 support**: The current pinned version does not run on Raspberry Pi 5 at all. The upstream added two new RP1 hardware backends in PR #1886 (merged Apr 2026) that enable Pi 5 operation.
- **Python 3.13 build failure**: The old `bindings/python/setup.py` used `distutils` which was removed in Python 3.12. Pi OS now ships Python 3.13 — the bindings could not be compiled. Fixed upstream in PR #1833.
- **New build system**: The library migrated from `make build-python` to scikit-build-core + cmake. The entire repo is now pip-installable via `pip install .` from the repo root.

## Changes

### Submodule (`rpi-rgb-led-matrix-master`)
- Updated to upstream master HEAD (`8907235`)
- `.gitmodules` now sets `branch = master` so `git submodule update --remote` always fetches latest

### `first_time_install.sh`
- `git submodule update` now uses `--remote` flag — fresh installs always pull current upstream
- Removed `make build-python` step (target no longer exists in new build system)
- Install now runs `pip install .` from the repo root instead of `bindings/python/`
- Build deps updated: removed `cython3`/`scons`/`python3-dev`, added `python-dev-is-python3`

### `src/display_manager.py`
- Added `rp1_rio` option (read from `runtime_config`, same pattern as `gpio_slowdown`)
- Only applied when explicitly set in config — ignored on Pi 4 and earlier

### `config/config.template.json`
- Added `"rp1_rio": 0` to the `runtime` section alongside `gpio_slowdown`

## Pi 5 configuration notes

The library **auto-detects Pi 5 hardware** — no config change is required for basic operation. The `rp1_rio` key is a tuning option:

| Value | Mode | Description |
|---|---|---|
| `0` (default) | PIO | Uses Pi 5's RP1 coprocessor — minimal CPU usage, recommended |
| `1` | RIO | Registered IO — higher throughput, higher CPU; `gpio_slowdown` effect is **inverted** in this mode |

`adafruit-hat-pwm` is confirmed supported on Pi 5. Pi 4 and earlier are unaffected — `rp1_rio` is silently ignored on non-Pi-5 hardware.

## No API breakage

Zero changes to `core.pyx` or `graphics.pyx` between old and new version — confirmed by diff. `RGBMatrix`, `RGBMatrixOptions`, `FrameCanvas`, `CreateFrameCanvas`, `SetImage`, `SwapOnVSync`, `Clear`, `.width`, `.height`, `.brightness` all work identically.

## Test plan

- [x] Built successfully on devpi (Python 3.13 / aarch64) with new scikit-build-core system
- [x] `from rgbmatrix import RGBMatrix, RGBMatrixOptions` passes on devpi
- [x] `opts.rp1_rio = 0` confirmed present (new Pi 5 property)
- [x] Test suite: 463 passed, 21 failed (3 of those pre-existing on main from PR #333; all 18 original pre-existing failures unchanged)
- [ ] Physical LED display smoke test on Pi

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new Raspberry Pi 5 display configuration option.

* **Chores**
  * Updated installation process with new dependencies and build methodology.
  * Updated underlying display library to latest version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/LEDMatrix/pull/334)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->