### PR TITLE
fix: requirements-test.txt conflicts with requirements.txt (pytest pin)

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,9 @@
 # Test-only dependencies for the plugin safety harness and pytest suite.
 # Install alongside requirements.txt:  pip install -r requirements.txt -r requirements-test.txt
-# Upper bounds pin the major version so a new release can't silently change
-# golden-image / time-sensitive test behavior between CI runs.
-pytest>=7.4,<9
-pytest-cov>=4.1,<7
-jsonschema>=4.0,<5       # manifest validation
+#
+# pytest, pytest-cov, pytest-mock, and jsonschema are already pinned (with
+# major-version caps) in requirements.txt, so they are intentionally NOT
+# repeated here — re-pinning pytest to <9 collided with requirements.txt's
+# pytest>=9.0.3,<10 and made the two files impossible to install together.
+# Only declare what requirements.txt doesn't already provide.
 freezegun>=1.2,<2        # deterministic time for golden-image tests


### PR DESCRIPTION
## Problem

`pip install -r requirements.txt -r requirements-test.txt` currently fails on `main` with `ResolutionImpossible`:

```
ERROR: Cannot install pytest<10.0.0 and >=9.0.3 and pytest<9 and >=7.4
because these package versions have conflicting dependencies.
```

`requirements.txt` pins `pytest>=9.0.3,<10` (added in #331), but `requirements-test.txt` (added in #361) re-pins `pytest>=7.4,<9`. The ranges are disjoint, so the two files can't be installed together.

This breaks:
- the core test workflow (`.github/workflows/test.yml`), and
- the `ledmatrix-plugins` safety workflow, which installs both core files to run the harness.

## Fix

`pytest`, `pytest-cov`, `pytest-mock`, and `jsonschema` are **already** pinned with major-version caps in `requirements.txt`. Drop them from `requirements-test.txt` and keep only `freezegun` — the one test dependency `requirements.txt` doesn't already provide. No duplicate pins, no conflict.

Verified `pip install --dry-run -r requirements.txt -r requirements-test.txt` resolves cleanly (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)