### PR TITLE
fix(plugin-loader): auto-detect new dependencies via requirements.txt hash

### DIFF
--- a/src/plugin_system/plugin_loader.py
+++ b/src/plugin_system/plugin_loader.py
@@ -170,6 +170,9 @@ class PluginLoader:
             # CodeQL considers untainted.
             plugins_dir_real = os.path.realpath(str(plugins_dir))
             safe_dir_name = os.path.basename(plugin_dir_real)
+            if not safe_dir_name:
+                self.logger.error("Could not determine plugin directory name for %s", plugin_id)
+                return False
             safe_plugin_dir = os.path.join(plugins_dir_real, safe_dir_name)
             if not os.path.isdir(safe_plugin_dir):
                 self.logger.error(

--- a/src/plugin_system/plugin_loader.py
+++ b/src/plugin_system/plugin_loader.py
@@ -165,16 +165,36 @@ class PluginLoader:
         if not requirements_file.exists():
             return True  # No dependencies needed
         marker_path = plugin_dir_resolved / ".dependencies_installed"
-        current_hash = hashlib.sha256(requirements_file.read_bytes()).hexdigest()
+
+        # Validate both paths stay within the plugin directory (path containment check)
+        try:
+            requirements_file.relative_to(plugin_dir_resolved)
+            marker_path.relative_to(plugin_dir_resolved)
+        except ValueError:
+            self.logger.error("Dependency paths outside plugin directory for %s", plugin_id)
+            return False
+
+        try:
+            current_hash = hashlib.sha256(requirements_file.read_bytes()).hexdigest()
+        except OSError as e:
+            self.logger.error("Failed to read requirements.txt for %s: %s", plugin_id, e)
+            return False
 
         # Skip if requirements.txt hasn't changed since last install
         if marker_path.exists():
-            stored_hash = marker_path.read_text(encoding='utf-8').strip()
-            if stored_hash == current_hash:
-                self.logger.debug("Dependencies already installed for %s (requirements unchanged)", plugin_id)
-                return True
-            self.logger.info("Requirements changed for %s, reinstalling dependencies", plugin_id)
-        
+            try:
+                stored_hash = marker_path.read_text(encoding='utf-8').strip()
+            except OSError as e:
+                self.logger.warning(
+                    "Could not read dependency marker for %s (%s), will reinstall dependencies",
+                    plugin_id, e
+                )
+            else:
+                if stored_hash == current_hash:
+                    self.logger.debug("Dependencies already installed for %s (requirements unchanged)", plugin_id)
+                    return True
+                self.logger.info("Requirements changed for %s, reinstalling dependencies", plugin_id)
+
         try:
             self.logger.info("Installing dependencies for plugin %s...", plugin_id)
             result = subprocess.run(
@@ -184,10 +204,13 @@ class PluginLoader:
                 timeout=timeout,
                 check=False
             )
-            
+
             if result.returncode == 0:
-                marker_path.write_text(current_hash, encoding='utf-8')
-                ensure_file_permissions(marker_path, get_plugin_file_mode())
+                try:
+                    marker_path.write_text(current_hash, encoding='utf-8')
+                    ensure_file_permissions(marker_path, get_plugin_file_mode())
+                except OSError as marker_err:
+                    self.logger.debug("Could not write dependency marker for %s: %s", plugin_id, marker_err)
                 self.logger.info("Dependencies installed successfully for %s", plugin_id)
                 return True
             else:
@@ -202,8 +225,11 @@ class PluginLoader:
                         "Assuming they are satisfied: %s",
                         plugin_id, stderr.strip()
                     )
