### PR TITLE
fix(wifi): fix AP mode, captive portal, and WiFi connect flow

### DIFF
--- a/src/wifi_manager.py
+++ b/src/wifi_manager.py
@@ -694,7 +694,7 @@ class WiFiManager:
     # Helpers
     # ---------------------------------------------------------------------------
 
-    _IP_FORWARD_SAVE_PATH = Path("/tmp/ledmatrix_ip_forward_saved")
+    _IP_FORWARD_SAVE_PATH = Path("/tmp/ledmatrix_ip_forward_saved")  # nosec B108 - process-specific named file; device is single-user RPi
     # Written when AP mode is manually force-enabled; prevents daemon auto-disable
     _FORCE_AP_FLAG_PATH = Path("/tmp/ledmatrix_force_ap_active")  # nosec B108 - process-specific named file; device is single-user RPi
 

--- a/src/wifi_manager.py
+++ b/src/wifi_manager.py
@@ -1474,7 +1474,7 @@ class WiFiManager:
             # Find existing NM connection for this SSID.
             # 802-11-wireless.ssid is not a valid column in 'nmcli connection show',
             # so list all wifi connections then query each one's SSID individually.
-            list_result = subprocess.run(
+            list_result = subprocess.run(  # nosec B603 B607 - fixed args, no user input
                 ["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"],
                 capture_output=True, text=True, timeout=5
             )
@@ -1487,7 +1487,7 @@ class WiFiManager:
                     if len(parts) < 2 or parts[1].strip() != '802-11-wireless':
                         continue
                     conn_name = parts[0].strip()
-                    ssid_r = subprocess.run(
+                    ssid_r = subprocess.run(  # nosec B603 B607 - conn_name from nmcli output, not user input
                         ["nmcli", "-g", "802-11-wireless.ssid", "connection", "show", conn_name],
                         capture_output=True, text=True, timeout=5
                     )

--- a/src/wifi_manager.py
+++ b/src/wifi_manager.py
@@ -474,7 +474,7 @@ class WiFiManager:
                 if result.returncode == 0:
                     for line in result.stdout.strip().split('\n'):
                         if '/' in line:
-                            ip_address = line.split('/')[0].strip()
+                            ip_address = line.split(':', 1)[1].split('/')[0].strip()
                             break
                 
                 # Final fallback: Get signal strength by matching SSID in WiFi list
@@ -500,6 +500,11 @@ class WiFiManager:
             
             # Check if AP mode is active
             ap_active = self._is_ap_mode_active()
+            if ap_active and wifi_connected:
+                wifi_connected = False
+                ssid = None
+                ip_address = None
+                logger.debug(f"{wlan_device} is in AP mode — overriding wifi_connected to False")
             
             return WiFiStatus(
                 connected=wifi_connected,
@@ -689,7 +694,9 @@ class WiFiManager:
     # Helpers
     # ---------------------------------------------------------------------------
 
-    _IP_FORWARD_SAVE_PATH = Path("/tmp/ledmatrix_ip_forward_saved")  # nosec B108 - process-specific named file; device is single-user RPi
+    _IP_FORWARD_SAVE_PATH = Path("/tmp/ledmatrix_ip_forward_saved")
+    # Written when AP mode is manually force-enabled; prevents daemon auto-disable
+    _FORCE_AP_FLAG_PATH = Path("/tmp/ledmatrix_force_ap_active")  # nosec B108 - process-specific named file; device is single-user RPi
 
     def _validate_ap_config(self) -> Tuple[str, int]:
         """Return a sanitized (ssid, channel) pair from config, falling back to defaults."""
@@ -1367,7 +1374,7 @@ class WiFiManager:
                         logger.error(f"Failed to restore original connection: {original_ssid}")
                         # Trigger AP mode as last resort
                         self._show_led_message("Enabling AP mode...", duration=5)
-                        ap_success, ap_msg = self.enable_ap_mode()
+                        ap_success, ap_msg = self.enable_ap_mode(force=True)
                         if ap_success:
                             logger.info("AP mode enabled as failsafe")
                             return False, "Connection failed and restoration failed. AP mode enabled."
@@ -1379,7 +1386,7 @@ class WiFiManager:
                 elif not success:
                     logger.warning(f"Connection to {ssid} failed and no original connection to restore")
                     self._show_led_message("Enabling AP mode...", duration=5)
-                    ap_success, ap_msg = self.enable_ap_mode()
+                    ap_success, ap_msg = self.enable_ap_mode(force=True)
                     if ap_success:
                         logger.info("AP mode enabled as failsafe")
                         return False, "Connection failed. AP mode enabled."
@@ -1400,7 +1407,7 @@ class WiFiManager:
                     logger.error(f"Failed to restore after exception: {restore_error}")
                     # Last resort: enable AP mode
                     try:
-                        self.enable_ap_mode()
+                        self.enable_ap_mode(force=True)
                     except Exception as ap_error:  # nosec B110 - last-resort; do not re-raise, but log for debugging
                         logger.error("Last-resort AP mode enable failed in recovery path: %s", ap_error, exc_info=True)
             return False, str(e)
@@ -1464,26 +1471,29 @@ class WiFiManager:
             # Show LED message
             self._show_led_message(f"Connecting to {ssid}...", duration=10)
             
-            # First, check if connection already exists and try to activate it
-            # NetworkManager connection names might not match SSID exactly, so search by SSID
-            check_result = subprocess.run(
-                ["nmcli", "-t", "-f", "NAME,802-11-wireless.ssid", "connection", "show"],
-                capture_output=True,
-                text=True,
-                timeout=5
+            # Find existing NM connection for this SSID.
+            # 802-11-wireless.ssid is not a valid column in 'nmcli connection show',
+            # so list all wifi connections then query each one's SSID individually.
+            list_result = subprocess.run(
+                ["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"],
+                capture_output=True, text=True, timeout=5
             )
-            
             existing_conn_name = None
-            if check_result.returncode == 0:
-                for line in check_result.stdout.strip().split('\n'):
-                    if ':' in line:
-                        parts = line.split(':')
-                        if len(parts) >= 2:
-                            conn_name = parts[0].strip()
-                            conn_ssid = parts[1].strip() if len(parts) > 1 else ""
-                            if conn_ssid == ssid:
-                                existing_conn_name = conn_name
-                                break
+            if list_result.returncode == 0:
+                for line in list_result.stdout.strip().split('\n'):
+                    if ':' not in line:
+                        continue
+                    parts = line.split(':')
+                    if len(parts) < 2 or parts[1].strip() != '802-11-wireless':
+                        continue
+                    conn_name = parts[0].strip()
+                    ssid_r = subprocess.run(
+                        ["nmcli", "-g", "802-11-wireless.ssid", "connection", "show", conn_name],
+                        capture_output=True, text=True, timeout=5
+                    )
+                    if ssid_r.returncode == 0 and ssid_r.stdout.strip() == ssid:
+                        existing_conn_name = conn_name
+                        break
             
             # Also try direct lookup by SSID (in case connection name matches SSID)
             if not existing_conn_name:
@@ -1855,7 +1865,7 @@ class WiFiManager:
         logger.warning(f"Failed to enable WiFi radio after {max_retries} attempts")
         return False
     
-    def enable_ap_mode(self) -> Tuple[bool, str]:
+    def enable_ap_mode(self, force: bool = False) -> Tuple[bool, str]:
         """
         Enable access point mode
         
@@ -1877,13 +1887,13 @@ class WiFiManager:
             if not self._ensure_wifi_radio_enabled():
                 return False, "WiFi radio is disabled and could not be enabled"
             
-            # Check if WiFi is connected
+            # Check if WiFi is connected (skip when force=True)
             status = self.get_wifi_status()
-            if status.connected:
+            if not force and status.connected:
                 return False, "Cannot enable AP mode while WiFi is connected"
             
-            # Check if Ethernet is connected
-            if self._is_ethernet_connected():
+            # Check if Ethernet is connected (skip when force=True)
+            if not force and self._is_ethernet_connected():
                 return False, "Cannot enable AP mode while Ethernet is connected"
             
             # Try hostapd/dnsmasq first (captive portal mode)
@@ -1891,6 +1901,11 @@ class WiFiManager:
                 result = self._enable_ap_mode_hostapd()
                 if result[0]:
                     self._ap_enabled_at = time.time()
+                    if force:
+                        try:
+                            self._FORCE_AP_FLAG_PATH.touch()
+                        except OSError:
+                            pass
                     return result
 
             # Fallback to nmcli hotspot (simpler, no captive portal)
@@ -1900,6 +1915,11 @@ class WiFiManager:
                 result = self._enable_ap_mode_nmcli_hotspot()
                 if result[0]:
                     self._ap_enabled_at = time.time()
+                    if force:
+                        try:
+                            self._FORCE_AP_FLAG_PATH.touch()
+                        except OSError:
+                            pass
                 return result
 
             return False, "No WiFi tools available (nmcli, hostapd, or dnsmasq required)"
@@ -2091,8 +2111,14 @@ class WiFiManager:
                 self._clear_led_message()
                 return False, "AP started but captive-portal redirect setup failed"
 
-            # Verify the AP is actually running
-            status = self._get_ap_status_nmcli()
+            # Verify the AP is actually running (retry up to 5x with 2s delay for NM async activation)
+            status = {}
+            for _attempt in range(5):
+                status = self._get_ap_status_nmcli()
+                if status.get('active'):
+                    break
+                logger.debug(f"AP verification attempt {_attempt + 1}/5 not yet active, waiting 2s")
+                time.sleep(2)
             if status.get('active'):
                 ip = status.get('ip', '192.168.4.1')
                 logger.info(f"AP mode confirmed active at {ip} (open network, no password)")
@@ -2290,6 +2316,7 @@ class WiFiManager:
                         logger.warning("WiFi radio may be disabled after nmcli AP cleanup")
 
                 self._ap_enabled_at = None
+                self._FORCE_AP_FLAG_PATH.unlink(missing_ok=True)
                 logger.info("AP mode disabled successfully")
                 return True, "AP mode disabled"
             except Exception as e:
@@ -2478,22 +2505,29 @@ address=/detectportal.firefox.com/192.168.4.1
                 else:
                     logger.warning(f"Failed to enable AP mode: {message}")
             elif not should_have_ap and ap_active:
-                # Should not have AP but do - disable AP mode
-                # Always disable if WiFi or Ethernet connects, regardless of auto_enable setting
-                if status.connected or ethernet_connected:
+                # Should not have AP but do - check if it was manually force-enabled
+                force_active = self._FORCE_AP_FLAG_PATH.exists()
+                if status.connected:
+                    # WiFi connected: always disable AP (user successfully configured WiFi)
                     success, message = self.disable_ap_mode()
                     if success:
-                        if status.connected:
-                            logger.info("Auto-disabled AP mode (WiFi connected)")
-                        elif ethernet_connected:
-                            logger.info("Auto-disabled AP mode (Ethernet connected)")
-                        self._disconnected_checks = 0  # Reset counter
+                        logger.info("Auto-disabled AP mode (WiFi connected)")
+                        self._disconnected_checks = 0
                         return True
                     else:
                         logger.warning(f"Failed to auto-disable AP mode: {message}")
+                elif ethernet_connected and not force_active:
+                    # Ethernet connected, AP not manually forced: auto-disable
+                    success, message = self.disable_ap_mode()
+                    if success:
+                        logger.info("Auto-disabled AP mode (Ethernet connected)")
+                        self._disconnected_checks = 0
+                        return True
+                    else:
+                        logger.warning(f"Failed to auto-disable AP mode: {message}")
+                elif ethernet_connected and force_active:
+                    logger.debug("AP mode is force-active; Ethernet connected but auto-disable suppressed")
                 elif not auto_enable:
-                    # AP is active but auto_enable is disabled - this means it was manually enabled
-                    # Don't disable it automatically, let it stay active
                     logger.debug("AP mode is active (manually enabled), keeping active")
 
             # Idle-timeout check: disable AP if no client has connected within the window.

--- a/src/wifi_manager.py
+++ b/src/wifi_manager.py
@@ -150,6 +150,18 @@ class WiFiManager:
         logger.info(f"WiFi Manager initialized - nmcli: {self.has_nmcli}, iwlist: {self.has_iwlist}, "
                    f"hostapd: {self.has_hostapd}, dnsmasq: {self.has_dnsmasq}, "
                    f"interface: {self._wifi_interface}, trixie: {self._is_trixie}")
+
+        # Once per process: remove a stale force-AP flag left by a prior crash.
+        # Guard with a class-level flag so the nmcli AP-state check only runs
+        # once even though WiFiManager is instantiated per-request.
+        if not WiFiManager._startup_cleanup_done:
+            WiFiManager._startup_cleanup_done = True
+            if self._FORCE_AP_FLAG_PATH.exists() and not self._is_ap_mode_active():
+                try:
+                    self._FORCE_AP_FLAG_PATH.unlink(missing_ok=True)
+                    logger.debug("Removed stale force-AP flag on startup (AP not active)")
+                except OSError as exc:
+                    logger.warning(f"Could not remove stale force-AP flag: {exc}")
     
     def _show_led_message(self, message: str, duration: int = 5):
         """
@@ -474,7 +486,10 @@ class WiFiManager:
                 if result.returncode == 0:
                     for line in result.stdout.strip().split('\n'):
                         if '/' in line:
-                            ip_address = line.split(':', 1)[1].split('/')[0].strip()
+                            # nmcli -t output is "IP4.ADDRESS[1]:x.x.x.x/prefix";
+                            # bare "x.x.x.x/prefix" is also accepted defensively.
+                            _, sep, rest = line.partition(':')
+                            ip_address = (rest if sep else line).split('/')[0].strip()
                             break
                 
                 # Final fallback: Get signal strength by matching SSID in WiFi list
@@ -500,6 +515,8 @@ class WiFiManager:
             
             # Check if AP mode is active
             ap_active = self._is_ap_mode_active()
+            # wlan0 shows as "connected" in AP mode; clear client-station fields so
+            # callers don't mistake the AP for an outbound WiFi connection.
             if ap_active and wifi_connected:
                 wifi_connected = False
                 ssid = None
@@ -697,6 +714,8 @@ class WiFiManager:
     _IP_FORWARD_SAVE_PATH = Path("/tmp/ledmatrix_ip_forward_saved")  # nosec B108 - process-specific named file; device is single-user RPi
     # Written when AP mode is manually force-enabled; prevents daemon auto-disable
     _FORCE_AP_FLAG_PATH = Path("/tmp/ledmatrix_force_ap_active")  # nosec B108 - process-specific named file; device is single-user RPi
+    # Ensures the startup stale-flag cleanup runs once per process, not per instantiation
+    _startup_cleanup_done: bool = False
 
     def _validate_ap_config(self) -> Tuple[str, int]:
         """Return a sanitized (ssid, channel) pair from config, falling back to defaults."""
@@ -1896,6 +1915,9 @@ class WiFiManager:
             if not force and self._is_ethernet_connected():
                 return False, "Cannot enable AP mode while Ethernet is connected"
             
+            if force:
+                logger.debug(f"enable_ap_mode: force=True — WiFi/Ethernet guards bypassed; will create {self._FORCE_AP_FLAG_PATH}")
+
             # Try hostapd/dnsmasq first (captive portal mode)
             if self.has_hostapd and self.has_dnsmasq:
                 result = self._enable_ap_mode_hostapd()
@@ -1904,8 +1926,9 @@ class WiFiManager:
                     if force:
                         try:
                             self._FORCE_AP_FLAG_PATH.touch()
-                        except OSError:
-                            pass
+                            logger.debug(f"Force-AP flag created: {self._FORCE_AP_FLAG_PATH}")
+                        except OSError as exc:
+                            logger.warning(f"Failed to create force-AP flag {self._FORCE_AP_FLAG_PATH}: {exc}")
                     return result
 
             # Fallback to nmcli hotspot (simpler, no captive portal)
@@ -1918,8 +1941,9 @@ class WiFiManager:
                     if force:
                         try:
                             self._FORCE_AP_FLAG_PATH.touch()
-                        except OSError:
-                            pass
+                            logger.debug(f"Force-AP flag created: {self._FORCE_AP_FLAG_PATH}")
+                        except OSError as exc:
+                            logger.warning(f"Failed to create force-AP flag {self._FORCE_AP_FLAG_PATH}: {exc}")
                 return result
 
             return False, "No WiFi tools available (nmcli, hostapd, or dnsmasq required)"

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -6542,7 +6542,7 @@ def scan_wifi_networks():
         ap_was_active = wifi_manager._is_ap_mode_active()
 
         # Perform the scan (this will handle AP mode disabling/enabling internally)
-        networks = wifi_manager.scan_networks()
+        networks, _was_cached = wifi_manager.scan_networks()
 
         # Convert to dict format
         networks_data = [
@@ -6680,7 +6680,8 @@ def enable_ap_mode():
         from src.wifi_manager import WiFiManager
 
         wifi_manager = WiFiManager()
-        success, message = wifi_manager.enable_ap_mode()
+        force = bool((request.get_json(silent=True) or {}).get('force', False))
+        success, message = wifi_manager.enable_ap_mode(force=force)
 
         if success:
             return jsonify({

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -6680,7 +6680,8 @@ def enable_ap_mode():
         from src.wifi_manager import WiFiManager
 
         wifi_manager = WiFiManager()
-        force = bool((request.get_json(silent=True) or {}).get('force', False))
+        _force_raw = (request.get_json(silent=True) or {}).get('force', False)
+        force = _force_raw is True or (isinstance(_force_raw, str) and _force_raw.lower() in ('true', '1'))
         success, message = wifi_manager.enable_ap_mode(force=force)
 
         if success:


### PR DESCRIPTION
## Summary

- **Scan API 500 error**: `scan_networks()` returns a tuple; endpoint was iterating the tuple directly — unpack with `_was_cached`
- **IP address display bug**: `nmcli -t` output includes `IP4.ADDRESS[1]:` prefix; fix by splitting on `:` before `/`
- **AP enable blocked**: Add `force: bool = False` to `enable_ap_mode()` to bypass WiFi/Ethernet guards; expose via `force` JSON field in the enable endpoint
- **Daemon auto-disables forced AP**: Add `_FORCE_AP_FLAG_PATH` flag file written on force-enable, checked in `check_and_manage_ap_mode()` before auto-disabling; `disable_ap_mode()` clears it
- **AP mode reported as WiFi connected**: `_get_status_nmcli()` saw `wlan0: connected` and set `wifi_connected=True` even in AP mode; override to `False` when `_is_ap_mode_active()` is True
- **AP verification fails on async NM activation**: Retry `_get_ap_status_nmcli()` up to 5× with 2 s delay instead of a single immediate check
- **WiFi connect ignores existing NM connections**: `802-11-wireless.ssid` is not a valid column in `nmcli connection show`; replace with `NAME,TYPE` list + per-connection SSID query via `-g` — fixes `netplan generate failed` on Trixie/netplan systems
- **Failsafe AP re-enable blocked by Ethernet**: All recovery-path `enable_ap_mode()` calls in `connect_to_network()` now pass `force=True`

## Test plan

- [x] `GET /api/v3/wifi/scan` returns network list (no 500)
- [x] `GET /api/v3/wifi/status` shows correct IP address (no field-label prefix)
- [x] `POST /api/v3/wifi/ap/enable` with `{"force":true}` succeeds while Ethernet is connected
- [x] AP persists through multiple daemon 30 s cycles without being auto-disabled
- [x] Laptop connects to `LEDMatrix-Setup` open AP, gets DHCP IP in `192.168.4.0/24`
- [x] Port 80 → 5000 nftables captive portal redirect works
- [x] WiFi scan via AP returns cached results
- [x] `POST /api/v3/wifi/connect` finds existing NM connection (`netplan-wlan0-*`) and activates it — Pi connects to home network, AP disables, daemon logs correct state

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual "force" Access Point (AP) activation (API accepts optional force flag).
  * Scan endpoint now handles a returned cache flag when listing networks.

* **Bug Fixes**
  * More robust Wi‑Fi/AP state detection and clearer reporting when AP is active.
  * Suppressed unwanted AP auto‑disable when AP was manually/forcibly enabled.
  * Improved network-recovery fallbacks to reliably trigger AP when needed.
  * Increased AP startup reliability via verified startup and rollback on failure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/LEDMatrix/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->