### PR TITLE
feat(pi5): RP1 backend UI, gpio slowdown guidance, and hardware init error banner

### DIFF
--- a/plugin-repos/march-madness/requirements.txt
+++ b/plugin-repos/march-madness/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.33.0
-urllib3>=2.2.2
+urllib3>=2.6.3
 Pillow>=12.2.0
 pytz>=2022.1
 numpy>=1.24.0

--- a/src/display_manager.py
+++ b/src/display_manager.py
@@ -170,7 +170,7 @@ class DisplayManager:
                 f"Matrix initialization failed — running in fallback/simulation mode "
                 f"(size {fallback_width}x{fallback_height}). Error: {e}. "
                 "On Raspberry Pi 5: ensure rpi-rgb-led-matrix was built from the latest "
-                "submodule (re-run first_time_install.sh) and that gpio_slowdown is 4 or higher."
+                "submodule (re-run first_time_install.sh). gpio_slowdown of 2–3 is typical for Pi 5 PIO mode."
             )
             # Do not raise here; allow fallback mode so web preview and non-hardware environments work
 

--- a/src/display_manager.py
+++ b/src/display_manager.py
@@ -1,4 +1,6 @@
+import json
 import os
+import tempfile
 if os.getenv("EMULATOR", "false") == "true":
     from RGBMatrixEmulator import RGBMatrix, RGBMatrixOptions
 else:
@@ -175,14 +177,28 @@ class DisplayManager:
             # Do not raise here; allow fallback mode so web preview and non-hardware environments work
 
         # Write hardware status file so the web UI can surface init failures
+        _hw_status = {"ok": self.matrix is not None, "error": _init_error_str}
+        _status_path = "/tmp/led_matrix_hw_status.json"  # nosec B108
         try:
-            import json as _json
-            _hw_status = {"ok": self.matrix is not None, "error": _init_error_str}
-            _status_path = "/tmp/led_matrix_hw_status.json"  # nosec B108
-            with open(_status_path, "w") as _f:
-                _json.dump(_hw_status, _f)
+            if os.path.islink(_status_path):
+                logger.warning("Skipping hardware status write: %s is a symlink", _status_path)
+            else:
+                _fd, _tmp_path = tempfile.mkstemp(dir="/tmp", prefix=".led_hw_")  # nosec B108
+                try:
+                    with os.fdopen(_fd, "w") as _f:
+                        json.dump(_hw_status, _f)
+                        _f.flush()
+                        os.fsync(_f.fileno())
+                    os.chmod(_tmp_path, 0o600)
+                    os.replace(_tmp_path, _status_path)
+                except Exception:
+                    try:
+                        os.unlink(_tmp_path)
+                    except OSError:
+                        pass
+                    raise
         except Exception:
-            pass
+            logger.error("Failed to write hardware status file", exc_info=True)
 
     @property
     def width(self):
@@ -764,8 +780,8 @@ class DisplayManager:
             try:
                 self.image = Image.new('RGB', (self.width, self.height))
                 self.draw = ImageDraw.Draw(self.image)
-            except Exception:  # nosec B110 - best-effort canvas reset during cleanup; non-critical
-                pass
+            except (OSError, RuntimeError, ValueError, MemoryError):
+                logger.debug("Canvas reset during cleanup failed", exc_info=True)
         # Reset the singleton state when cleaning up
         DisplayManager._instance = None
         DisplayManager._initialized = False

--- a/src/display_manager.py
+++ b/src/display_manager.py
@@ -58,6 +58,7 @@ class DisplayManager:
         
     def _setup_matrix(self):
         """Initialize the RGB matrix with configuration settings."""
+        _init_error_str = None
         try:
             # Allow callers (e.g., web UI) to force non-hardware fallback mode
             if getattr(self, '_force_fallback', False):
@@ -87,7 +88,7 @@ class DisplayManager:
             options.disable_hardware_pulsing = hardware_config.get('disable_hardware_pulsing', False)
             options.show_refresh_rate = hardware_config.get('show_refresh_rate', False)
             options.limit_refresh_rate_hz = hardware_config.get('limit_refresh_rate_hz', 90)
-            options.gpio_slowdown = runtime_config.get('gpio_slowdown', 2)
+            options.gpio_slowdown = runtime_config.get('gpio_slowdown', 3)
             
             # Disable internal privilege dropping - we manage this via systemd or remain root
             # This prevents the library from dropping to 'daemon' user which breaks file permissions
@@ -141,6 +142,7 @@ class DisplayManager:
                 self._draw_test_pattern()
             
         except Exception as e:
+            _init_error_str = str(e)
             logger.error(f"Failed to initialize RGB Matrix: {e}", exc_info=True)
             # Create a fallback image for web preview using configured dimensions when available
             self.matrix = None
