### PR TITLE
fix(install): avoid apt-package uninstall failure during web dep install

### DIFF
--- a/scripts/install_dependencies_apt.py
+++ b/scripts/install_dependencies_apt.py
@@ -75,12 +75,20 @@ def install_via_pip(package_name):
     Debian/Ubuntu-based systems without a virtual environment.
     --prefer-binary prefers pre-built wheels over source distributions to avoid
     exhausting /tmp space during compilation.
+    --ignore-installed stops pip from trying to *uninstall* packages that were
+    installed by apt (e.g. python3-requests). Those Debian packages ship no
+    pip RECORD file, so an uninstall attempt fails with "uninstall-no-record-file"
+    and aborts the whole install. With --ignore-installed, pip lays the new
+    version down in /usr/local where it shadows the apt copy instead of removing
+    it. This matters when a pip dependency (google-api-python-client pulls a
+    newer requests) needs to upgrade an apt-managed package.
 
     Returns (success, output).
     """
     print(f"Installing {package_name} via pip...")
     success, output = _run([
-        sys.executable, '-m', 'pip', 'install', '--break-system-packages', '--prefer-binary', package_name
+        sys.executable, '-m', 'pip', 'install',
+        '--break-system-packages', '--prefer-binary', '--ignore-installed', package_name
     ])
     if success:
         print(f"Successfully installed {package_name} via pip")

--- a/scripts/install_dependencies_apt.py
+++ b/scripts/install_dependencies_apt.py
@@ -208,7 +208,7 @@ def main():
             if setup_py.exists():
                 # Try installing - use regular install, not editable mode
                 # This is optional for web interface and should already be installed in Step 6
-                ok, output = _run([sys.executable, '-m', 'pip', 'install', '--break-system-packages', str(rgbmatrix_path)])
+                ok, output = _run([sys.executable, '-m', 'pip', 'install', '--break-system-packages', '--ignore-installed', str(rgbmatrix_path)])
                 if ok:
                     print("rgbmatrix module installed successfully")
                 else:


### PR DESCRIPTION
> [!NOTE]
> **Untested on a fresh install.** This PR is Claude's interpretation of an issue raised in Discord (a fresh Pi install failing at step 7). The reasoning and fix are explained below, but I have **not** reproduced the failure or verified the fix on a clean Raspberry Pi OS image. Please review/test before merging.

## Problem

On a fresh Raspberry Pi install, step 7 ("Install web interface dependencies") aborts with:

```
× Cannot uninstall requests 2.32.3
╰─> The package's contents are unknown: no RECORD file was found for requests.
  hint: The package was installed by debian.
✗ An error occurred during: Install web interface dependencies
```

### Why it happens

1. `install_dependencies_apt.py` installs `requests` via apt → `python3-requests` (2.32.3). Debian-packaged Python modules ship **no pip `RECORD` file**.
2. Later it pip-installs `google-api-python-client`. Its dependency tree pulls a newer `requests`, and pip's resolver tries to **uninstall** the apt copy to replace it.
3. pip can't uninstall an apt-managed package with no RECORD → `uninstall-no-record-file` → the whole install aborts.

## Fix

Add `--ignore-installed` to `install_via_pip`. pip then installs the new version into `/usr/local/lib/.../dist-packages` (which shadows the apt copy on Debian) instead of trying to remove the apt-managed package. This resolves the failure for **any** transitive dependency pip needs to upgrade over an apt-installed package, not just `requests`.

## Manual workaround (for anyone hitting this now)

```bash
python3 -m pip install --break-system-packages --ignore-installed --prefer-binary \
  'requests>=2.33.0,<3.0.0' \
  'google-api-python-client>=2.147.0,<3.0.0' \
  'google-auth-oauthlib>=1.2.0,<2.0.0' \
  'google-auth-httplib2>=0.2.0,<1.0.0'
# then re-run (idempotent): bash first_time_install.sh
```

## Testing

Byte-compiled and functionally verified that `install_via_pip` now emits `--break-system-packages --prefer-binary --ignore-installed`. **Not** validated end-to-end on a fresh Pi image (see note above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dependency installation process to prevent conflicts when mixing system package manager and pip installations, improving installation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->