### PR TITLE
fix(web): repair array-table.js syntax error and version static assets

### DIFF
--- a/web_interface/app.py
+++ b/web_interface/app.py
@@ -391,6 +391,22 @@ def captive_portal_redirect():
     # Redirect to lightweight captive portal setup page (not the full UI)
     return redirect(url_for('pages_v3.captive_setup'), code=302)
 
+# Append a content-version query param (file mtime) to every static URL so the
+# long-lived `immutable` cache (see add_security_headers below) is actually safe:
+# when a static file changes its URL changes, so browsers refetch it. Without
+# this, edited JS/CSS were served immutable under an unchanging URL and never
+# reached clients until a manual cache clear.
+@app.url_defaults
+def add_static_version(endpoint, values):
+    if endpoint == 'static' and values.get('filename'):
+        try:
+            file_path = os.path.join(app.static_folder, values['filename'])
+            values['v'] = int(os.path.getmtime(file_path))
+        except OSError:
+            # File missing (e.g. plugin asset not yet installed) — skip versioning.
+            pass
+
+
 # Add security headers and caching to all responses
 @app.after_request
 def add_security_headers(response):

--- a/web_interface/static/v3/js/widgets/array-table.js
+++ b/web_interface/static/v3/js/widgets/array-table.js
@@ -440,7 +440,7 @@
                 <h3 class="text-base font-semibold text-gray-900">Advanced Properties</h3>
                 <button type="button" onclick="window.closeArrayTableRowEditor()"
                         class="text-gray-400 hover:text-gray-600"><i class="fas fa-times"></i></button>
-            </div>`;
+            </div>`);
 
         const body = document.createElement('div');
         body.className = 'px-5 py-4 space-y-4';
@@ -512,7 +512,7 @@
             <button type="button" onclick="window.closeArrayTableRowEditor()"
                     class="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-md hover:bg-gray-100">Cancel</button>
             <button type="button" id="array-row-editor-save"
-                    class="px-4 py-2 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-md">Save</button>`;
+                    class="px-4 py-2 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-md">Save</button>`);
 
         // Save handler
         footer.querySelector('#array-row-editor-save').onclick = function() {

--- a/web_interface/templates/v3/base.html
+++ b/web_interface/templates/v3/base.html
@@ -867,7 +867,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 
     <!-- Custom v3 styles -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='v3/app.css') }}?v=20260216b">
+    <link rel="stylesheet" href="{{ url_for('static', filename='v3/app.css') }}">
 </head>
 <body x-data="app()" class="bg-gray-50 min-h-screen">
     <!-- Header -->


### PR DESCRIPTION
## Problem

The v3 web UI's **Overview tab renders blank** (and other Alpine-driven tabs are affected). Browser console shows:

```
Uncaught SyntaxError: missing ) after argument list (at array-table.js:438:29)
```

## Root cause

**1. Syntax error in `array-table.js`.** Two `safeSetHTML(target, \`…\`)` calls closed the template-literal argument with `` `; `` instead of `` `); `` (lines ~443 and ~515, from the array-table v2 work). The SyntaxError aborts the whole script, so widget registration and Alpine initialization stop partway and the tab content never renders.

**2. Static assets are cached `immutable` but not versioned.** `add_security_headers` sends `Cache-Control: public, max-age=31536000, immutable` for `/static/`, and the comment notes this is meant to pair with "versioning via query params" — but only `app.css` ever had a hand-maintained `?v=`. Every JS file (incl. `array-table.js`) is referenced with a plain, unchanging URL, so once a browser caches it, edits never propagate (a normal reload, even hard reload, is short-circuited by `immutable`). This means even after fixing #1, clients keep the broken file.

## Fix

- `array-table.js`: close both `safeSetHTML(...)` calls correctly (`` `); ``). Validated with `node --check`.
- `app.py`: add a `@app.url_defaults` hook that appends each static file's mtime as `?v=<mtime>` to every `url_for('static', …)`. Changed files get a new URL (refetched); unchanged files keep the long `immutable` cache. This realizes the versioning the cache header already assumed.
- `base.html`: drop the now-redundant manual `?v=` on `app.css` (would otherwise produce a double query string).

## Testing

- `node --check web_interface/static/v3/js/widgets/array-table.js` passes.
- Verified in a browser: served HTML now references e.g. `…/array-table.js?v=<mtime>`, the versioned URL serves the corrected file, and the Overview (display preview + system panels) renders. Editing a static file and reloading now propagates without a manual cache clear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved static asset caching with automatic versioning to ensure clients receive fresh content when files are updated while maintaining long-lived cache benefits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->