### PR TITLE
fix(logs): include ledmatrix-web logs in viewer and log subprocess stderr on failure

### DIFF
--- a/web_interface/app.py
+++ b/web_interface/app.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import queue
+import shutil
 import sys
 import subprocess
 import threading
@@ -23,6 +24,9 @@ from src.plugin_system.operation_queue import PluginOperationQueue
 from src.plugin_system.state_manager import PluginStateManager
 from src.plugin_system.operation_history import OperationHistory
 from src.plugin_system.health_monitor import PluginHealthMonitor
+
+_JOURNALCTL = shutil.which('journalctl')
+_SYSTEMCTL = shutil.which('systemctl')
 
 # Create Flask app
 app = Flask(__name__)
@@ -492,12 +496,13 @@ def system_status_generator():
             # Check if display service is running (cached to avoid per-client subprocess forks)
             now = time.time()
             if (now - _ledmatrix_service_cache['timestamp']) >= _LEDMATRIX_SERVICE_CACHE_TTL:
-                try:
-                    result = subprocess.run(['systemctl', 'is-active', 'ledmatrix'],
-                                            capture_output=True, text=True, timeout=2)
-                    _ledmatrix_service_cache['active'] = result.stdout.strip() == 'active'
-                except (subprocess.SubprocessError, OSError):
-                    pass
+                if _SYSTEMCTL:
+                    try:
+                        result = subprocess.run([_SYSTEMCTL, 'is-active', 'ledmatrix'],
+                                                capture_output=True, text=True, timeout=2)
+                        _ledmatrix_service_cache['active'] = result.stdout.strip() == 'active'
+                    except (subprocess.SubprocessError, OSError) as e:
+                        app.logger.warning("systemctl status check failed: %s", e)
                 _ledmatrix_service_cache['timestamp'] = now
             service_active = _ledmatrix_service_cache['active']
             
@@ -589,8 +594,13 @@ def logs_generator():
             # Get recent logs from journalctl (simplified version)
             # Note: User should be in systemd-journal group to read logs without sudo
             try:
+                if not _JOURNALCTL:
+                    yield {'timestamp': time.time(), 'logs': 'journalctl not found; cannot read logs'}
+                    time.sleep(60)
+                    continue
                 result = subprocess.run(
-                    ['journalctl', '-u', 'ledmatrix.service', '-n', '50', '--no-pager'],
+                    [_JOURNALCTL, '-u', 'ledmatrix.service', '-u', 'ledmatrix-web.service',
+                     '-n', '50', '--no-pager', '--output=short-iso'],
                     capture_output=True, text=True, timeout=5
                 )
 
@@ -606,7 +616,7 @@ def logs_generator():
                         # No logs available
                         logs_data = {
                             'timestamp': time.time(),
-                            'logs': 'No logs available from ledmatrix service'
+                            'logs': 'No logs available from ledmatrix or ledmatrix-web service'
                         }
                         yield logs_data
                 else:

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -4,6 +4,7 @@ import os
 import re
 import stat
 import sys
+import shutil
 import subprocess
 import tempfile
 import time
@@ -24,6 +25,9 @@ from src.web_interface.validators import (
     validate_file_upload
 )
 from src.error_aggregator import get_error_aggregator
+
+_SUDO = shutil.which('sudo')
+_JOURNALCTL = shutil.which('journalctl')
 
 # Will be initialized when blueprint is registered
 config_manager = None
@@ -1456,31 +1460,41 @@ def execute_system_action():
             if mode:
                 # For on-demand modes, we would need to integrate with the display controller
                 # For now, just start the display service
-                result = subprocess.run(['sudo', 'systemctl', 'start', 'ledmatrix'],
-                                     capture_output=True, text=True)
+                try:
+                    result = subprocess.run(['sudo', 'systemctl', 'start', 'ledmatrix'],
+                                         capture_output=True, text=True, timeout=10)
+                except subprocess.TimeoutExpired as e:
+                    logger.error("start_display (%s) timed out: %s", mode, e)
+                    return jsonify({'status': 'error', 'message': 'Command timed out', 'returncode': -1, 'stderr': 'timeout'})
                 logger.info("start_display (%s) returned code %d", mode, result.returncode)
-                return jsonify({
+                if result.returncode != 0 and result.stderr:
+                    logger.error("start_display (%s) stderr: %s", mode, result.stderr.strip())
+                resp = {
                     'status': 'success' if result.returncode == 0 else 'error',
                     'message': 'Display started' if result.returncode == 0 else 'Failed to start display',
-                })
+                }
+                if result.returncode != 0:
+                    resp['returncode'] = result.returncode
+                    resp['stderr'] = result.stderr.strip()
+                return jsonify(resp)
             else:
                 result = subprocess.run(['sudo', 'systemctl', 'start', 'ledmatrix'],
-                                     capture_output=True, text=True)
+                                     capture_output=True, text=True, timeout=10)
         elif action == 'stop_display':
             result = subprocess.run(['sudo', 'systemctl', 'stop', 'ledmatrix'],
-                                 capture_output=True, text=True)
+                                 capture_output=True, text=True, timeout=10)
         elif action == 'enable_autostart':
             result = subprocess.run(['sudo', 'systemctl', 'enable', 'ledmatrix'],
-                                 capture_output=True, text=True)
+                                 capture_output=True, text=True, timeout=10)
         elif action == 'disable_autostart':
             result = subprocess.run(['sudo', 'systemctl', 'disable', 'ledmatrix'],
-                                 capture_output=True, text=True)
+                                 capture_output=True, text=True, timeout=10)
         elif action == 'reboot_system':
             result = subprocess.run(['sudo', 'reboot'],
-                                 capture_output=True, text=True)
+                                 capture_output=True, text=True, timeout=10)
         elif action == 'shutdown_system':
             result = subprocess.run(['sudo', 'poweroff'],
-                                 capture_output=True, text=True)
+                                 capture_output=True, text=True, timeout=10)
         elif action == 'git_pull':
             # Use PROJECT_ROOT instead of hardcoded path
             project_dir = str(PROJECT_ROOT)
