### PR TITLE
fix(reconciler): prefer config.json over state manager for enabled mismatch

### DIFF
--- a/src/plugin_system/state_reconciliation.py
+++ b/src/plugin_system/state_reconciliation.py
@@ -376,12 +376,18 @@ class StateReconciliation:
                 # so that manual config edits (or the state left behind after an
                 # uninstall+reinstall cycle) don't silently override the user's intent.
                 config_enabled = inconsistency.expected_state.get('enabled')
-                self.state_manager.set_plugin_enabled(inconsistency.plugin_id, config_enabled)
-                self.logger.info(
-                    f"Fixed: Synced state manager enabled={config_enabled} for "
-                    f"{inconsistency.plugin_id} to match config"
-                )
-                return True
+                success = self.state_manager.set_plugin_enabled(inconsistency.plugin_id, config_enabled)
+                if success:
+                    self.logger.info(
+                        f"Fixed: Synced state manager enabled={config_enabled} for "
+                        f"{inconsistency.plugin_id} to match config"
+                    )
+                else:
+                    self.logger.warning(
+                        f"Failed to sync state manager enabled={config_enabled} for "
+                        f"{inconsistency.plugin_id}"
+                    )
+                return success
             
         except Exception as e:
             self.logger.error(f"Error fixing inconsistency: {e}", exc_info=True)

--- a/src/plugin_system/state_reconciliation.py
+++ b/src/plugin_system/state_reconciliation.py
@@ -340,15 +340,15 @@ class StateReconciliation:
         # Check: Enabled state mismatch
         config_enabled = config.get('enabled', False)
         state_mgr_enabled = state_mgr.get('enabled')
-        
+
         if state_mgr_enabled is not None and config_enabled != state_mgr_enabled:
             inconsistencies.append(Inconsistency(
                 plugin_id=plugin_id,
                 inconsistency_type=InconsistencyType.PLUGIN_ENABLED_MISMATCH,
                 description=f"Plugin {plugin_id} enabled state mismatch: config={config_enabled}, state_manager={state_mgr_enabled}",
                 fix_action=FixAction.AUTO_FIX,
-                current_state={'enabled': config_enabled},
-                expected_state={'enabled': state_mgr_enabled},
+                current_state={'enabled': state_mgr_enabled},
+                expected_state={'enabled': config_enabled},
                 can_auto_fix=True
             ))
         
@@ -371,14 +371,16 @@ class StateReconciliation:
                 return self._auto_repair_missing_plugin(inconsistency.plugin_id)
 
             elif inconsistency.inconsistency_type == InconsistencyType.PLUGIN_ENABLED_MISMATCH:
-                # Sync enabled state from state manager to config
-                expected_enabled = inconsistency.expected_state.get('enabled')
-                config = self.config_manager.load_config()
-                if inconsistency.plugin_id not in config:
-                    config[inconsistency.plugin_id] = {}
-                config[inconsistency.plugin_id]['enabled'] = expected_enabled
-                self.config_manager.save_config(config)
-                self.logger.info(f"Fixed: Synced enabled state for {inconsistency.plugin_id}")
+                # config.json is the user-editable source of truth for enabled state.
+                # Bring the state manager in sync with config rather than the reverse,
+                # so that manual config edits (or the state left behind after an
+                # uninstall+reinstall cycle) don't silently override the user's intent.
+                config_enabled = inconsistency.expected_state.get('enabled')
+                self.state_manager.set_plugin_enabled(inconsistency.plugin_id, config_enabled)
+                self.logger.info(
+                    f"Fixed: Synced state manager enabled={config_enabled} for "
+                    f"{inconsistency.plugin_id} to match config"
+                )
                 return True
             
         except Exception as e:


### PR DESCRIPTION
## Summary

- **Root cause**: When `config.json` and `plugin_state.json` disagree on a plugin's `enabled` state, the reconciler was syncing `config.json` to match `plugin_state.json`. This meant the internal state file silently overrode the user's config on every restart.
- **Common trigger**: Uninstall a plugin (sets state manager `enabled=false`), then reinstall it. The reinstall restores the plugin files and config entry but leaves the state manager with `enabled=false`. Any `enabled=true` the user had in `config.json` gets wiped on next reconciliation.
- **Fix**: Flip the sync direction — call `state_manager.set_plugin_enabled()` to bring `plugin_state.json` in line with `config.json`. `config.json` is the user-editable source of truth; the state file is an internal tracker that should follow it when they disagree.

## Reproduction

1. Install a plugin and enable it so `config.json` has `"enabled": true`
2. Uninstall the plugin with `preserve_config: false` (state manager sets `enabled=false`)
3. Reinstall the plugin via an update/install operation
4. Restart the service — reconciler fires, sees mismatch, overwrites `config.json` to `enabled=false`
5. Plugin is silently disabled despite `config.json` having said `enabled=true`

## Test plan

- [ ] Install and enable a plugin; verify it loads on restart
- [ ] Uninstall + reinstall a plugin; verify the reconciler syncs state manager to match config, not the reverse
- [ ] Enable a plugin via the web UI toggle (updates both files atomically); verify no mismatch is detected on restart
- [ ] Check reconciler log for `"Synced state manager enabled=..."` message instead of old `"Synced enabled state for ..."`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin state reconciliation now treats configuration as authoritative and records expected/current states correctly.
  * Automatic fixes now update the runtime/plugin manager to match configuration (instead of modifying config), and logs were updated to reflect this sync direction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/LEDMatrix/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->