### PR TITLE
fix(web-ui): support multiple browser tabs via SSE broadcaster

### DIFF
--- a/web_interface/app.py
+++ b/web_interface/app.py
@@ -445,14 +445,23 @@ class _StreamBroadcaster:
         for data in self._generator_factory():
             with self._lock:
                 if not self._clients:
-                    continue
-                dead = set()
+                    # No subscribers — exit so the thread doesn't spin indefinitely.
+                    # subscribe() will restart it when a new client arrives.
+                    break
                 for q in self._clients:
                     try:
                         q.put_nowait(data)
                     except queue.Full:
-                        dead.add(q)
-                self._clients -= dead
+                        # Client is reading too slowly; drop the oldest item and
+                        # deliver the latest so the queue never stalls the client.
+                        try:
+                            q.get_nowait()
+                        except queue.Empty:
+                            pass
+                        try:
+                            q.put_nowait(data)
+                        except queue.Full:
+                            pass
 
 # System status generator for SSE
 def system_status_generator():

--- a/web_interface/app.py
+++ b/web_interface/app.py
@@ -2,8 +2,10 @@ from flask import Flask, request, redirect, url_for, jsonify, Response, send_fro
 import json
 import logging
 import os
+import queue
 import sys
 import subprocess
+import threading
 import time
 from pathlib import Path
 from datetime import datetime, timedelta
@@ -413,13 +415,44 @@ def add_security_headers(response):
     
     return response
 
-# SSE helper function
-def sse_response(generator_func):
-    """Helper to create SSE responses"""
-    def generate():
-        for data in generator_func():
-            yield f"data: {json.dumps(data)}\n\n"
-    return Response(generate(), mimetype='text/event-stream')
+class _StreamBroadcaster:
+    """Fan-out broadcaster: one background generator thread pushes to all SSE clients.
+
+    This means N browser tabs share one generator instead of each running their own,
+    keeping PIL encodes / subprocess forks constant regardless of how many tabs are open.
+    """
+
+    def __init__(self, generator_factory):
+        self._generator_factory = generator_factory
+        self._clients: set = set()
+        self._lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+
+    def subscribe(self) -> queue.Queue:
+        q: queue.Queue = queue.Queue(maxsize=5)
+        with self._lock:
+            self._clients.add(q)
+            if not (self._thread and self._thread.is_alive()):
+                self._thread = threading.Thread(target=self._broadcast, daemon=True)
+                self._thread.start()
+        return q
+
+    def unsubscribe(self, q: queue.Queue) -> None:
+        with self._lock:
+            self._clients.discard(q)
+
+    def _broadcast(self):
+        for data in self._generator_factory():
+            with self._lock:
+                if not self._clients:
+                    continue
+                dead = set()
+                for q in self._clients:
+                    try:
+                        q.put_nowait(data)
+                    except queue.Full:
+                        dead.add(q)
+                self._clients -= dead
 
 # System status generator for SSE
 def system_status_generator():
@@ -596,20 +629,50 @@ def logs_generator():
 
         time.sleep(5)  # Update every 5 seconds (reduced frequency for better performance)
 
+# One broadcaster per stream — shared across all SSE clients
+_stats_broadcaster = _StreamBroadcaster(system_status_generator)
+_display_broadcaster = _StreamBroadcaster(display_preview_generator)
+_logs_broadcaster = _StreamBroadcaster(logs_generator)
+
+
+def _sse_stream(broadcaster: _StreamBroadcaster) -> Response:
+    """Return a streaming SSE response backed by a shared broadcaster."""
+    q = broadcaster.subscribe()
+
+    def generate():
+        try:
+            while True:
+                try:
+                    data = q.get(timeout=30)
+                    yield f"data: {json.dumps(data)}\n\n"
+                except queue.Empty:
+                    # Send an SSE comment heartbeat to keep the connection alive
+                    # through proxies that close idle connections.
+                    yield ": heartbeat\n\n"
+        except GeneratorExit:
+            pass
+        finally:
+            broadcaster.unsubscribe(q)
+
+    return Response(generate(), mimetype='text/event-stream')
+
+
 # SSE endpoints
 @app.route('/api/v3/stream/stats')
 def stream_stats():
