### PR TITLE
fix(systemd): wait for network-online.target before starting services

### DIFF
--- a/scripts/install/install_web_service.sh
+++ b/scripts/install/install_web_service.sh
@@ -31,7 +31,8 @@ echo "Generating service file with dynamic paths..."
 WEB_SERVICE_FILE_CONTENT=$(cat <<EOF
 [Unit]
 Description=LED Matrix Web Interface Service
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple

--- a/systemd/ledmatrix-web.service
+++ b/systemd/ledmatrix-web.service
@@ -7,7 +7,8 @@
 
 [Unit]
 Description=LED Matrix Web Interface Service
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple

--- a/systemd/ledmatrix.service
+++ b/systemd/ledmatrix.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=LED Matrix Display Service
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Problem

On boot, both `ledmatrix` and `ledmatrix-web` services were starting before the network connection was established. The unit files had `After=network.target`, which only guarantees that NetworkManager has *started* — not that the device has an active internet connection.

**Observed on devpi (2026-05-15 14:48):**
```
14:48:03  service started
14:48:07  ERROR - Failed to fetch aircraft data: [Errno 101] Network is unreachable
14:48:07  ERROR - Failed to resolve 'data-cloud.flightradar24.com' [Errno -3]
14:48:07  ERROR - Failed to resolve 'api.openweathermap.org' [Errno -3]
14:50:40  service restarted (network now available) — everything recovered cleanly
```

All three errors fired simultaneously ~4 seconds after startup, while WiFi association and DHCP were still completing.

## Fix

Change `After=network.target` → `After=network-online.target` + `Wants=network-online.target` in:

- `systemd/ledmatrix.service`
- `systemd/ledmatrix-web.service`
- `scripts/install/install_web_service.sh` (inline heredoc that generates the web service file at install time)

`network-online.target` is provided by `NetworkManager-wait-online.service` on Raspberry Pi OS and waits for an active network route before releasing. The tradeoff is a few extra seconds at boot, which is acceptable for a display device.

## Test plan

- [x] Applied live to devpi via `sed` + `systemctl daemon-reload` — confirmed `After=network-online.target` in running unit
- [ ] Reboot devpi and verify services start without network errors in `journalctl -u ledmatrix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated systemd service configurations for ledmatrix and ledmatrix-web to wait for full network availability during startup, ensuring services initialize after the network is fully online rather than just detected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/LEDMatrix/pull/335)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->