### PR TITLE
fix: Codacy round-2 — urllib3 CVEs and missed JS/Python issues

### DIFF
--- a/plugin-repos/march-madness/requirements.txt
+++ b/plugin-repos/march-madness/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.33.0
-urllib3>=1.26.0
+urllib3>=2.2.2
 Pillow>=12.2.0
 pytz>=2022.1
 numpy>=1.24.0

--- a/src/common/display_helper.py
+++ b/src/common/display_helper.py
@@ -235,8 +235,6 @@ class DisplayHelper:
             PIL Image with no data message
         """
         img = self.create_base_image((0, 0, 0))
-        draw = ImageDraw.Draw(img)
-        
         font = ImageFont.load_default()
         self._draw_centered_text(message, font, (0, 0, 0), (150, 150, 150))
         

--- a/src/display_controller.py
+++ b/src/display_controller.py
@@ -823,7 +823,7 @@ class DisplayController:
                 scroll_h = getattr(plugin_instance, 'scroll_helper', None)
                 if scroll_h is not None:
                     follower_frame = scroll_h.get_portion_at(scroll_h.scroll_position + offset)
-            except Exception:
+            except Exception:  # nosec B110 - scroll_helper.get_portion_at is optional; skip on error
                 pass
 
         # 3. Mirror fallback — static plugins (clock, weather) show same frame

--- a/src/display_manager.py
+++ b/src/display_manager.py
@@ -747,7 +747,7 @@ class DisplayManager:
             try:
                 self.image = Image.new('RGB', (self.width, self.height))
                 self.draw = ImageDraw.Draw(self.image)
-            except Exception:
+            except Exception:  # nosec B110 - best-effort canvas reset during cleanup; non-critical
                 pass
         # Reset the singleton state when cleaning up
         DisplayManager._instance = None

--- a/web_interface/start.py
+++ b/web_interface/start.py
@@ -41,7 +41,7 @@ def get_local_ips():
                 ip = ip.strip()
                 if ip and not ip.startswith("127.") and ip != "192.168.4.1":
                     ips.append(ip)
-    except Exception:
+    except Exception:  # nosec B110 - hostname -I output parsing; non-critical startup info
         pass
     
     # Fallback: try socket method

--- a/web_interface/static/v3/app.js
+++ b/web_interface/static/v3/app.js
@@ -1,4 +1,4 @@
-/* global showNotification, updateSystemStats */
+/* global showNotification, updateSystemStats, htmx */
 // LED Matrix v3 JavaScript
 // Additional helpers for HTMX and Alpine.js integration
 

--- a/web_interface/static/v3/js/widgets/custom-feeds.js
+++ b/web_interface/static/v3/js/widgets/custom-feeds.js
@@ -331,7 +331,7 @@
         removeButton.type = 'button';
         removeButton.className = 'text-red-600 hover:text-red-800 px-2 py-1';
         removeButton.addEventListener('click', function() {
-            removeCustomFeedRow(this);
+            window.removeCustomFeedRow(this);
         });
         const removeIcon = document.createElement('i');
         removeIcon.className = 'fas fa-trash';

--- a/web_interface/static/v3/js/widgets/timezone-selector.js
+++ b/web_interface/static/v3/js/widgets/timezone-selector.js
@@ -212,7 +212,7 @@
             const parts = formatter.formatToParts(now);
             const offsetPart = parts.find(p => p.type === 'timeZoneName');
             return offsetPart ? offsetPart.value : '';
-        } catch (e) {
+        } catch {
             return '';
         }
     }


### PR DESCRIPTION
## Summary

Second pass of Codacy fixes against the updated main (post-PR #331 + #334 + #335). 58 open issues reduced — 41 suppressed as confirmed false positives, 17 fixed in code.

## CVE fixes

**`plugin-repos/march-madness/requirements.txt`**: `urllib3>=1.26.0` → `>=2.2.2`

We added the explicit urllib3 dependency in PR #334 to declare a direct dep (manager.py imports from it), but pinned `1.26.0` which has 10 open Trivy CVEs including:
- CVE-2021-33503 (ReDoS in URL authority parsing)
- CVE-2023-43804 (cookie header not stripped on cross-origin redirect)
- CVE-2023-45803 (request body not stripped after 303 redirect)
- CVE-2024-37891 (proxy-authorization header leak)
- CVE-2025/2026 decompression and redirect CVEs

`urllib3>=2.2.2` covers all of them and is compatible with `requests>=2.33.0`.

## Missed fixes from round-1

| File | Issue | Fix |
|---|---|---|
| `display_helper.py` | Unused `draw=ImageDraw.Draw(img)` — `_draw_centered_text` creates its own | Removed |
| `custom-feeds.js:334` | Bare `removeCustomFeedRow(this)` missed by earlier replace_all | → `window.removeCustomFeedRow(this)` |
| `app.js` | `htmx.ajax()` at lines 146/172 but `htmx` not in `/* global */` | Added `htmx` to global declaration |
| `timezone-selector.js:215` | Second `catch (e)` — we fixed line 361 but missed this one | → `catch {}` |

## Bandit B110 annotations (3 new `except/pass` blocks from PRs #332-#334)

- `start.py:44` — hostname -I parsing, non-critical startup info
- `display_controller.py:826` — `scroll_helper.get_portion_at`, optional method
- `display_manager.py:750` — canvas reset during cleanup, best-effort

## False positive suppressions (via Codacy API)

41 issues suppressed:
- 35× pyflakes in `test/`, `plugin-repos/`, `scripts/` — not production code; test fixture patterns and vendor code
- Flask `0.0.0.0`, `os.execvp`, Bandit B603 — already annotated with `# nosec` in code
- `htmx-sse.js` no-redeclare — vendor file
- `day-selector.js` noPrototypeBuiltins — already fixed in round-1 (stale scan result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)