-                    marker_path.write_text(current_hash, encoding='utf-8')
-                    ensure_file_permissions(marker_path, get_plugin_file_mode())
+                    try:
+                        marker_path.write_text(current_hash, encoding='utf-8')
+                        ensure_file_permissions(marker_path, get_plugin_file_mode())
+                    except OSError as marker_err:
+                        self.logger.debug("Could not write dependency marker for %s: %s", plugin_id, marker_err)
                     return True
                 self.logger.warning(
                     "Dependency installation returned non-zero exit code for %s: %s",

--- a/src/plugin_system/plugin_loader.py
+++ b/src/plugin_system/plugin_loader.py
@@ -5,6 +5,7 @@ Handles plugin module imports, dependency installation, and class instantiation.
 Extracted from PluginManager to improve separation of concerns.
 """
 
+import hashlib
 import json
 import importlib
 import importlib.util
@@ -164,11 +165,15 @@ class PluginLoader:
         if not requirements_file.exists():
             return True  # No dependencies needed
         marker_path = plugin_dir_resolved / ".dependencies_installed"
+        current_hash = hashlib.sha256(requirements_file.read_bytes()).hexdigest()
 
-        # Check if already installed
+        # Skip if requirements.txt hasn't changed since last install
         if marker_path.exists():
-            self.logger.debug("Dependencies already installed for %s", plugin_id)
-            return True
+            stored_hash = marker_path.read_text(encoding='utf-8').strip()
+            if stored_hash == current_hash:
+                self.logger.debug("Dependencies already installed for %s (requirements unchanged)", plugin_id)
+                return True
+            self.logger.info("Requirements changed for %s, reinstalling dependencies", plugin_id)
         
         try:
             self.logger.info("Installing dependencies for plugin %s...", plugin_id)
@@ -181,9 +186,7 @@ class PluginLoader:
             )
             
             if result.returncode == 0:
-                # Mark as installed
-                marker_path.touch()
-                # Set proper file permissions after creating marker
+                marker_path.write_text(current_hash, encoding='utf-8')
                 ensure_file_permissions(marker_path, get_plugin_file_mode())
                 self.logger.info("Dependencies installed successfully for %s", plugin_id)
                 return True
@@ -199,7 +202,7 @@ class PluginLoader:
                         "Assuming they are satisfied: %s",
                         plugin_id, stderr.strip()
                     )
-                    marker_path.touch()
+                    marker_path.write_text(current_hash, encoding='utf-8')
                     ensure_file_permissions(marker_path, get_plugin_file_mode())
                     return True
                 self.logger.warning(

--- a/src/plugin_system/plugin_loader.py
+++ b/src/plugin_system/plugin_loader.py
@@ -139,51 +139,61 @@ class PluginLoader:
         self,
         plugin_dir: Path,
         plugin_id: str,
+        plugins_dir: Optional[Path] = None,
         timeout: int = 300
     ) -> bool:
         """
         Install plugin dependencies from requirements.txt.
-        
+
         Args:
             plugin_dir: Plugin directory path
             plugin_id: Plugin identifier
+            plugins_dir: Trusted base plugins directory for path containment check
             timeout: Installation timeout in seconds
-            
+
         Returns:
             True if dependencies installed or not needed, False on error
         """
         plugin_id = os.path.basename(plugin_id or '')
         if not plugin_id:
             return False
-        # Resolve and validate plugin_dir before constructing any derived paths
-        try:
-            plugin_dir_resolved = plugin_dir.resolve(strict=True)
-        except OSError:
+
+        # Resolve to a canonical absolute path (normalises .. and symlinks)
+        plugin_dir_real = os.path.realpath(str(plugin_dir))
+
+        if plugins_dir is not None:
+            # Validate plugin_dir is within the trusted plugins base directory.
+            # os.path.realpath + startswith is the CodeQL-recognised sanitiser
+            # pattern for path-injection (py/path-injection).
+            plugins_dir_real = os.path.realpath(str(plugins_dir))
+            if not plugin_dir_real.startswith(plugins_dir_real + os.sep):
+                self.logger.error(
+                    "Plugin dir for %s is outside the plugins directory, skipping deps",
+                    plugin_id,
+                )
+                return False
+        elif not os.path.isdir(plugin_dir_real):
             self.logger.error("Plugin directory does not exist: %s", plugin_dir)
             return False
-        requirements_file = plugin_dir_resolved / "requirements.txt"
-        if not requirements_file.exists():
+
+        requirements_file = os.path.join(plugin_dir_real, "requirements.txt")
+        marker_file = os.path.join(plugin_dir_real, ".dependencies_installed")
+
+        if not os.path.isfile(requirements_file):
             return True  # No dependencies needed
-        marker_path = plugin_dir_resolved / ".dependencies_installed"
-
-        # Validate both paths stay within the plugin directory (path containment check)
-        try:
-            requirements_file.relative_to(plugin_dir_resolved)
-            marker_path.relative_to(plugin_dir_resolved)
-        except ValueError:
-            self.logger.error("Dependency paths outside plugin directory for %s", plugin_id)
-            return False
 
         try:
-            current_hash = hashlib.sha256(requirements_file.read_bytes()).hexdigest()
+            with open(requirements_file, 'rb') as fh:
+                current_hash = hashlib.sha256(fh.read()).hexdigest()
         except OSError as e:
             self.logger.error("Failed to read requirements.txt for %s: %s", plugin_id, e)
             return False
 
         # Skip if requirements.txt hasn't changed since last install
-        if marker_path.exists():
+        if os.path.isfile(marker_file):
             try:
-                stored_hash = marker_path.read_text(encoding='utf-8').strip()
+                with open(marker_file, 'r', encoding='utf-8') as fh:
+                    stored_hash = fh.read().strip()
             except OSError as e:
                 self.logger.warning(
                     "Could not read dependency marker for %s (%s), will reinstall dependencies",
@@ -198,7 +208,7 @@ class PluginLoader:
         try:
             self.logger.info("Installing dependencies for plugin %s...", plugin_id)
             result = subprocess.run(
-                [sys.executable, "-m", "pip", "install", "--break-system-packages", "-r", str(requirements_file)],
+                [sys.executable, "-m", "pip", "install", "--break-system-packages", "-r", requirements_file],
                 capture_output=True,
                 text=True,
                 timeout=timeout,
@@ -207,8 +217,9 @@ class PluginLoader:
 
             if result.returncode == 0:
                 try:
-                    marker_path.write_text(current_hash, encoding='utf-8')
-                    ensure_file_permissions(marker_path, get_plugin_file_mode())
+                    with open(marker_file, 'w', encoding='utf-8') as fh:
+                        fh.write(current_hash)
+                    ensure_file_permissions(Path(marker_file), get_plugin_file_mode())
                 except OSError as marker_err:
                     self.logger.debug("Could not write dependency marker for %s: %s", plugin_id, marker_err)
                 self.logger.info("Dependencies installed successfully for %s", plugin_id)
@@ -226,8 +237,9 @@ class PluginLoader:
                         plugin_id, stderr.strip()
                     )
                     try:
-                        marker_path.write_text(current_hash, encoding='utf-8')
-                        ensure_file_permissions(marker_path, get_plugin_file_mode())
+                        with open(marker_file, 'w', encoding='utf-8') as fh:
+                            fh.write(current_hash)
+                        ensure_file_permissions(Path(marker_file), get_plugin_file_mode())
                     except OSError as marker_err:
                         self.logger.debug("Could not write dependency marker for %s: %s", plugin_id, marker_err)
                     return True
@@ -572,11 +584,12 @@ class PluginLoader:
         display_manager: Any,
         cache_manager: Any,
         plugin_manager: Any,
-        install_deps: bool = True
+        install_deps: bool = True,
+        plugins_dir: Optional[Path] = None,
     ) -> Tuple[Any, Any]:
         """
         Complete plugin loading process.
-        
+
         Args:
             plugin_id: Plugin identifier
             manifest: Plugin manifest
@@ -586,16 +599,17 @@ class PluginLoader:
             cache_manager: Cache manager instance
             plugin_manager: Plugin manager instance
             install_deps: Whether to install dependencies
-            
+            plugins_dir: Trusted base plugins directory forwarded to install_dependencies
+
         Returns:
             Tuple of (plugin_instance, module)
-            
+
         Raises:
             PluginError: If loading fails
         """
         # Install dependencies if needed
         if install_deps:
-            self.install_dependencies(plugin_dir, plugin_id)
+            self.install_dependencies(plugin_dir, plugin_id, plugins_dir=plugins_dir)
         
         # Load module
         entry_point = manifest.get('entry_point', 'manager.py')

--- a/src/plugin_system/plugin_loader.py
+++ b/src/plugin_system/plugin_loader.py
@@ -609,7 +609,12 @@ class PluginLoader:
         """
         # Install dependencies if needed
         if install_deps:
-            self.install_dependencies(plugin_dir, plugin_id, plugins_dir=plugins_dir)
+            if not self.install_dependencies(plugin_dir, plugin_id, plugins_dir=plugins_dir):
+                raise PluginError(
+                    f"Dependency installation failed for plugin {plugin_id} in {plugin_dir}",
+                    plugin_id=plugin_id,
+                    context={'plugin_dir': str(plugin_dir)},
+                )
         
         # Load module
         entry_point = manifest.get('entry_point', 'manager.py')

--- a/src/plugin_system/plugin_loader.py
+++ b/src/plugin_system/plugin_loader.py
@@ -162,22 +162,28 @@ class PluginLoader:
         plugin_dir_real = os.path.realpath(str(plugin_dir))
 
         if plugins_dir is not None:
-            # Validate plugin_dir is within the trusted plugins base directory.
-            # os.path.realpath + startswith is the CodeQL-recognised sanitiser
-            # pattern for path-injection (py/path-injection).
+            # Reconstruct the plugin path from a trusted base + a sanitised
+            # directory name.  os.path.basename() is CodeQL's recognised
+            # py/path-injection sanitiser: it strips all directory components
+            # so the result cannot contain traversal sequences.  Joining it
+            # with the resolved, trusted plugins_dir produces a path that
+            # CodeQL considers untainted.
             plugins_dir_real = os.path.realpath(str(plugins_dir))
-            if not plugin_dir_real.startswith(plugins_dir_real + os.sep):
+            safe_dir_name = os.path.basename(plugin_dir_real)
+            safe_plugin_dir = os.path.join(plugins_dir_real, safe_dir_name)
+            if not os.path.isdir(safe_plugin_dir):
                 self.logger.error(
-                    "Plugin dir for %s is outside the plugins directory, skipping deps",
-                    plugin_id,
+                    "Plugin directory for %s not found inside plugins dir", plugin_id
                 )
                 return False
-        elif not os.path.isdir(plugin_dir_real):
-            self.logger.error("Plugin directory does not exist: %s", plugin_dir)
-            return False
+        else:
+            safe_plugin_dir = plugin_dir_real
+            if not os.path.isdir(safe_plugin_dir):
+                self.logger.error("Plugin directory does not exist: %s", plugin_dir)
+                return False
 
-        requirements_file = os.path.join(plugin_dir_real, "requirements.txt")
-        marker_file = os.path.join(plugin_dir_real, ".dependencies_installed")
+        requirements_file = os.path.join(safe_plugin_dir, "requirements.txt")
+        marker_file = os.path.join(safe_plugin_dir, ".dependencies_installed")
 
         if not os.path.isfile(requirements_file):
             return True  # No dependencies needed

--- a/src/plugin_system/plugin_manager.py
+++ b/src/plugin_system/plugin_manager.py
@@ -350,7 +350,8 @@ class PluginManager:
                 display_manager=self.display_manager,
                 cache_manager=self.cache_manager,
                 plugin_manager=self,
-                install_deps=True
+                install_deps=True,
+                plugins_dir=self.plugins_dir,
             )
             
             # Store module

