### PR TITLE
fix(web): restore missing brace in Tools tab HTMX-fallback path

### DIFF
--- a/web_interface/templates/v3/base.html
+++ b/web_interface/templates/v3/base.html
@@ -1938,6 +1938,7 @@
                                         contentEl.innerHTML = '<div class="bg-red-50 border border-red-200 rounded-lg p-4"><p class="text-red-800">Failed to load Tools. Please refresh the page.</p></div>';
                                     });
                             }
+                        }
                     }, 100);
                 },
 


### PR DESCRIPTION
## Summary

- The `else if (++tries > 100)` block added by #373 was missing its closing `}` before `}, 100)` closed the `setInterval` arrow function
- This produced a JavaScript `SyntaxError` that silenced the entire 1,400-line script block — including `new EventSource(...)` and all of the `_statsOpenHandler`/`_statsErrorHandler` registrations
- Result: the connection-status indicator never transitioned away from its default `"Disconnected"` HTML for every user on the current build

One character inserted, restoring the structure to what existed before #373 added the `tools` branch:

```diff
                             }
+                        }
                     }, 100);
```

## Test plan

- [ ] Reload the web UI — connection badge should turn green within ~1 second
- [ ] Click the Tools tab — content loads normally (HTMX path still works)
- [ ] Confirm no JS errors in browser console on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a JavaScript syntax issue in the tab-loading fallback flow, improving reliability when the main loading library is not yet available.
  * Ensured the fallback logic completes correctly after fetching content, helping prevent unexpected behavior during tab content loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->