-    return sse_response(system_status_generator)
+    return _sse_stream(_stats_broadcaster)
 
 @app.route('/api/v3/stream/display')
 def stream_display():
-    return sse_response(display_preview_generator)
+    return _sse_stream(_display_broadcaster)
 
 @app.route('/api/v3/stream/logs')
 def stream_logs():
-    return sse_response(logs_generator)
+    return _sse_stream(_logs_broadcaster)
 
-# Exempt SSE streams from CSRF and add rate limiting
+# Exempt SSE streams from CSRF and apply a generous rate limit.
+# SSE connections are long-lived HTTP requests, not repeated API calls, so the
+# tight "20 per minute" default would be exhausted quickly on reconnects.
 if csrf:
     csrf.exempt(stream_stats)
     csrf.exempt(stream_display)
@@ -617,9 +680,9 @@ if csrf:
     # Note: api_v3 blueprint is exempted above after registration
 
 if limiter:
-    limiter.limit("20 per minute")(stream_stats)
-    limiter.limit("20 per minute")(stream_display)
-    limiter.limit("20 per minute")(stream_logs)
+    limiter.limit("200 per minute")(stream_stats)
+    limiter.limit("200 per minute")(stream_display)
+    limiter.limit("200 per minute")(stream_logs)
 
 # Main route - redirect to v3 interface as default
 @app.route('/')

--- a/web_interface/static/v3/app.js
+++ b/web_interface/static/v3/app.js
@@ -51,7 +51,7 @@ document.body.addEventListener('htmx:afterRequest', function(event) {
     }
 });
 
