### PR TITLE
fix(plugin-config): handle missing type key in oneOf/anyOf schema fields

### DIFF
--- a/src/plugin_system/store_manager.py
+++ b/src/plugin_system/store_manager.py
@@ -10,6 +10,7 @@ import json
 import stat
 import subprocess
 import shutil
+import threading
 import zipfile
 import tempfile
 import requests
@@ -100,6 +101,10 @@ class PluginStoreManager:
         # handlers. Bumping the cached-entry timestamp on failure serves
         # the stale payload cheaply until the backoff expires.
         self._failure_backoff_seconds = 60
+        # Prevents concurrent callers from each firing a network request when
+        # the registry cache expires. Only one thread fetches; others wait and
+        # then get the result from the warm cache (double-checked locking).
+        self._registry_fetch_lock = threading.Lock()
 
         # Ensure plugins directory exists
         self.plugins_dir.mkdir(exist_ok=True)
@@ -575,41 +580,50 @@ class PluginStoreManager:
             (current_time - self.registry_cache_time) < self.registry_cache_timeout):
             return self.registry_cache
 
-        try:
-            self.logger.info(f"Fetching plugin registry from {self.REGISTRY_URL}")
-            response = self._http_get_with_retries(self.REGISTRY_URL, timeout=10)
-            response.raise_for_status()
-            self.registry_cache = response.json()
-            self.registry_cache_time = current_time
-            self.logger.info(f"Fetched registry with {len(self.registry_cache.get('plugins', []))} plugins")
-            return self.registry_cache
-        except requests.RequestException as e:
-            self.logger.error(f"Error fetching registry: {e}")
-            if raise_on_failure:
-                raise
-            # Prefer stale cache over an empty list so the plugin list UI
-            # keeps working on a flaky connection (e.g. Pi on WiFi). Bump
-            # registry_cache_time into a short backoff window so the next
-            # request serves the stale payload cheaply instead of
-            # re-hitting the network on every request (matches the
-            # pattern used by github_cache / commit_info_cache).
-            if self.registry_cache:
-                self.logger.warning("Falling back to stale registry cache")
-                self.registry_cache_time = (
-                    time.time() + self._failure_backoff_seconds - self.registry_cache_timeout
-                )
+        with self._registry_fetch_lock:
+            # Re-check inside the lock — a concurrent caller that was waiting
+            # may have already populated the cache while we blocked.
+            current_time = time.time()
+            if (self.registry_cache and self.registry_cache_time and
+                    not force_refresh and
+                    (current_time - self.registry_cache_time) < self.registry_cache_timeout):
                 return self.registry_cache
-            return {"plugins": []}
-        except json.JSONDecodeError as e:
-            self.logger.error(f"Error parsing registry JSON: {e}")
-            if raise_on_failure:
-                raise
-            if self.registry_cache:
-                self.registry_cache_time = (
-                    time.time() + self._failure_backoff_seconds - self.registry_cache_timeout
-                )
+
+            try:
+                self.logger.info(f"Fetching plugin registry from {self.REGISTRY_URL}")
+                response = self._http_get_with_retries(self.REGISTRY_URL, timeout=10)
+                response.raise_for_status()
+                self.registry_cache = response.json()
+                self.registry_cache_time = current_time
+                self.logger.info(f"Fetched registry with {len(self.registry_cache.get('plugins', []))} plugins")
                 return self.registry_cache
