### PR TITLE
fix(web): use fully-qualified .service unit names for privileged systemctl

### DIFF
--- a/test/web_interface/test_systemctl_sudoers_alignment.py
+++ b/test/web_interface/test_systemctl_sudoers_alignment.py
@@ -1,0 +1,76 @@
+"""Guards that every privileged systemctl call the web interface makes is
+covered by a passwordless-sudo grant in configure_web_sudo.sh.
+
+The web interface runs headless (no TTY), so any `sudo` call that is not
+matched by a NOPASSWD rule in /etc/sudoers.d/ledmatrix_web falls back to a
+password prompt and fails with:
+
+    sudo: a terminal is required to read the password
+
+sudo matches the command line by exact string, so `systemctl start ledmatrix`
+and `systemctl start ledmatrix.service` are NOT interchangeable. This test
+parses both the production blueprint and the sudoers-generator script and
+asserts the (verb, unit) pairs line up, catching the suffix-mismatch class of
+bug before it ships.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+API_V3 = PROJECT_ROOT / "web_interface" / "blueprints" / "api_v3.py"
+SUDOERS_SCRIPT = PROJECT_ROOT / "scripts" / "install" / "configure_web_sudo.sh"
+
+
+def _sudo_systemctl_calls(source: str) -> set[tuple[str, str]]:
+    """Return (verb, unit) for every list literal beginning with
+    ['sudo', 'systemctl', ...] passed to a subprocess call in the source."""
+    calls: set[tuple[str, str]] = set()
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.List):
+            continue
+        elts = node.elts
+        if len(elts) < 4:
+            continue
+        if not all(isinstance(e, ast.Constant) and isinstance(e.value, str) for e in elts[:4]):
+            continue
+        if elts[0].value == "sudo" and elts[1].value == "systemctl":
+            calls.add((elts[2].value, elts[3].value))
+    return calls
+
+
+def _granted_systemctl_rules(script: str) -> set[tuple[str, str]]:
+    """Return (verb, unit) for each `$SYSTEMCTL_PATH <verb> <unit>` NOPASSWD
+    grant emitted by the sudoers-generator script."""
+    rules: set[tuple[str, str]] = set()
+    for match in re.finditer(r"\$SYSTEMCTL_PATH\s+(\S+)\s+(\S+)", script):
+        verb, unit = match.group(1), match.group(2).rstrip('"')
+        rules.add((verb, unit))
+    return rules
+
+
+def test_every_sudo_systemctl_call_is_granted() -> None:
+    calls = _sudo_systemctl_calls(API_V3.read_text())
+    rules = _granted_systemctl_rules(SUDOERS_SCRIPT.read_text())
+
+    assert calls, "expected to find sudo systemctl calls in api_v3.py"
+
+    uncovered = {c for c in calls if c not in rules}
+    assert not uncovered, (
+        "These sudo systemctl calls have no matching NOPASSWD grant in "
+        "configure_web_sudo.sh; they will fail headless with "
+        "'sudo: a terminal is required to read the password': "
+        + ", ".join(f"systemctl {v} {u}" for v, u in sorted(uncovered))
+    )
+
+
+def test_units_are_fully_qualified() -> None:
+    """Privileged systemctl calls must name the unit as <name>.service so they
+    match the sudoers grants, which use the fully-qualified unit name."""
+    calls = _sudo_systemctl_calls(API_V3.read_text())
+    unqualified = {(v, u) for v, u in calls if not u.endswith(".service")}
+    assert not unqualified, (
+        "sudo systemctl calls must use fully-qualified .service unit names: "
+        + ", ".join(f"systemctl {v} {u}" for v, u in sorted(unqualified))
+    )

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -190,7 +190,7 @@ def _ensure_display_service_running():
     if status.get('active'):
         status['started'] = False
         return status
-    result = _run_systemctl_command(['sudo', 'systemctl', 'start', 'ledmatrix'])
+    result = _run_systemctl_command(['sudo', 'systemctl', 'start', 'ledmatrix.service'])
     service_status = _get_display_service_status()
     result['started'] = result.get('returncode') == 0
     result['active'] = service_status.get('active')
@@ -199,7 +199,7 @@ def _ensure_display_service_running():
 
 def _stop_display_service():
     """Stop the ledmatrix display service."""
-    result = _run_systemctl_command(['sudo', 'systemctl', 'stop', 'ledmatrix'])
+    result = _run_systemctl_command(['sudo', 'systemctl', 'stop', 'ledmatrix.service'])
     status = _get_display_service_status()
     result['active'] = status.get('active')
     result['status'] = status
@@ -1461,7 +1461,7 @@ def execute_system_action():
                 # For on-demand modes, we would need to integrate with the display controller
                 # For now, just start the display service
                 try:
-                    result = subprocess.run(['sudo', 'systemctl', 'start', 'ledmatrix'],
+                    result = subprocess.run(['sudo', 'systemctl', 'start', 'ledmatrix.service'],
                                          capture_output=True, text=True, timeout=10)
                 except subprocess.TimeoutExpired as e:
                     logger.error("start_display (%s) timed out: %s", mode, e)
@@ -1478,16 +1478,16 @@ def execute_system_action():
                     resp['stderr'] = result.stderr.strip()
                 return jsonify(resp)
             else:
-                result = subprocess.run(['sudo', 'systemctl', 'start', 'ledmatrix'],
+                result = subprocess.run(['sudo', 'systemctl', 'start', 'ledmatrix.service'],
                                      capture_output=True, text=True, timeout=10)
         elif action == 'stop_display':
-            result = subprocess.run(['sudo', 'systemctl', 'stop', 'ledmatrix'],
+            result = subprocess.run(['sudo', 'systemctl', 'stop', 'ledmatrix.service'],
                                  capture_output=True, text=True, timeout=10)
         elif action == 'enable_autostart':
-            result = subprocess.run(['sudo', 'systemctl', 'enable', 'ledmatrix'],
+            result = subprocess.run(['sudo', 'systemctl', 'enable', 'ledmatrix.service'],
                                  capture_output=True, text=True, timeout=10)
         elif action == 'disable_autostart':
-            result = subprocess.run(['sudo', 'systemctl', 'disable', 'ledmatrix'],
+            result = subprocess.run(['sudo', 'systemctl', 'disable', 'ledmatrix.service'],
                                  capture_output=True, text=True, timeout=10)
         elif action == 'reboot_system':
             result = subprocess.run(['sudo', 'reboot'],
@@ -1568,11 +1568,11 @@ def execute_system_action():
                 'message': pull_message,
             })
         elif action == 'restart_display_service':
-            result = subprocess.run(['sudo', 'systemctl', 'restart', 'ledmatrix'],
+            result = subprocess.run(['sudo', 'systemctl', 'restart', 'ledmatrix.service'],
                                  capture_output=True, text=True, timeout=10)
         elif action == 'restart_web_service':
             # Try to restart the web service (assuming it's ledmatrix-web.service)
-            result = subprocess.run(['sudo', 'systemctl', 'restart', 'ledmatrix-web'],
+            result = subprocess.run(['sudo', 'systemctl', 'restart', 'ledmatrix-web.service'],
                                  capture_output=True, text=True, timeout=10)
         else:
             return jsonify({'status': 'error', 'message': 'Unknown action'}), 400


### PR DESCRIPTION
## TL;DR

This is a **`sudo` string-matching bug, not a systemd one.** The web UI's Start/Stop/Restart actions silently require a password and fail because the command strings the code passes to `sudo` don't match the strings granted in the sudoers file. No unit is renamed or removed.

## Symptom

From the web interface, any privileged display action (start/stop/enable/disable/restart) fails. The log shows:

```
sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
```

The web service runs headless (no controlling terminal), so when `sudo` can't find a matching `NOPASSWD` rule it falls back to a password prompt with nowhere to read it, and dies.

## Root cause

`scripts/install/configure_web_sudo.sh` grants passwordless rules using the **fully-qualified** unit name:

```
<web_user> ALL=(ALL) NOPASSWD: /usr/bin/systemctl start ledmatrix.service
```

But `web_interface/blueprints/api_v3.py` invoked the **bare** name:

```python
subprocess.run(['sudo', 'systemctl', 'start', 'ledmatrix'], ...)
```

`sudo` authorizes by matching the command line as an **exact string**. `systemctl start ledmatrix` and `systemctl start ledmatrix.service` are different strings, so the grant never matched and the call fell through to a password prompt.

This is purely a `sudo` issue. **systemd treats `ledmatrix` and `ledmatrix.service` as the same unit** — `systemctl` auto-appends the `.service` suffix — and the installer (`scripts/install/install_service.sh`) creates and enables the unit as `ledmatrix.service`. So both spellings target the identical, existing unit; only `sudo`'s authorization check cares about the exact text.

(`is-active` happened to work because the sudoers script grants both spellings for that one verb, and it isn't a `sudo` call anyway.)

## Fix

Make the code's command strings match the strings the sudoers file already grants — i.e. use the fully-qualified unit names everywhere a privileged `systemctl` call is made:

- `ledmatrix` → `ledmatrix.service` (start / stop / enable / disable / restart)
- `ledmatrix-web` → `ledmatrix-web.service` (restart)

The sudoers script is unchanged. Existing installs that already ran `configure_web_sudo.sh` work immediately after the web service restarts — no re-provisioning needed.

## Test

Adds `test/web_interface/test_systemctl_sudoers_alignment.py`, which statically parses both `api_v3.py` and `configure_web_sudo.sh` and asserts that every `sudo systemctl` call in the code is covered by a `NOPASSWD` grant (and that units are fully qualified). It fails on the pre-fix code — flagging exactly the five broken calls (start/stop/enable/disable/restart) — and passes after, so it guards this whole class of code↔sudoers drift going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