-// SSE reconnection helper
+// SSE reconnection helper — closes and reopens both SSE streams.
 window.reconnectSSE = function() {
     if (window.statsSource) {
         window.statsSource.close();
@@ -65,8 +65,9 @@ window.reconnectSSE = function() {
     if (window.displaySource) {
         window.displaySource.close();
         window.displaySource = new EventSource('/api/v3/stream/display');
-        window.displaySource.onmessage = function() {
-            // Handle display updates
+        window.displaySource.onmessage = function(event) {
+            const data = JSON.parse(event.data);
+            if (typeof updateDisplayPreview === 'function') updateDisplayPreview(data);
         };
     }
 };

--- a/web_interface/static/v3/app.js
+++ b/web_interface/static/v3/app.js
@@ -1,4 +1,4 @@
-/* global showNotification, updateSystemStats, htmx */
+/* global showNotification, updateSystemStats, updateDisplayPreview, htmx */
 // LED Matrix v3 JavaScript
 // Additional helpers for HTMX and Alpine.js integration
 

--- a/web_interface/static/v3/app.js
+++ b/web_interface/static/v3/app.js
@@ -51,7 +51,8 @@ document.body.addEventListener('htmx:afterRequest', function(event) {
     }
 });
 
-// SSE reconnection helper — closes and reopens both SSE streams.
+// SSE reconnection helper — closes and reopens both SSE streams,
+// reattaching the open/error handlers defined in base.html.
 window.reconnectSSE = function() {
     if (window.statsSource) {
         window.statsSource.close();
@@ -60,6 +61,8 @@ window.reconnectSSE = function() {
             const data = JSON.parse(event.data);
             if (typeof updateSystemStats === 'function') updateSystemStats(data);
         };
+        if (window._statsOpenHandler) window.statsSource.addEventListener('open', window._statsOpenHandler);
+        if (window._statsErrorHandler) window.statsSource.addEventListener('error', window._statsErrorHandler);
     }
 
     if (window.displaySource) {
@@ -69,6 +72,7 @@ window.reconnectSSE = function() {
             const data = JSON.parse(event.data);
             if (typeof updateDisplayPreview === 'function') updateDisplayPreview(data);
         };
+        if (window._displayErrorHandler) window.displaySource.addEventListener('error', window._displayErrorHandler);
     }
 };
 

--- a/web_interface/templates/v3/base.html
+++ b/web_interface/templates/v3/base.html
@@ -1406,23 +1406,28 @@
         }
 
         var _statsErrorCount = 0;
-        window.statsSource.addEventListener('open', function() {
+
+        // Named on window so reconnectSSE() in app.js can reattach them after
+        // replacing the EventSource instances.
+        window._statsOpenHandler = function() {
             _statsErrorCount = 0;
             _setConnectionStatus(true, false);
-        });
-
-        window.statsSource.addEventListener('error', function() {
+        };
+        window._statsErrorHandler = function() {
             _statsErrorCount++;
             // EventSource readyState 0 = CONNECTING (auto-retrying), 2 = CLOSED
             var reconnecting = window.statsSource.readyState === EventSource.CONNECTING;
             _setConnectionStatus(false, reconnecting && _statsErrorCount <= 3);
-        });
-
-        window.displaySource.addEventListener('error', function() {
+        };
+        window._displayErrorHandler = function() {
             // Display stream errors don't change the status badge but log to console
             // so failures aren't completely silent.
             console.warn('LEDMatrix: display preview stream error (readyState=' + window.displaySource.readyState + ')');
-        });
+        };
+
+        window.statsSource.addEventListener('open', window._statsOpenHandler);
+        window.statsSource.addEventListener('error', window._statsErrorHandler);
+        window.displaySource.addEventListener('error', window._displayErrorHandler);
 
         function updateSystemStats(data) {
             // Update CPU in header

--- a/web_interface/templates/v3/base.html
+++ b/web_interface/templates/v3/base.html
@@ -1370,33 +1370,58 @@
 
     <!-- SSE connection for real-time updates -->
     <script>
-        // Connect to SSE streams
-        const statsSource = new EventSource('/api/v3/stream/stats');
-        const displaySource = new EventSource('/api/v3/stream/display');
+        // Assign to window so reconnectSSE() in app.js can reach them.
+        window.statsSource = new EventSource('/api/v3/stream/stats');
+        window.displaySource = new EventSource('/api/v3/stream/display');
 
-        statsSource.onmessage = function(event) {
+        window.statsSource.onmessage = function(event) {
             const data = JSON.parse(event.data);
             updateSystemStats(data);
         };
 
-        displaySource.onmessage = function(event) {
+        window.displaySource.onmessage = function(event) {
             const data = JSON.parse(event.data);
             updateDisplayPreview(data);
         };
 
-        // Connection status
-        statsSource.addEventListener('open', function() {
-            document.getElementById('connection-status').innerHTML = `
-                <div class="w-2 h-2 bg-green-500 rounded-full"></div>
-                <span class="text-gray-600">Connected</span>
-            `;
+        function _setConnectionStatus(connected, reconnecting) {
+            const el = document.getElementById('connection-status');
+            if (!el) return;
+            if (connected) {
+                el.innerHTML = `
+                    <div class="w-2 h-2 bg-green-500 rounded-full"></div>
+                    <span class="text-gray-600">Connected</span>
+                `;
+            } else if (reconnecting) {
+                el.innerHTML = `
+                    <div class="w-2 h-2 bg-yellow-500 rounded-full animate-pulse"></div>
+                    <span class="text-gray-600">Reconnecting…</span>
+                `;
+            } else {
+                el.innerHTML = `
+                    <div class="w-2 h-2 bg-red-500 rounded-full"></div>
+                    <span class="text-gray-600" title="Connection lost — try refreshing the page">Disconnected</span>
+                `;
+            }
+        }
+
+        var _statsErrorCount = 0;
+        window.statsSource.addEventListener('open', function() {
+            _statsErrorCount = 0;
+            _setConnectionStatus(true, false);
         });
 
-        statsSource.addEventListener('error', function() {
-            document.getElementById('connection-status').innerHTML = `
-                <div class="w-2 h-2 bg-red-500 rounded-full"></div>
-                <span class="text-gray-600">Disconnected</span>
-            `;
+        window.statsSource.addEventListener('error', function() {
+            _statsErrorCount++;
+            // EventSource readyState 0 = CONNECTING (auto-retrying), 2 = CLOSED
+            var reconnecting = window.statsSource.readyState === EventSource.CONNECTING;
+            _setConnectionStatus(false, reconnecting && _statsErrorCount <= 3);
+        });
+
+        window.displaySource.addEventListener('error', function() {
+            // Display stream errors don't change the status badge but log to console
+            // so failures aren't completely silent.
+            console.warn('LEDMatrix: display preview stream error (readyState=' + window.displaySource.readyState + ')');
         });
 
         function updateSystemStats(data) {


### PR DESCRIPTION
## Summary

- **Root cause — per-client generators**: Each browser tab opened its own SSE connections that each ran completely independent generator threads: separate PIL image encodes every second, separate `journalctl` subprocesses every 5 seconds. On a Raspberry Pi, two tabs = double the work.
- **Root cause — rate limit storm**: SSE streams were limited to 20 connections/minute per IP. When `EventSource` auto-retried on any error (every ~3 seconds), the limit was quickly exhausted, causing tabs to silently hang with no user feedback.
- **Root cause — JS bugs**: `reconnectSSE()` in `app.js` was dead code because `base.html` declared `statsSource`/`displaySource` as `const` (block-scoped) while `app.js` looked for `window.statsSource`. The `displaySource` also had no error handler, so display preview failures were completely invisible.

## Changes

### `web_interface/app.py`
- Added `import queue` and `import threading`
- New `_StreamBroadcaster` class: one background thread per stream type fans data out to all subscribed client queues — N tabs share 1 PIL encode/sec and 1 subprocess run regardless of tab count
- Three global broadcaster instances (`_stats_broadcaster`, `_display_broadcaster`, `_logs_broadcaster`)
- New `_sse_stream()` helper handles subscribe/unsubscribe and sends `: heartbeat` SSE comments every 30s to keep idle connections alive through proxies
- SSE rate limit raised from `"20 per minute"` → `"200 per minute"`

### `web_interface/templates/v3/base.html`
- `const statsSource/displaySource` → `window.statsSource/displaySource` (fixes `reconnectSSE` scope)
- Connection status now shows "Reconnecting…" (yellow pulse) on first few errors, "Disconnected" with a tooltip hint after persistent failure
- Added `error` event handler on `displaySource` so failures log to console instead of vanishing silently

### `web_interface/static/v3/app.js`
- Filled in the empty `displaySource.onmessage` stub in `reconnectSSE()` — now calls `updateDisplayPreview(data)` to match the handler in `base.html`

## Test plan

- [ ] Open the web UI in two separate browser tabs — both should show live stats and display preview simultaneously
- [ ] Open browser DevTools → Network → confirm each tab has its own SSE connections, both receive events
- [ ] Verify server CPU/process usage does not double when a second tab is opened
- [ ] Simulate a connection drop (disable/re-enable network) — status badge should show "Reconnecting…" then recover to "Connected" without manual refresh
- [ ] Confirm no 429 errors appear in Flask logs during normal multi-tab use

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display stream data parsing to ensure proper message handling

* **Improvements**
  * Switched streams to a shared fan‑out broadcaster so updates are delivered efficiently to multiple clients
  * Increased stream endpoint rate limits (20 → 200 per minute)
  * Added periodic heartbeats to keep long-lived SSE connections alive
  * Improved connection-status handling with a “Reconnecting…” intermediate state and resilient reconnection hooks

* **Style**
  * Exposed stream objects and reusable handlers globally to support reconnect logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/LEDMatrix/pull/349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->