### PR TITLE
fix(fonts): skip preview API call for BDF bitmap fonts

### DIFF
--- a/web_interface/templates/v3/partials/fonts.html
+++ b/web_interface/templates/v3/partials/fonts.html
@@ -843,6 +843,14 @@ async function updateFontPreview() {
         return;
     }
 
+    // BDF bitmap fonts cannot be rendered server-side — skip the API call
+    if (family.toLowerCase().endsWith('.bdf')) {
+        previewImage.style.display = 'none';
+        loadingText.style.display = 'block';
+        loadingText.textContent = 'Preview not available for BDF bitmap fonts';
+        return;
+    }
+
     // Show loading state
     loadingText.textContent = 'Loading preview...';
     loadingText.style.display = 'block';


### PR DESCRIPTION
## Summary

- Selecting a BDF font in the fonts tab triggered a `GET /api/v3/fonts/preview` request that always returned 400 — the endpoint explicitly rejects BDF files since bitmap glyph rendering is not implemented server-side
- Added an early-return guard in `updateFontPreview()` for `.bdf` files: shows "Preview not available for BDF bitmap fonts" and skips the API call entirely

## Test plan

- [ ] Open the fonts tab and select a `.bdf` font (e.g. `10x20.bdf`) — the preview area should show the fallback message with no network request and no console error
- [ ] Select a `.ttf` or `.otf` font — preview should render as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced BDF bitmap font handling by displaying an informational message when font previews are unavailable, providing clearer feedback to users instead of failing silently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/LEDMatrix/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->