### PR TITLE
fix(display): resume rotation where it left off after live priority ends

### DIFF
--- a/src/display_controller.py
+++ b/src/display_controller.py
@@ -178,7 +178,11 @@ class DisplayController:
         self.on_demand_last_event: Optional[str] = None
         self.on_demand_schedule_override = False
         self.rotation_resume_index: Optional[int] = None
-        
+        # Saved rotation position when a live-priority plugin preempts the
+        # rotation, so it resumes where it left off (not after the live plugin)
+        # once live priority ends.
+        self._live_resume_index: Optional[int] = None
+
         # WiFi status message tracking
         global WIFI_STATUS_FILE
         if WIFI_STATUS_FILE is None:
@@ -1471,6 +1475,36 @@ class DisplayController:
         except Exception as e:
             logger.debug(f"Error logging memory stats: {e}")
 
+    def _apply_live_priority(self, live_priority_mode):
+        """Switch to a live-priority mode, or resume rotation when it ends.
+
+        When a live-priority plugin preempts the rotation, the position the
+        rotation had reached is saved so that, once live priority ends, the
+        rotation resumes from there instead of continuing after the live
+        plugin's mode (which would skip every mode between the two). The save
+        happens only on the initial switch, not on each re-check while the
+        live hold continues.
+        """
+        if live_priority_mode:
+            if self.current_display_mode != live_priority_mode:
+                logger.info("Live content detected - switching immediately to %s", live_priority_mode)
+                if self._live_resume_index is None:
+                    self._live_resume_index = self.current_mode_index
+                self.current_display_mode = live_priority_mode
+                self.force_change = True
+                # Update mode index to match the new mode
+                try:
+                    self.current_mode_index = self.available_modes.index(live_priority_mode)
+                except ValueError:
+                    pass
+        elif self._live_resume_index is not None and self.available_modes:
+            # Live priority ended — resume rotation where it was interrupted.
+            self.current_mode_index = self._live_resume_index % len(self.available_modes)
+            self.current_display_mode = self.available_modes[self.current_mode_index]
+            self.force_change = True
+            logger.info("Live priority ended - resuming rotation at %s", self.current_display_mode)
+            self._live_resume_index = None
+
     def _check_live_priority(self):
         """
         Check all plugins for live priority content.
@@ -1658,15 +1692,7 @@ class DisplayController:
                 # Check for live priority content and switch to it immediately
                 if not self.on_demand_active and not wifi_status_data:
                     live_priority_mode = self._check_live_priority()
-                    if live_priority_mode and self.current_display_mode != live_priority_mode:
-                        logger.info("Live content detected - switching immediately to %s", live_priority_mode)
-                        self.current_display_mode = live_priority_mode
-                        self.force_change = True
-                        # Update mode index to match the new mode
-                        try:
-                            self.current_mode_index = self.available_modes.index(live_priority_mode)
-                        except ValueError:
-                            pass
+                    self._apply_live_priority(live_priority_mode)
 
                 # Vegas scroll mode - continuous ticker across all plugins
                 # Priority: on-demand > wifi-status > live-priority > vegas > normal rotation

--- a/test/test_display_controller.py
+++ b/test/test_display_controller.py
@@ -167,6 +167,53 @@ class TestDisplayControllerLivePriority:
         assert controller.current_display_mode == "test_plugin_live"
         assert controller.force_change is True
 
+    def test_live_priority_resume_continues_rotation(self, test_display_controller):
+        """Regression: when live priority ends, rotation resumes where it was
+        interrupted, not after the live plugin's mode.
+
+        Without the fix, _apply_live_priority left current_mode_index pointing at
+        the live plugin's slot, so the next rotation step skipped every mode
+        between the interrupted position and the live plugin (e.g. elections,
+        which sits just before a flights plugin in the order)."""
+        controller = test_display_controller
+        controller.available_modes = [
+            "weather", "forecast", "almanac", "election_ticker", "flight_live"
+        ]
+        # Rotation is about to show the 3rd mode (index 2).
+        controller.current_mode_index = 2
+        controller.current_display_mode = "almanac"
+        controller._live_resume_index = None
+
+        # Live priority (e.g. planes overhead) preempts -> flight_live (index 4).
+        controller._apply_live_priority("flight_live")
+        assert controller.current_display_mode == "flight_live"
+        assert controller.current_mode_index == 4
+        assert controller._live_resume_index == 2  # saved rotation position
+
+        # Re-checks while the hold continues must not move the saved position.
+        controller._apply_live_priority("flight_live")
+        assert controller._live_resume_index == 2
+
+        # Live priority ends -> resume at the saved index (almanac), so the next
+        # rotation step lands on election_ticker (index 3) rather than skipping it.
+        controller._apply_live_priority(None)
+        assert controller.current_mode_index == 2
+        assert controller.current_display_mode == "almanac"
+        assert controller._live_resume_index is None
+
+    def test_live_priority_no_resume_when_idle(self, test_display_controller):
+        """No saved position + no live content is a no-op (normal rotation)."""
+        controller = test_display_controller
+        controller.available_modes = ["a", "b", "c"]
+        controller.current_mode_index = 1
+        controller.current_display_mode = "b"
+        controller._live_resume_index = None
+
+        controller._apply_live_priority(None)
+
+        assert controller.current_mode_index == 1
+        assert controller.current_display_mode == "b"
+
 
 class TestDisplayControllerDynamicDuration:
     """Test dynamic duration handling."""


### PR DESCRIPTION
## Problem

When a live-priority plugin preempts the rotation (e.g. a live game, or a flights/ADS-B plugin while aircraft are overhead), the controller overwrites `current_mode_index` with the live plugin's index. Once live priority ends, the rotation continues from *after* the live plugin's mode — skipping every mode between where the rotation actually was and the live plugin.

If the live plugin sits late in the mode order, the modes just before it are starved indefinitely: every time live priority fires, the rotation teleports past them. In practice a plugin two slots before a frequently-live plugin may never be shown.

## Fix

Extract the live-priority transition into a small `_apply_live_priority()` helper that:

- saves the rotation position on the **initial** switch into a live-priority mode (and only then, not on every re-check while the hold continues), and
- restores that position when live priority ends, so the rotation resumes exactly where it was interrupted instead of after the live plugin's mode.

No behavior change while live content is active; only the resume point changes.

## Tests

Added regression tests in `test/test_display_controller.py` (`TestDisplayControllerLivePriority`):

- resume continues rotation at the interrupted position (not after the live plugin)
- the saved position is not overwritten by re-checks during the hold
- idle no-op when there is no live content and nothing saved

`TestDisplayControllerLivePriority` passes 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display rotation resumption after live-priority plugin deactivation. The display now correctly returns to its previously saved rotation position instead of resuming from an unexpected point.

* **Tests**
  * Added regression tests for live-priority behavior, including rotation resumption verification and edge case handling when no saved position exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->