@@ -164,8 +166,23 @@ class DisplayManager:
             except Exception:  # nosec B110 - best-effort fallback visualization; drawing errors must not crash startup
                 # Best-effort; ignore drawing errors in fallback
                 pass
-            logger.error(f"Matrix initialization failed, using fallback mode with size {fallback_width}x{fallback_height}. Error: {e}")
+            logger.error(
+                f"Matrix initialization failed — running in fallback/simulation mode "
+                f"(size {fallback_width}x{fallback_height}). Error: {e}. "
+                "On Raspberry Pi 5: ensure rpi-rgb-led-matrix was built from the latest "
+                "submodule (re-run first_time_install.sh) and that gpio_slowdown is 4 or higher."
+            )
             # Do not raise here; allow fallback mode so web preview and non-hardware environments work
+
+        # Write hardware status file so the web UI can surface init failures
+        try:
+            import json as _json
+            _hw_status = {"ok": self.matrix is not None, "error": _init_error_str}
+            _status_path = "/tmp/led_matrix_hw_status.json"  # nosec B108
+            with open(_status_path, "w") as _f:
+                _json.dump(_hw_status, _f)
+        except Exception:
+            pass
 
     @property
     def width(self):

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -1545,8 +1545,12 @@ def get_hardware_status():
         return jsonify({"status": "success", "data": hw_data})
     except FileNotFoundError:
         return jsonify({"status": "success", "data": {"ok": None, "error": "Display service not yet started"}})
-    except Exception as e:
-        return jsonify({"status": "error", "message": str(e)}), 500
+    except (json.JSONDecodeError, PermissionError):
+        logger.error("Failed to read hardware status file", exc_info=True)
+        return jsonify({"status": "error", "message": "Unable to read hardware status"}), 500
+    except Exception:
+        logger.error("Unexpected error reading hardware status", exc_info=True)
+        return jsonify({"status": "error", "message": "Unable to read hardware status"}), 500
 
 @api_v3.route('/display/current', methods=['GET'])
 def get_display_current():

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -699,7 +699,7 @@ def save_main_config():
 
         # Handle display settings
         display_fields = ['rows', 'cols', 'chain_length', 'parallel', 'brightness', 'hardware_mapping',
-                         'gpio_slowdown', 'scan_mode', 'disable_hardware_pulsing', 'inverse_colors', 'show_refresh_rate',
+                         'gpio_slowdown', 'rp1_rio', 'scan_mode', 'disable_hardware_pulsing', 'inverse_colors', 'show_refresh_rate',
                          'pwm_bits', 'pwm_dither_bits', 'pwm_lsb_nanoseconds', 'limit_refresh_rate_hz', 'use_short_date_format',
                          'max_dynamic_duration_seconds', 'led_rgb_sequence', 'multiplexing', 'panel_type']
 
@@ -747,6 +747,14 @@ def save_main_config():
             # Handle runtime settings
             if 'gpio_slowdown' in data:
                 current_config['display']['runtime']['gpio_slowdown'] = int(data['gpio_slowdown'])
+            if 'rp1_rio' in data:
+                try:
+                    rp1_val = int(data['rp1_rio'])
+                    if rp1_val not in (0, 1):
+                        return jsonify({'status': 'error', 'message': "rp1_rio must be 0 (PIO) or 1 (RIO)"}), 400
+                    current_config['display']['runtime']['rp1_rio'] = rp1_val
+                except (ValueError, TypeError):
+                    return jsonify({'status': 'error', 'message': "rp1_rio must be 0 or 1"}), 400
 
             # Handle checkboxes - coerce to bool to ensure proper JSON types
             for checkbox in ['disable_hardware_pulsing', 'inverse_colors', 'show_refresh_rate']:
@@ -1526,6 +1534,19 @@ def execute_system_action():
         print(f"Error in execute_system_action: {str(e)}")
         print(error_details)
         return jsonify({'status': 'error', 'message': str(e), 'details': error_details}), 500
+
+@api_v3.route('/hardware/status', methods=['GET'])
+def get_hardware_status():
+    """Return LED matrix hardware initialization status written by display_manager at startup."""
+    status_path = "/tmp/led_matrix_hw_status.json"  # nosec B108
+    try:
+        with open(status_path) as f:
+            hw_data = json.load(f)
+        return jsonify({"status": "success", "data": hw_data})
+    except FileNotFoundError:
+        return jsonify({"status": "success", "data": {"ok": None, "error": "Display service not yet started"}})
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e)}), 500
 
 @api_v3.route('/display/current', methods=['GET'])
 def get_display_current():

