### PR TITLE
fix(reconciler): suppress false-positive stale-config banner on fresh installs

### DIFF
--- a/src/plugin_system/state_reconciliation.py
+++ b/src/plugin_system/state_reconciliation.py
@@ -185,13 +185,19 @@ class StateReconciliation:
                 message=f"Reconciliation failed: {str(e)}"
             )
     
-    # Top-level config keys that are NOT plugins
+    # Top-level config keys that are NOT plugins.
+    # Includes both config.json structural keys and config_secrets.json top-level
+    # keys (load_config() deep-merges secrets in, so secrets keys appear here too).
     _SYSTEM_CONFIG_KEYS = frozenset({
         'web_display_autostart', 'timezone', 'location', 'display',
         'plugin_system', 'vegas_scroll_speed', 'vegas_separator_width',
         'vegas_target_fps', 'vegas_buffer_ahead', 'vegas_plugin_order',
         'vegas_excluded_plugins', 'vegas_scroll_enabled', 'logging',
         'dim_schedule', 'network', 'system', 'schedule',
+        # Multi-display sync config (config.json structural key)
+        'sync',
+        # Secrets file top-level keys (merged in by load_config)
+        'github', 'youtube',
     })
 
     def _get_config_state(self) -> Dict[str, Dict[str, Any]]:


### PR DESCRIPTION
## Summary

- `config_manager.load_config()` deep-merges `config_secrets.json` into the main config before returning. This causes secrets top-level keys (`github`, `youtube`) to appear alongside structural config keys (`sync`) in the dict that `_get_config_state()` iterates.
- `_SYSTEM_CONFIG_KEYS` was missing all three, so the reconciler flagged them as `PLUGIN_MISSING_ON_DISK` on every startup — showing the **"Stale plugin config entries found"** warning banner to users with a fresh install where those plugins have never existed.
- Found via a fresh install on devpi: the banner appeared immediately after `first_time_install.sh` completed with no plugins ever installed.

## Test plan

- [ ] Fresh install (`first_time_install.sh -y`): confirm the stale-config banner no longer appears after reboot
- [ ] `GET /api/v3/plugins/reconciliation-status`: confirm `unresolved` list is empty (or contains only genuinely missing plugins, not `sync`/`github`/`youtube`)
- [ ] Existing installs with real stale plugin entries (e.g. a plugin was deleted from disk): confirm the banner still fires correctly for those

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin system configuration state reconciliation to properly exclude additional system configuration keys from plugin detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/LEDMatrix/pull/351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->