### PR TITLE
fix(pi5): auto-detect Pi 5 and force rgbmatrix rebuild when rp1_rio missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,15 @@ The system supports live, recent, and upcoming game information for multiple spo
 | This project can be finnicky! RGB LED Matrix displays are not built the same or to a high-quality standard. We have seen many displays arrive dead or partially working in our discord. Please purchase from a reputable vendor. |
 
 ### Raspberry Pi
-- Raspberry Pi Zero's don't have enough processing power for this project and the Pi 5 is unsupported due to new GPIO output.
-- **Raspberry Pi 3B or 4 (NOT RPi 5!)**  
+- Raspberry Pi Zero's don't have enough processing power for this project.
+- **Raspberry Pi 3B, 4, or 5**
   [Amazon Affiliate Link – Raspberry Pi 4 4GB RAM](https://amzn.to/4dJixuX)
   [Amazon Affiliate Link – Raspberry Pi 4 8GB RAM](https://amzn.to/4qbqY7F)
+  - **Pi 5 users**: the installer automatically detects Pi 5 and builds the `rpi-rgb-led-matrix` library with RP1 support. If you previously installed on a Pi 4 and migrated the SD card, or if you see `mmap` errors in the logs, force a fresh library build:
+    ```bash
+    sudo RPI_RGB_FORCE_REBUILD=1 ./first_time_install.sh
+    ```
+  - Pi 5 config: leave `rp1_rio` at `0` (PIO mode, default) and set `gpio_slowdown` to `1` or `2`.
 
 
 ### RGB Matrix Bonnet / HAT
@@ -582,7 +587,7 @@ These settings control runtime behavior and GPIO timing:
   - **Critical setting**: Must match your Raspberry Pi model for stability
   - **Raspberry Pi 3**: Use 3
   - **Raspberry Pi 4**: Use 4
-  - **Raspberry Pi 5**: Use 5 (or higher if needed)
+  - **Raspberry Pi 5**: Use 1–2 in PIO mode (`rp1_rio: 0`, the default); start with `1` and increase if you see flickering
   - **Raspberry Pi Zero/1**: Use 1-2
   - Incorrect values can cause display corruption, flickering, or system instability
   - If you experience issues, try adjusting this value up or down by 1

--- a/first_time_install.sh
+++ b/first_time_install.sh
@@ -36,7 +36,15 @@ if [ -r /proc/device-tree/model ]; then
     DEVICE_MODEL=$(tr -d '\0' </proc/device-tree/model)
     echo "Detected device: $DEVICE_MODEL"
 else
+    DEVICE_MODEL=""
     echo "⚠ Could not detect Raspberry Pi model (continuing anyway)"
+fi
+
+# Detect Pi 5 for hardware-specific install decisions (RP1 library verification)
+IS_PI5=0
+if echo "${DEVICE_MODEL:-}" | grep -qi "Raspberry Pi 5"; then
+    IS_PI5=1
+    echo "Raspberry Pi 5 detected — will verify RP1 library support."
 fi
 
 # Check OS version - must be Raspberry Pi OS Lite (Trixie)
@@ -783,9 +791,26 @@ CURRENT_STEP="Build and install rpi-rgb-led-matrix"
 echo "Step 6: Building and installing rpi-rgb-led-matrix..."
 echo "-----------------------------------------------------"
 
-# If already installed and not forcing rebuild, skip expensive build
+# On Pi 5, also check that the installed library has rp1_rio support.
+# A library built before Pi 5 support was added imports fine but maps to the
+# Pi 3 peripheral bus address (0x3f000000) instead of the RP1 chip at runtime.
+_HAS_RP1=0
+if python3 -c 'from rgbmatrix import RGBMatrixOptions; assert hasattr(RGBMatrixOptions(), "rp1_rio")' >/dev/null 2>&1; then
+    _HAS_RP1=1
+fi
+
+_SKIP_BUILD=0
 if python3 -c 'from rgbmatrix import RGBMatrix, RGBMatrixOptions' >/dev/null 2>&1 && [ "${RPI_RGB_FORCE_REBUILD:-0}" != "1" ]; then
-    echo "rgbmatrix Python package already available; skipping build (set RPI_RGB_FORCE_REBUILD=1 to force rebuild)."
+    if [ "$IS_PI5" = "1" ] && [ "$_HAS_RP1" = "0" ]; then
+        echo "⚠ Pi 5 detected: installed rgbmatrix lacks rp1_rio support (older build)."
+        echo "  Forcing rebuild to get Pi 5 RP1 support..."
+    else
+        _SKIP_BUILD=1
+    fi
+fi
+
+if [ "$_SKIP_BUILD" = "1" ]; then
+    echo "rgbmatrix already installed${IS_PI5:+ with Pi 5 RP1 support}; skipping build (set RPI_RGB_FORCE_REBUILD=1 to force rebuild)."
 else
     # Ensure rpi-rgb-led-matrix submodule is initialized
     if [ ! -d "$PROJECT_ROOT_DIR/rpi-rgb-led-matrix-master" ]; then
@@ -852,6 +877,17 @@ except Exception as e:
 PY
     then
         echo "✓ rpi-rgb-led-matrix installed and verified"
+        # Pi 5: confirm the freshly-built library has rp1_rio support
+        if [ "$IS_PI5" = "1" ]; then
+            if python3 -c 'from rgbmatrix import RGBMatrixOptions; assert hasattr(RGBMatrixOptions(), "rp1_rio")' >/dev/null 2>&1; then
+                echo "✓ Pi 5 RP1 (rp1_rio) support confirmed"
+            else
+                echo "⚠ rp1_rio not found after rebuild — the submodule may be an older version."
+                echo "  Try updating the submodule and rebuilding:"
+                echo "    git submodule update --remote rpi-rgb-led-matrix-master"
+                echo "    sudo RPI_RGB_FORCE_REBUILD=1 ./first_time_install.sh"
+            fi
+        fi
     else
         echo "✗ rpi-rgb-led-matrix import test failed"
         exit 1

--- a/first_time_install.sh
+++ b/first_time_install.sh
@@ -810,7 +810,9 @@ if python3 -c 'from rgbmatrix import RGBMatrix, RGBMatrixOptions' >/dev/null 2>&
 fi
 
 if [ "$_SKIP_BUILD" = "1" ]; then
-    echo "rgbmatrix already installed${IS_PI5:+ with Pi 5 RP1 support}; skipping build (set RPI_RGB_FORCE_REBUILD=1 to force rebuild)."
+    _skip_suffix=""
+    if [ "$IS_PI5" = "1" ]; then _skip_suffix=" with Pi 5 RP1 support"; fi
+    echo "rgbmatrix already installed${_skip_suffix}; skipping build (set RPI_RGB_FORCE_REBUILD=1 to force rebuild)."
 else
     # Ensure rpi-rgb-led-matrix submodule is initialized
     if [ ! -d "$PROJECT_ROOT_DIR/rpi-rgb-led-matrix-master" ]; then

--- a/src/display_manager.py
+++ b/src/display_manager.py
@@ -110,9 +110,10 @@ class DisplayManager:
                     options.rp1_rio = runtime_config.get('rp1_rio')
                 else:
                     logger.warning(
-                        "rp1_rio is set in config but the current RGBMatrixOptions "
-                        "implementation does not support it (RGBMatrixEmulator or older "
-                        "library version) — value will be ignored"
+                        "rp1_rio is set in config but the installed rgbmatrix library does "
+                        "not support it — the library was likely built without Pi 5 RP1 "
+                        "support (mmap to 0x3f000000 instead of RP1 chip). "
+                        "Fix: sudo RPI_RGB_FORCE_REBUILD=1 ./first_time_install.sh"
                     )
             
             logger.info(f"Initializing RGB Matrix with settings: rows={options.rows}, cols={options.cols}, chain_length={options.chain_length}, parallel={options.parallel}, hardware_mapping={options.hardware_mapping}")


### PR DESCRIPTION
## Problem

Users running LEDMatrix on a Raspberry Pi 5 see:
```
mmap error: Invalid argument
MMapping from base 0x3f000000, offset 0x3000
rp1_rio is set in config but the current RGBMatrixOptions implementation does not support it
```

**Root cause**: The install script (Step 6) skips the `rpi-rgb-led-matrix` build if the Python module is already importable — but it doesn't check whether the installed build actually has Pi 5 / RP1 support. A library built before Pi 5 support was added imports fine but maps to `0x3f000000` (the Pi 3 peripheral bus address) instead of the RP1 chip. The result is the display doesn't work correctly on Pi 5.

## Fixes

### `first_time_install.sh`
- Detect Pi 5 from `/proc/device-tree/model` at startup
- Step 6 skip logic now also checks `hasattr(RGBMatrixOptions(), 'rp1_rio')`: if the installed library lacks `rp1_rio` (built before Pi 5 support), the build is forced even when the module already imports. This is the fix for the migration case (Pi 4 → Pi 5 same SD card, or previous install).
- After a Pi 5 build, verify `rp1_rio` is present and print the submodule update command if it's still missing.

### `src/display_manager.py`
- The `rp1_rio` warning now names the symptom (`mmap to 0x3f000000`) and gives the exact fix command so users can act immediately from the log.

### `README.md`
- Remove "Pi 5 is unsupported" — Pi 5 has been supported since the library submodule included `rp1_pio` and `rp1_rio` backends.
- Document the forced-rebuild command for users migrating from Pi 4.
- Fix `gpio_slowdown` guidance: Pi 5 PIO mode uses 1–2, not 5.

## Test plan
- [ ] Run installer on Pi 5 with an older rgbmatrix (no `rp1_rio`) — confirm it forces a rebuild instead of skipping
- [ ] After rebuild: confirm `✓ Pi 5 RP1 (rp1_rio) support confirmed` in output, no `0x3f000000` errors in journal
- [ ] Run installer on Pi 4 — confirm skip behaviour is unchanged (no spurious rebuild)
- [ ] README: confirm Pi 5 appears as supported hardware with setup notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Raspberry Pi 5 added to hardware requirements with updated configuration guidance (recommended gpio_slowdown 1–2 in PIO mode, increase if flicker), troubleshooting tips, and explicit rebuild instructions for Pi 5 support.

* **Chores**
  * Installer improved to better detect Pi models and verify Pi 5 support after install, including guidance to force a rebuild when needed.
  * Refined error/warning messages to be clearer and more actionable for users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/LEDMatrix/pull/341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->