--- a/web_interface/templates/v3/partials/display.html
+++ b/web_interface/templates/v3/partials/display.html
@@ -186,8 +186,8 @@
                         RP1 Backend <span class="text-xs text-gray-400 font-normal">(Pi 5 only)</span>
                     </label>
                     <select id="rp1_rio" name="rp1_rio" class="form-control">
-                        <option value="0" {% if main_config.display.get('runtime', {}).get('rp1_rio', 0) == 0 %}selected{% endif %}>0 &mdash; PIO (default, low CPU)</option>
-                        <option value="1" {% if main_config.display.get('runtime', {}).get('rp1_rio', 0) == 1 %}selected{% endif %}>1 &mdash; RIO (higher throughput; slowdown inverted)</option>
+                        <option value="0" {% if main_config.display.get('runtime', {}).get('rp1_rio', 0)|int == 0 %}selected{% endif %}>0 &mdash; PIO (default, low CPU)</option>
+                        <option value="1" {% if main_config.display.get('runtime', {}).get('rp1_rio', 0)|int == 1 %}selected{% endif %}>1 &mdash; RIO (higher throughput; slowdown inverted)</option>
                     </select>
                     <p class="mt-1 text-sm text-gray-600">Pi 5 RP1 coprocessor mode. Ignored on Pi 3/4.</p>
                 </div>

--- a/web_interface/templates/v3/partials/display.html
+++ b/web_interface/templates/v3/partials/display.html
@@ -18,7 +18,7 @@
         <p class="text-sm text-yellow-700 mt-2">
             On Raspberry Pi 5: ensure the library was rebuilt from the latest submodule
             (<code class="bg-yellow-100 px-1 rounded">first_time_install.sh</code>)
-            and set <strong>GPIO Slowdown to 4 or higher</strong> below.
+            and try adjusting <strong>GPIO Slowdown</strong> (start at 3, reduce if the display looks dim or choppy).
             Check the <a href="/v3/logs" class="underline font-medium">Logs tab</a> for the full error.
         </p>
     </div>
@@ -178,7 +178,7 @@
                            min="0"
                            max="10"
                            class="form-control">
-                    <p class="mt-1 text-sm text-gray-600">Pi 3: 3 &middot; Pi 4: 4 &middot; Pi 5: 4&ndash;5 (in RIO mode, lower values may work better)</p>
+                    <p class="mt-1 text-sm text-gray-600">Pi 3: 1&ndash;2 &middot; Pi 4: 2&ndash;4 &middot; Pi 5 PIO: 1&ndash;3. Increase if display shows garbage; in RIO mode higher values may improve performance.</p>
                 </div>
 
                 <div class="form-group">

--- a/web_interface/templates/v3/partials/display.html
+++ b/web_interface/templates/v3/partials/display.html
@@ -4,6 +4,25 @@
         <p class="mt-1 text-sm text-gray-600">Configure LED matrix hardware settings and display options.</p>
     </div>
 
+    <!-- Hardware status banner: shown when display service is in fallback/simulation mode -->
+    <div x-data="{ show: false, errorMsg: '' }"
+         x-init="fetch('/api/v3/hardware/status').then(r => r.json()).then(d => {
+             const hw = (d && d.data) || {};
+             if (hw.ok === false) { show = true; errorMsg = hw.error || 'Unknown error'; }
+         }).catch(() => {})"
+         x-show="show"
+         style="display:none"
+         class="bg-yellow-50 border border-yellow-300 rounded-lg p-4 mb-6">
+        <p class="font-semibold text-yellow-800"><i class="fas fa-exclamation-triangle mr-2"></i>LED matrix running in simulation mode</p>
+        <p class="text-sm text-yellow-700 mt-1">Hardware initialization failed: <span x-text="errorMsg" class="font-mono text-xs break-all"></span></p>
+        <p class="text-sm text-yellow-700 mt-2">
+            On Raspberry Pi 5: ensure the library was rebuilt from the latest submodule
+            (<code class="bg-yellow-100 px-1 rounded">first_time_install.sh</code>)
+            and set <strong>GPIO Slowdown to 4 or higher</strong> below.
+            Check the <a href="/v3/logs" class="underline font-medium">Logs tab</a> for the full error.
+        </p>
+    </div>
+
     <form hx-post="/api/v3/config/main"
           hx-ext="json-enc"
           hx-headers='{"Content-Type": "application/json"}'
@@ -149,7 +168,7 @@
                 </div>
             </div>
 
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div class="form-group">
                     <label for="gpio_slowdown" class="block text-sm font-medium text-gray-700">GPIO Slowdown</label>
                     <input type="number"
@@ -157,9 +176,20 @@
                            name="gpio_slowdown"
                            value="{{ main_config.display.runtime.gpio_slowdown or 3 }}"
                            min="0"
