### PR TITLE
fix(plugins): skip update for local-only plugins instead of failing

### DIFF
--- a/plugin-repos/starlark-apps/manifest.json
+++ b/plugin-repos/starlark-apps/manifest.json
@@ -22,5 +22,6 @@
     "Pillow>=10.0.0",
     "PyYAML>=6.0",
     "requests>=2.31.0"
-  ]
+  ],
+  "local_only": true
 }

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -2687,6 +2687,16 @@ def update_plugin():
                 with open(manifest_path, 'r', encoding='utf-8') as f:
                     manifest = json.load(f)
                     current_last_updated = manifest.get('last_updated')
+                if manifest.get('local_only'):
+                    logger.debug("Skipping update for local-only plugin: %s", plugin_id)
+                    if api_v3.operation_history:
+                        api_v3.operation_history.record_operation(
+                            "update",
+                            plugin_id=plugin_id,
+                            status="skipped",
+                            details={"reason": "local_only"}
+                        )
+                    return success_response(message=f'Plugin {plugin_id} is managed locally and does not receive registry updates')
             except Exception as e:
                 logger.debug("Could not read local manifest for plugin: %s", e)
 


### PR DESCRIPTION
## Summary
- Adds `"local_only": true` to `plugin-repos/starlark-apps/manifest.json` to mark it as a bundled plugin that doesn't receive registry updates
- In `api_v3.py`, the update endpoint now reads this flag before attempting an update and returns a `skipped` (success) response instead of falling through to the \"not found in registry\" error path
- Operation history records `status: skipped, reason: local_only` instead of `status: failed`

## Test plan
- [ ] Trigger update for `starlark-apps` via the web UI — should show no error
- [ ] Confirm operation history shows `skipped` instead of `failed` for starlark-apps
- [ ] Confirm all other plugin updates are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for designating plugins as local-only, allowing them to be managed independently without receiving registry updates.
  * Local-only plugins are now properly skipped during update operations with appropriate status tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/LEDMatrix/pull/354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->