-            return {"plugins": []}
+            except requests.RequestException as e:
+                self.logger.error(f"Error fetching registry: {e}")
+                if raise_on_failure:
+                    raise
+                # Prefer stale cache over an empty list so the plugin list UI
+                # keeps working on a flaky connection (e.g. Pi on WiFi). Bump
+                # registry_cache_time into a short backoff window so the next
+                # request serves the stale payload cheaply instead of
+                # re-hitting the network on every request (matches the
+                # pattern used by github_cache / commit_info_cache).
+                if self.registry_cache:
+                    self.logger.warning("Falling back to stale registry cache")
+                    self.registry_cache_time = (
+                        time.time() + self._failure_backoff_seconds - self.registry_cache_timeout
+                    )
+                    return self.registry_cache
+                return {"plugins": []}
+            except json.JSONDecodeError as e:
+                self.logger.error(f"Error parsing registry JSON: {e}")
+                if raise_on_failure:
+                    raise
+                if self.registry_cache:
+                    self.registry_cache_time = (
+                        time.time() + self._failure_backoff_seconds - self.registry_cache_timeout
+                    )
+                    return self.registry_cache
+                return {"plugins": []}
     
     def search_plugins(self, query: str = "", category: str = "", tags: List[str] = None, fetch_commit_info: bool = True, include_saved_repos: bool = True, saved_repositories_manager = None) -> List[Dict]:
         """

--- a/web_interface/app.py
+++ b/web_interface/app.py
@@ -716,6 +716,33 @@ def _run_startup_reconciliation() -> None:
                 "manual 'Reconcile' action to resolve.",
                 len(result.inconsistencies_manual),
             )
+
+        # Write status file so the web UI can surface unresolved issues as a
+        # banner without the user having to read journalctl. Mirrors the
+        # hw_status pattern (/tmp/led_matrix_hw_status.json).
+        import json as _json, tempfile as _tempfile, os as _os
+        _recon_status = {
+            "done": True,
+            "successful": result.reconciliation_successful,
+            "fixed_count": len(result.inconsistencies_fixed),
+            "unresolved": [
+                {
+                    "plugin_id": inc.plugin_id,
+                    "type": inc.inconsistency_type.value,
+                    "description": inc.description,
+                }
+                for inc in result.inconsistencies_manual
+            ],
+        }
+        _recon_path = "/tmp/ledmatrix_reconciliation.json"
+        try:
+            if not _os.path.islink(_recon_path):
+                _fd, _tmp = _tempfile.mkstemp(dir="/tmp", prefix=".led_recon_")
+                with _os.fdopen(_fd, "w") as _f:
+                    _json.dump(_recon_status, _f)
+                _os.replace(_tmp, _recon_path)
+        except Exception as _e:
+            _logger.warning("[Reconciliation] Could not write status file: %s", _e)
     except Exception as e:
         _logger.error("[Reconciliation] Error: %s", e, exc_info=True)
     finally:

--- a/web_interface/app.py
+++ b/web_interface/app.py
@@ -735,14 +735,22 @@ def _run_startup_reconciliation() -> None:
             ],
         }
         _recon_path = "/tmp/ledmatrix_reconciliation.json"
+        _tmp = None
         try:
             if not _os.path.islink(_recon_path):
                 _fd, _tmp = _tempfile.mkstemp(dir="/tmp", prefix=".led_recon_")
                 with _os.fdopen(_fd, "w") as _f:
                     _json.dump(_recon_status, _f)
                 _os.replace(_tmp, _recon_path)
-        except Exception as _e:
+                _tmp = None  # Rename succeeded; nothing to clean up
+        except (OSError, ValueError, TypeError) as _e:
             _logger.warning("[Reconciliation] Could not write status file: %s", _e)
+        finally:
+            if _tmp is not None and _os.path.exists(_tmp):
+                try:
+                    _os.unlink(_tmp)
+                except OSError:
+                    pass
     except Exception as e:
         _logger.error("[Reconciliation] Error: %s", e, exc_info=True)
     finally:

--- a/web_interface/app.py
+++ b/web_interface/app.py
@@ -734,11 +734,11 @@ def _run_startup_reconciliation() -> None:
                 for inc in result.inconsistencies_manual
             ],
         }
-        _recon_path = "/tmp/ledmatrix_reconciliation.json"
+        _recon_path = _os.path.join(_tempfile.gettempdir(), "ledmatrix_reconciliation.json")
         _tmp = None
         try:
             if not _os.path.islink(_recon_path):
-                _fd, _tmp = _tempfile.mkstemp(dir="/tmp", prefix=".led_recon_")
+                _fd, _tmp = _tempfile.mkstemp(dir=_tempfile.gettempdir(), prefix=".led_recon_")
                 with _os.fdopen(_fd, "w") as _f:
                     _json.dump(_recon_status, _f)
                 _os.replace(_tmp, _recon_path)

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -2,6 +2,7 @@ from flask import Blueprint, request, jsonify, Response
 import json
 import os
 import re
+import stat
 import sys
 import subprocess
 import time
@@ -10,6 +11,7 @@ import uuid
 import logging
 from datetime import datetime
 from pathlib import Path
+from typing import Dict, Any
 
 logger = logging.getLogger(__name__)
 
@@ -1397,10 +1399,12 @@ def check_for_update():
     _safe: Dict[str, Any] = {'update_available': False, 'remote_sha': 'unknown', 'commits_behind': 0}
     try:
         cwd = str(PROJECT_ROOT)
-        subprocess.run(
+        fetch_result = subprocess.run(
             ['git', 'fetch', 'origin', 'main', '--quiet'],
             capture_output=True, timeout=10, cwd=cwd,
         )
+        if fetch_result.returncode != 0:
+            return jsonify(_safe)
         local = subprocess.run(
             ['git', 'rev-parse', 'HEAD'],
             capture_output=True, text=True, timeout=5, cwd=cwd,
@@ -1427,7 +1431,7 @@ def check_for_update():
         _update_check_cache['ts'] = now
         return jsonify(result)
     except Exception as e:
-        logger.debug("check-update: %s", e)
+        logger.warning("check-update failed: %s", e)
         return jsonify(_safe)
 
 @api_v3.route('/system/action', methods=['POST'])
@@ -2484,13 +2488,22 @@ def get_reconciliation_status():
     """Return the result of the last startup reconciliation from /tmp status file."""
     _recon_path = "/tmp/ledmatrix_reconciliation.json"
     try:
+        st = os.lstat(_recon_path)
+    except FileNotFoundError:
+        return jsonify({'status': 'success', 'data': {'done': False, 'unresolved': []}})
+    if stat.S_ISLNK(st.st_mode) or not stat.S_ISREG(st.st_mode):
+        logger.warning("[Reconciliation] Status file is not a regular file: %s", _recon_path)
+        return jsonify({'status': 'error', 'message': 'Status file unavailable'}), 500
+    try:
         with open(_recon_path) as _f:
             data = json.load(_f)
         return jsonify({'status': 'success', 'data': data})
-    except FileNotFoundError:
-        return jsonify({'status': 'success', 'data': {'done': False, 'unresolved': []}})
-    except Exception as e:
-        return jsonify({'status': 'error', 'message': str(e)}), 500
+    except json.JSONDecodeError:
+        logger.exception("[Reconciliation] Failed to parse status file: %s", _recon_path)
+        return jsonify({'status': 'error', 'message': 'Status file unavailable'}), 500
+    except PermissionError:
+        logger.exception("[Reconciliation] Permission denied reading status file: %s", _recon_path)
+        return jsonify({'status': 'error', 'message': 'Status file unavailable'}), 500
 
 @api_v3.route('/plugins/config', methods=['GET'])
 def get_plugin_config():

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -5,6 +5,7 @@ import re
 import stat
 import sys
 import subprocess
+import tempfile
 import time
 import hashlib
 import uuid
@@ -2491,7 +2492,7 @@ def reconcile_plugin_state():
 @api_v3.route('/plugins/reconciliation-status', methods=['GET'])
 def get_reconciliation_status():
     """Return the result of the last startup reconciliation from /tmp status file."""
-    _recon_path = "/tmp/ledmatrix_reconciliation.json"
+    _recon_path = os.path.join(tempfile.gettempdir(), "ledmatrix_reconciliation.json")
     try:
         st = os.lstat(_recon_path)
     except FileNotFoundError:

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -1404,6 +1404,11 @@ def check_for_update():
             capture_output=True, timeout=10, cwd=cwd,
         )
         if fetch_result.returncode != 0:
+            logger.warning("check-update: git fetch failed (rc=%d): %s",
+                           fetch_result.returncode,
+                           fetch_result.stderr.decode(errors='replace').strip())
+            _update_check_cache['result'] = _safe
+            _update_check_cache['ts'] = now
             return jsonify(_safe)
         local = subprocess.run(
             ['git', 'rev-parse', 'HEAD'],
@@ -2493,17 +2498,17 @@ def get_reconciliation_status():
         return jsonify({'status': 'success', 'data': {'done': False, 'unresolved': []}})
     if stat.S_ISLNK(st.st_mode) or not stat.S_ISREG(st.st_mode):
         logger.warning("[Reconciliation] Status file is not a regular file: %s", _recon_path)
-        return jsonify({'status': 'error', 'message': 'Status file unavailable'}), 500
+        return jsonify({'status': 'success', 'data': {'done': False, 'unresolved': []}})
     try:
         with open(_recon_path) as _f:
             data = json.load(_f)
         return jsonify({'status': 'success', 'data': data})
     except json.JSONDecodeError:
         logger.exception("[Reconciliation] Failed to parse status file: %s", _recon_path)
-        return jsonify({'status': 'error', 'message': 'Status file unavailable'}), 500
+        return jsonify({'status': 'success', 'data': {'done': False, 'unresolved': []}})
     except PermissionError:
         logger.exception("[Reconciliation] Permission denied reading status file: %s", _recon_path)
-        return jsonify({'status': 'error', 'message': 'Status file unavailable'}), 500
+        return jsonify({'status': 'success', 'data': {'done': False, 'unresolved': []}})
 
 @api_v3.route('/plugins/config', methods=['GET'])
 def get_plugin_config():

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -1384,6 +1384,52 @@ def get_system_version():
     except Exception as e:
         return jsonify({'status': 'error', 'message': str(e)}), 500
 
+_update_check_cache: Dict[str, Any] = {'result': None, 'ts': 0.0}
+_UPDATE_CHECK_TTL = 300  # 5 minutes — avoids a git fetch on every page load
+
+@api_v3.route('/system/check-update', methods=['GET'])
+def check_for_update():
+    """Check whether a newer LEDMatrix commit is available on origin/main."""
+    now = time.time()
+    if _update_check_cache['result'] and now - _update_check_cache['ts'] < _UPDATE_CHECK_TTL:
+        return jsonify(_update_check_cache['result'])
+
+    _safe: Dict[str, Any] = {'update_available': False, 'remote_sha': 'unknown', 'commits_behind': 0}
+    try:
+        cwd = str(PROJECT_ROOT)
+        subprocess.run(
+            ['git', 'fetch', 'origin', 'main', '--quiet'],
+            capture_output=True, timeout=10, cwd=cwd,
+        )
+        local = subprocess.run(
+            ['git', 'rev-parse', 'HEAD'],
+            capture_output=True, text=True, timeout=5, cwd=cwd,
+        ).stdout.strip()
+        remote = subprocess.run(
+            ['git', 'rev-parse', 'origin/main'],
+            capture_output=True, text=True, timeout=5, cwd=cwd,
+        ).stdout.strip()
+
+        if not local or not remote:
+            return jsonify(_safe)
+
+        if local == remote:
+            result: Dict[str, Any] = {'update_available': False, 'remote_sha': remote, 'commits_behind': 0}
+        else:
+            count_str = subprocess.run(
+                ['git', 'rev-list', 'HEAD..origin/main', '--count'],
+                capture_output=True, text=True, timeout=5, cwd=cwd,
+            ).stdout.strip()
+            count = int(count_str) if count_str.isdigit() else 0
+            result = {'update_available': count > 0, 'remote_sha': remote, 'commits_behind': count}
+
+        _update_check_cache['result'] = result
+        _update_check_cache['ts'] = now
+        return jsonify(result)
+    except Exception as e:
+        logger.debug("check-update: %s", e)
+        return jsonify(_safe)
+
 @api_v3.route('/system/action', methods=['POST'])
 def execute_system_action():
     """Execute system actions (start/stop/reboot/etc)"""
@@ -2432,6 +2478,19 @@ def reconcile_plugin_state():
             context=error.context,
             status_code=500
         )
+
+@api_v3.route('/plugins/reconciliation-status', methods=['GET'])
+def get_reconciliation_status():
+    """Return the result of the last startup reconciliation from /tmp status file."""
+    _recon_path = "/tmp/ledmatrix_reconciliation.json"
+    try:
+        with open(_recon_path) as _f:
+            data = json.load(_f)
+        return jsonify({'status': 'success', 'data': data})
+    except FileNotFoundError:
+        return jsonify({'status': 'success', 'data': {'done': False, 'unresolved': []}})
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 500
 
 @api_v3.route('/plugins/config', methods=['GET'])
 def get_plugin_config():

--- a/web_interface/templates/v3/partials/overview.html
+++ b/web_interface/templates/v3/partials/overview.html
@@ -14,36 +14,49 @@
 <script>
 (function () {
     var DISMISS_KEY = 'ledmatrix-recon-dismissed';
-    fetch('/api/v3/plugins/reconciliation-status')
-        .then(function (r) { return r.json(); })
-        .then(function (resp) {
-            var d = resp.data || {};
-            if (!d.done || !d.unresolved || d.unresolved.length === 0) return;
-            var key = d.unresolved.map(function (i) { return i.plugin_id; }).sort().join(',');
-            if (sessionStorage.getItem(DISMISS_KEY) === key) return;
-            var ids = d.unresolved.map(function (i) { return i.plugin_id; }).join(', ');
-            document.getElementById('reconciliation-banner-text').textContent =
-                'Stale plugin config entries found: ' + ids +
-                '. Remove them from config.json or reinstall via the Plugin Store.';
-            var banner = document.getElementById('reconciliation-banner');
-            banner.style.setProperty('display', 'flex', 'important');
-        })
-        .catch(function () {});
+    var _recon_timer = null;
+
+    function checkReconciliation() {
+        fetch('/api/v3/plugins/reconciliation-status')
+            .then(function (r) { return r.json(); })
+            .then(function (resp) {
+                var d = resp.data || {};
+                if (!d.done) {
+                    // Reconciliation still running — poll again shortly
+                    _recon_timer = setTimeout(checkReconciliation, 2000);
+                    return;
+                }
+                _recon_timer = null;
+                if (!d.unresolved || d.unresolved.length === 0) return;
+                var key = d.unresolved.map(function (i) { return i.plugin_id; }).sort().join(',');
+                if (sessionStorage.getItem(DISMISS_KEY) === key) return;
+                var ids = d.unresolved.map(function (i) { return i.plugin_id; }).join(', ');
+                document.getElementById('reconciliation-banner-text').textContent =
+                    'Stale plugin config entries found: ' + ids +
+                    '. Remove them from config.json or reinstall via the Plugin Store.';
+                var banner = document.getElementById('reconciliation-banner');
+                banner.dataset.dismissKey = key;
+                banner.style.setProperty('display', 'flex', 'important');
+            })
+            .catch(function () {});
+    }
+    checkReconciliation();
 
     window.dismissReconciliationBanner = function () {
         var banner = document.getElementById('reconciliation-banner');
         banner.style.setProperty('display', 'none', 'important');
-        try {
-            fetch('/api/v3/plugins/reconciliation-status')
-                .then(function (r) { return r.json(); })
-                .then(function (resp) {
-                    var d = resp.data || {};
-                    if (d.unresolved && d.unresolved.length) {
-                        var key = d.unresolved.map(function (i) { return i.plugin_id; }).sort().join(',');
-                        sessionStorage.setItem(DISMISS_KEY, key);
-                    }
-                });
-        } catch (e) {}
+        if (_recon_timer !== null) {
+            clearTimeout(_recon_timer);
+            _recon_timer = null;
+        }
+        // Persist dismissal immediately so the banner won't reappear on reload
+        // even if the background sync fetch below fails.
+        var key = banner.dataset.dismissKey;
+        if (key) {
+            try { sessionStorage.setItem(DISMISS_KEY, key); } catch (e) {}
+        }
+        // Background sync only — do not rely on this for DISMISS_KEY or hiding.
+        fetch('/api/v3/plugins/reconciliation-status').catch(function () {});
     };
 }());
 </script>

--- a/web_interface/templates/v3/partials/overview.html
+++ b/web_interface/templates/v3/partials/overview.html
@@ -1,3 +1,53 @@
+<!-- Reconciliation warning banner: shown when startup reconciliation found stale plugin config entries -->
+<div id="reconciliation-banner" class="bg-yellow-50 border border-yellow-300 rounded-lg p-4 mb-4 flex items-start" style="display:none !important" role="alert">
+    <div class="flex-shrink-0 mr-3 mt-0.5">
+        <i class="fas fa-exclamation-triangle text-yellow-500"></i>
+    </div>
+    <div class="flex-1">
+        <p class="text-sm font-medium text-yellow-800">Plugin Config Warning</p>
+        <p class="text-sm text-yellow-700 mt-1" id="reconciliation-banner-text"></p>
+    </div>
+    <button type="button" onclick="window.dismissReconciliationBanner()" class="ml-4 flex-shrink-0 text-yellow-500 hover:text-yellow-700" aria-label="Dismiss">
+        <i class="fas fa-times"></i>
+    </button>
+</div>
+<script>
+(function () {
+    var DISMISS_KEY = 'ledmatrix-recon-dismissed';
+    fetch('/api/v3/plugins/reconciliation-status')
+        .then(function (r) { return r.json(); })
+        .then(function (resp) {
+            var d = resp.data || {};
+            if (!d.done || !d.unresolved || d.unresolved.length === 0) return;
+            var key = d.unresolved.map(function (i) { return i.plugin_id; }).sort().join(',');
+            if (sessionStorage.getItem(DISMISS_KEY) === key) return;
+            var ids = d.unresolved.map(function (i) { return i.plugin_id; }).join(', ');
+            document.getElementById('reconciliation-banner-text').textContent =
+                'Stale plugin config entries found: ' + ids +
+                '. Remove them from config.json or reinstall via the Plugin Store.';
+            var banner = document.getElementById('reconciliation-banner');
+            banner.style.setProperty('display', 'flex', 'important');
+        })
+        .catch(function () {});
+
+    window.dismissReconciliationBanner = function () {
+        var banner = document.getElementById('reconciliation-banner');
+        banner.style.setProperty('display', 'none', 'important');
+        try {
+            fetch('/api/v3/plugins/reconciliation-status')
+                .then(function (r) { return r.json(); })
+                .then(function (resp) {
+                    var d = resp.data || {};
+                    if (d.unresolved && d.unresolved.length) {
+                        var key = d.unresolved.map(function (i) { return i.plugin_id; }).sort().join(',');
+                        sessionStorage.setItem(DISMISS_KEY, key);
+                    }
+                });
+        } catch (e) {}
+    };
+}());
+</script>
+
 <div class="bg-white rounded-lg shadow p-6">
     <div class="border-b border-gray-200 pb-4 mb-6">
         <h2 class="text-lg font-semibold text-gray-900">System Overview</h2>

--- a/web_interface/templates/v3/partials/plugin_config.html
+++ b/web_interface/templates/v3/partials/plugin_config.html
@@ -9,7 +9,8 @@
     {% set field_id = (plugin_id ~ '-' ~ full_key)|replace('.', '-')|replace('_', '-') %}
     {% set label = prop.title if prop.title else key|replace('_', ' ')|title %}
     {% set description = prop.description if prop.description else '' %}
-    {% set field_type = prop.type if prop.type is string else (prop.type[0] if prop.type is iterable else 'string') %}
+    {% set _pt = prop.get('type') %}
+    {% set field_type = _pt if (_pt is string) else ((_pt | first) if (_pt and _pt is iterable and _pt is not string) else 'string') %}
     
     {# Handle nested objects - check for widget first #}
     {% if field_type == 'object' %}


### PR DESCRIPTION
## Summary

- Plugin config tabs for plugins with `oneOf`/`anyOf` schema fields (no top-level `type` key) were returning HTTP 500 and rendering blank — the HTMX request would silently fail and the tab would never load
- Root cause: `prop.type` on a Jinja2 dict without a `type` key returns `Undefined`; Jinja2 `Undefined` is iterable (its `__iter__` is a generator function), so `prop.type is iterable` evaluated `True`, then `prop.type[0]` called `Undefined.__getitem__(0)` which raised `UndefinedError` and crashed the entire template render
- Fix: replace `prop.type` with `prop.get('type')` which returns `None` for missing keys; `None` is falsy and short-circuits safely to the `'string'` fallback

## Affected plugin

`stock-news` — the `max_headlines_per_symbol` field uses `oneOf: [integer, object]` with no top-level `type`, triggering the crash. Any future plugin schema using `oneOf`/`anyOf`/`allOf` without an explicit `type` is now also handled safely.

## Test plan

- [ ] Open the web UI and click the Stock News Ticker plugin config tab — it should now load instead of staying blank
- [ ] Verify other plugin config tabs still load normally
- [ ] Confirm `max_headlines_per_symbol` renders as a text input (graceful fallback for `oneOf` fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added system update checking to detect available releases
  * Added startup reconciliation status and API-driven banner to alert users about unresolved plugin configuration issues

* **Bug Fixes**
  * Fixed plugin configuration field type rendering in the UI
  * Improved thread-safe handling of plugin registry refreshes to reduce race-related failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/LEDMatrix/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->