-                           max="5"
+                           max="10"
                            class="form-control">
-                    <p class="mt-1 text-sm text-gray-600">GPIO slowdown factor (0-5)</p>
+                    <p class="mt-1 text-sm text-gray-600">Pi 3: 3 &middot; Pi 4: 4 &middot; Pi 5: 4&ndash;5 (in RIO mode, lower values may work better)</p>
+                </div>
+
+                <div class="form-group">
+                    <label for="rp1_rio" class="block text-sm font-medium text-gray-700">
+                        RP1 Backend <span class="text-xs text-gray-400 font-normal">(Pi 5 only)</span>
+                    </label>
+                    <select id="rp1_rio" name="rp1_rio" class="form-control">
+                        <option value="0" {% if main_config.display.get('runtime', {}).get('rp1_rio', 0) == 0 %}selected{% endif %}>0 &mdash; PIO (default, low CPU)</option>
+                        <option value="1" {% if main_config.display.get('runtime', {}).get('rp1_rio', 0) == 1 %}selected{% endif %}>1 &mdash; RIO (higher throughput; slowdown inverted)</option>
+                    </select>
+                    <p class="mt-1 text-sm text-gray-600">Pi 5 RP1 coprocessor mode. Ignored on Pi 3/4.</p>
                 </div>
 
                 <div class="form-group">


### PR DESCRIPTION
## Summary

Follow-up to #334 (Pi 5 library upgrade). The `rp1_rio` config key and updated library were already in place, but three gaps remained for users:

- **RP1 Backend control missing from web UI** — `rp1_rio` was in `config.json` but could only be changed by manually editing the file
- **GPIO Slowdown had no per-model guidance** — users didn't know what value to use for their Pi model
- **Matrix init failures were silent** — when the display service couldn't initialize (old library, wrong permissions, etc.), the web UI only showed a faint "Simulation" preview with no explanation

## Changes

**`src/display_manager.py`**
- Writes `/tmp/led_matrix_hw_status.json` at startup: `{"ok": bool, "error": str|null}` — read by the web UI to surface failures
- Improves the fallback error log to include a Pi 5 rebuild hint
- Fixes the hardcoded `gpio_slowdown` Python-level fallback default from `2` → `3` (only affects the edge case where the config's `runtime` section is entirely absent)

**`web_interface/blueprints/api_v3.py`**
- Adds `rp1_rio` to the display settings save path with validation (must be 0 or 1)
- Adds `GET /api/v3/hardware/status` endpoint that reads the status file

**`web_interface/templates/v3/partials/display.html`**
- Adds **RP1 Backend** select (`0 — PIO` / `1 — RIO`) in the Hardware Configuration section alongside GPIO Slowdown
- Updates GPIO Slowdown help text: _Pi 3: 3 · Pi 4: 4 · Pi 5: 4–5_ and raises the `max` from 5 → 10 to match the full library range
- Adds a yellow warning banner (hidden by default via `style="display:none"`, revealed by Alpine.js fetch) when the display service is in fallback/simulation mode, with Pi 5 remediation steps and a link to the Logs tab

## Pi 3/4 compatibility

- `rp1_rio=0` is set in config on save but the library silently ignores it on non-RP1 hardware (Pi 3/4) — confirmed by the `hasattr()` guard already present in `display_manager.py` and the library's own hardware detection
- The warning banner only appears when `ok: false` in the status file — Pi 3/4 users with working hardware see nothing
- All other changes are additive (new endpoint, new config key) or tighten a Python fallback default that is superseded by explicit config values in practice

## Test plan

- [ ] On Pi 5: open Display Settings, verify "RP1 Backend" dropdown appears, change to RIO (1), save — confirm `config.json` `display.runtime.rp1_rio` = 1 and service restarts with correct mode in logs
- [ ] On Pi 5: verify GPIO Slowdown help text shows per-model guidance and max is now 10
- [ ] On emulator/non-Pi: start display service → `/tmp/led_matrix_hw_status.json` should have `{"ok": false, ...}` → open Display Settings and confirm yellow warning banner appears with error text
- [ ] On Pi 3/4 with working hardware: confirm banner does NOT appear; `rp1_rio` defaults to 0 and is saved/applied without breaking anything
- [ ] POST `{"rp1_rio": 2}` to `/api/v3/config/main` → expect 400 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Hardware status monitoring endpoint and in-app warning banner showing display service status and error details
  - Raspberry Pi 5 runtime option (rp1_rio selector for PIO vs RIO mode)

* **Improvements**
  - More detailed hardware error diagnostics and Pi 5 remediation guidance
  - Expanded gpio_slowdown control range (max increased to 10)
  - Improved error handling for greater display stability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/LEDMatrix/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->