### PR TITLE
Increase max chain length to 24 panels

### DIFF
--- a/web_interface/templates/v3/partials/display.html
+++ b/web_interface/templates/v3/partials/display.html
@@ -68,7 +68,7 @@
                            name="chain_length"
                            value="{{ main_config.display.hardware.chain_length or 2 }}"
                            min="1"
-                           max="8"
+                           max="24"
                            class="form-control">
                     <p class="mt-1 text-sm text-gray-600">Number of LED panels chained together</p>
                 </div>


### PR DESCRIPTION
## Summary
- Raise the Display settings "Chain Length" input's HTML max from 8 to 24, allowing longer LED panel strings.
- Backend (`display_manager.py`, `api_v3.py`, `sync_manager.py`) already accepts any integer chain_length with no bounds checking, so no other changes are needed.

## Test plan
- [ ] Open the Display settings page in the v3 web UI and confirm the Chain Length field accepts values up to 24
- [ ] Save a chain_length value > 8 (e.g. 16) and confirm it persists to `config/config.json` and the computed display width updates accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum Chain Length hardware setting from 8 to 24 LED panels, enabling support for larger display configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->