@@ -1555,20 +1569,29 @@ def execute_system_action():
             })
         elif action == 'restart_display_service':
             result = subprocess.run(['sudo', 'systemctl', 'restart', 'ledmatrix'],
-                                 capture_output=True, text=True)
+                                 capture_output=True, text=True, timeout=10)
         elif action == 'restart_web_service':
             # Try to restart the web service (assuming it's ledmatrix-web.service)
             result = subprocess.run(['sudo', 'systemctl', 'restart', 'ledmatrix-web'],
-                                 capture_output=True, text=True)
+                                 capture_output=True, text=True, timeout=10)
         else:
             return jsonify({'status': 'error', 'message': 'Unknown action'}), 400
 
         logger.info("system action '%s' returncode=%d", action, result.returncode)
-        return jsonify({
+        if result.returncode != 0 and result.stderr:
+            logger.error("system action '%s' stderr: %s", action, result.stderr.strip())
+        resp = {
             'status': 'success' if result.returncode == 0 else 'error',
             'message': 'Action completed' if result.returncode == 0 else 'Action failed; check logs for details',
-        })
+        }
+        if result.returncode != 0:
+            resp['returncode'] = result.returncode
+            resp['stderr'] = result.stderr.strip()
+        return jsonify(resp)
 
+    except subprocess.TimeoutExpired as e:
+        logger.error("system action '%s' timed out: %s", action, e)
+        return jsonify({'status': 'error', 'message': 'Command timed out', 'returncode': -1, 'stderr': 'timeout'})
     except Exception as e:
         logger.error("execute_system_action failed: %s", e, exc_info=True)
         return jsonify({'status': 'error', 'message': 'Action failed; see logs for details'}), 500
@@ -6425,9 +6448,14 @@ def list_plugin_assets():
 def get_logs():
     """Get system logs from journalctl"""
     try:
+        if not _JOURNALCTL:
+            return jsonify({'status': 'error', 'message': 'journalctl not found on this system'}), 503
         # Get recent logs from journalctl
+        _cmd = ([_SUDO, _JOURNALCTL] if _SUDO else [_JOURNALCTL]) + [
+            '-u', 'ledmatrix.service', '-u', 'ledmatrix-web.service',
+            '-n', '100', '--no-pager', '--output=short-iso']
         result = subprocess.run(
-            ['sudo', 'journalctl', '-u', 'ledmatrix.service', '-n', '100', '--no-pager'],
+            _cmd,
             capture_output=True,
             text=True,
             timeout=5
@@ -6438,7 +6466,7 @@ def get_logs():
             return jsonify({
                 'status': 'success',
                 'data': {
-                    'logs': logs_text if logs_text else 'No logs available from ledmatrix service'
+                    'logs': logs_text if logs_text else 'No logs available from ledmatrix or ledmatrix-web service'
                 }
             })
         else:


### PR DESCRIPTION
## Summary

- **Log viewer now shows both services**: `ledmatrix.service` and `ledmatrix-web.service` are merged in both the live SSE stream (`app.py`) and the REST log endpoint (`api_v3.py`). Added `--output=short-iso` so timestamps from the two services sort cleanly when interleaved. Previously, any Python exception logged inside the Flask process was going to `ledmatrix-web` and never appearing in the viewer — producing the "check the logs" toast with an empty log panel.
- **Subprocess stderr is now logged on failure**: When `execute_system_action()` runs a `systemctl` command that returns non-zero, the error text from `result.stderr` is now logged at ERROR level. Same fix for the early-return `start_display` branch. Previously only the return code was recorded, so failures like sudo misconfiguration or a missing service unit were silently swallowed.

## Test plan

- [ ] Trigger a failed system action (e.g. restart display while service doesn't exist or sudo isn't configured) — confirm the `stderr` reason now appears in the log viewer
- [ ] Open the log viewer normally — confirm it shows interleaved entries from both `ledmatrix` and `ledmatrix-web` with ISO timestamps
- [ ] Confirm successful actions still log at INFO level with no spurious ERROR output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * System logs now include entries from both display and web services for more comprehensive diagnostics.
  * Improved error responses for system operations: non-zero failures now include exit code and trimmed error output to aid troubleshooting.
  * SSE log stream now reports when log tooling is unavailable and updates the “no logs available” message to reference both services.
  * API now returns a 503 when required log tooling is missing.
  * Log output timestamps standardized for clearer reading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/LEDMatrix/pull/350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->