### PR TITLE
fix(display): restore early-continue guard for mid-loop mode changes

### DIFF
--- a/src/display_controller.py
+++ b/src/display_controller.py
@@ -2186,6 +2186,23 @@ class DisplayController:
                                     loop_completed = True
                                     break
 
+                        # LOAD-BEARING: if current_display_mode changed mid-loop (on-demand
+                        # activation, live priority, etc.), restart the main loop now instead
+                        # of falling into the "honour minimum duration" sleep below. That sleep
+                        # can run for up to the *previous* mode's full display_duration (default
+                        # 30s) and doesn't poll on-demand requests or re-check the mode, so a
+                        # freshly-requested mode switch would sit invisible for up to 30s — or
+                        # get clobbered by a queued stop request — before ever rendering.
+                        #
+                        # This guard was added in #298 (live priority interrupting long display
+                        # durations) and was accidentally dropped in #330 as collateral damage of
+                        # an unrelated time.monotonic() -> time.time() cleanup in the same hunk.
+                        # Removing it again will silently reintroduce both issues. _activate_on_demand
+                        # already sets force_change=True and clears the display, so the next loop
+                        # iteration renders the new mode immediately.
+                        if self.current_display_mode != active_mode:
+                            continue
+
                         # Ensure we honour minimum duration when not dynamic and loop ended early
                         if (
                             not dynamic_enabled


### PR DESCRIPTION
## Summary
- Restores a 6-line `continue` guard right after the per-mode display FPS loop, so a mid-loop mode change (on-demand activation, live priority, etc.) takes effect on the next loop iteration instead of waiting out the previous mode's full `display_duration` (default 30s).
- Adds a comment explaining why this guard is load-bearing, with history.

## Background
The guard was originally added in #298 to fix #196 (live priority not interrupting long display durations), and was accidentally dropped in #330 — collateral damage from an unrelated `time.monotonic()` -> `time.time()` cleanup in the same diff hunk.

Without it, after `current_display_mode` changes mid-loop, the loop falls into `_sleep_with_plugin_updates(remaining_sleep)` for the rest of the *previous* mode's duration. That sleep doesn't poll on-demand requests or re-check the mode, so:
- A new on-demand mode can sit unrendered for up to ~30s after activation
- A queued stop request can be processed before the new mode ever renders, so the display silently snaps back to normal rotation without ever showing the on-demand content
- Live-priority interrupts (#196) suffer the same up-to-30s delay

## How discovered
Investigating reports that the new on-air MQTT plugin's ON/OFF toggle was "sometimes fast, sometimes slow." Captured a devpi log trace where ON was detected within ~1s but the display never actually switched — the OFF arrived ~16s later while the loop was still asleep from the ON activation, and on-demand mode was cleared before `on_air.display()` was ever called.

## Test plan
- [x] Verified fix on devpi: restarted `ledmatrix.service` with this change; on-air MQTT ON/OFF now switches the display within ~1s regardless of timing within the previous mode's cycle
- [ ] Confirm live-priority interrupts (favorite team game starting) also switch promptly (re-fixes #196)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced display mode switching responsiveness. The system now immediately recognizes when the active display mode changes and re-evaluates pending requests without introducing unnecessary delays. This ensures faster response to priority interruptions and on-demand activation requests, delivering more responsive real-time control and faster mode transitions for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->