--- a/src/plugin_system/store_manager.py
+++ b/src/plugin_system/store_manager.py
@@ -5,6 +5,7 @@ Handles plugin discovery, installation, updates, and uninstallation
 from both the official registry and custom GitHub repositories.
 """
 
+import hashlib
 import os
 import json
 import stat
@@ -1755,6 +1756,12 @@ class PluginStoreManager:
                 timeout=300
             )
             self.logger.info(f"Dependencies installed successfully for {plugin_path.name}")
+            # Write hash marker so plugin_loader skips redundant pip run on next startup
+            try:
+                current_hash = hashlib.sha256(requirements_file.read_bytes()).hexdigest()
+                (plugin_path / ".dependencies_installed").write_text(current_hash, encoding='utf-8')
+            except OSError as marker_err:
+                self.logger.debug("Could not write dependency marker for %s: %s", plugin_path.name, marker_err)
             return True
             
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Summary

- The `.dependencies_installed` marker was an empty file — adding a new package to `requirements.txt` (e.g. `astral` in ledmatrix-weather v2.3.0) never triggered a pip re-install on existing installs because the marker already existed
- The marker now stores a **SHA-256 hash of `requirements.txt`**; a hash mismatch (or missing marker) automatically triggers `pip install` and writes the updated hash
- `store_manager._install_dependencies()` also writes the hash marker after a store install/update, preventing a redundant pip run on the next startup

## Root cause

User reported `ModuleNotFoundError: No module named 'astral'` after updating the weather plugin. The `astral` package was added to `requirements.txt` in v2.3.0, but `plugin_loader.install_dependencies()` saw an existing (empty) marker file and skipped pip entirely.

## Test plan

- [ ] Install a plugin that has a `requirements.txt` — confirm `.dependencies_installed` now contains a SHA-256 hash string instead of being empty
- [ ] Modify `requirements.txt` (add/change a package) — confirm next restart triggers pip install and updates the hash
- [ ] Unchanged `requirements.txt` across restarts — confirm pip is skipped (debug log: "requirements unchanged")
- [ ] Install/update a plugin via plugin store — confirm marker is written and pip is not re-run on subsequent startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Skips reinstalling unchanged plugin requirements by recording a SHA-256 fingerprint, speeding plugin load and reducing startup time.
* **Stability**
  * Writes a fingerprint marker after successful install; marker-write failures are logged but do not cause install to be treated as failed.
* **Security / Behavior**
  * Optional containment check enforces installation only into a trusted plugins directory when configured, and installation errors surface with clearer context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChuckBuilds/LEDMatrix/pull/355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->