### PR TITLE
Fix: array-table boolean columns always saved as unchecked (countdown 'No Active' bug)

### DIFF
--- a/web_interface/static/v3/js/widgets/array-table.js
+++ b/web_interface/static/v3/js/widgets/array-table.js
@@ -174,11 +174,16 @@
         cell.style.verticalAlign = 'middle';
 
         if (colType === 'boolean') {
-            // Boolean: hidden sentinel + visible checkbox
+            // Boolean: hidden sentinel + visible checkbox, same `name` (so
+            // unchecked boxes still submit "false"). Keep the hidden's value
+            // synced to the checkbox at all times — some form-collection
+            // paths prefer whichever of the two same-named inputs comes
+            // first/last in the DOM, and a stale hidden value previously
+            // caused this field to silently revert to false on every save.
             const hidden = document.createElement('input');
             hidden.type  = 'hidden';
             hidden.name  = inputName;
-            hidden.value = 'false';
+            hidden.value = String(Boolean(colValue));
             cell.appendChild(hidden);
 
             const cb = document.createElement('input');
@@ -187,6 +192,9 @@
             cb.checked   = Boolean(colValue);
             cb.value     = 'true';
             cb.className = 'h-4 w-4 text-blue-600';
+            cb.addEventListener('change', () => {
+                hidden.value = String(cb.checked);
+            });
             cell.appendChild(cb);
 
         } else if (colType === 'integer' || colType === 'number') {

--- a/web_interface/templates/v3/partials/plugin_config.html
+++ b/web_interface/templates/v3/partials/plugin_config.html
@@ -450,15 +450,16 @@
                                             </div>
                                         </td>
                                         <td class="px-4 py-3 whitespace-nowrap text-center">
-                                            <input type="hidden" name="{{ full_key }}.{{ item_index }}.enabled" value="false">
-                                            <input type="checkbox" 
+                                            <input type="hidden" name="{{ full_key }}.{{ item_index }}.enabled" value="{{ 'true' if item.get('enabled', true) else 'false' }}">
+                                            <input type="checkbox"
                                                    name="{{ full_key }}.{{ item_index }}.enabled"
                                                    {% if item.get('enabled', true) %}checked{% endif %}
                                                    value="true"
+                                                   onchange="this.previousElementSibling.value = this.checked ? 'true' : 'false'"
                                                    class="h-4 w-4 text-blue-600">
                                         </td>
                                         <td class="px-4 py-3 whitespace-nowrap text-center">
-                                            <button type="button" 
+                                            <button type="button"
                                                     onclick="removeCustomFeedRow(this)"
                                                     class="text-red-600 hover:text-red-800 px-2 py-1">
                                                 <i class="fas fa-trash"></i>
@@ -549,11 +550,18 @@
                                         {% else %}{% set td_min_w = '110px' %}{% endif %}
                                         <td class="px-3 py-3 whitespace-nowrap" style="min-width:{{ td_min_w }};vertical-align:middle">
                                             {% if col_type == 'boolean' %}
-                                                <input type="hidden" name="{{ full_key }}.{{ item_index }}.{{ col_name }}" value="false">
+                                                {# Hidden sentinel ensures unchecked boxes still submit "false" (browsers
+                                                   omit unchecked checkboxes entirely). It shares the checkbox's `name`,
+                                                   so it must always mirror the checkbox's actual state — both here at
+                                                   render time and on every toggle — or whichever of the two same-named
+                                                   inputs the save request happens to prefer can silently revert this
+                                                   field to false regardless of what's checked. #}
+                                                <input type="hidden" name="{{ full_key }}.{{ item_index }}.{{ col_name }}" value="{{ 'true' if col_value else 'false' }}">
                                                 <input type="checkbox"
                                                        name="{{ full_key }}.{{ item_index }}.{{ col_name }}"
                                                        {% if col_value %}checked{% endif %}
                                                        value="true"
+                                                       onchange="this.previousElementSibling.value = this.checked ? 'true' : 'false'"
                                                        class="h-4 w-4 text-blue-600">
                                             {% elif col_type == 'integer' or col_type == 'number' %}
                                                 <input type="number"


### PR DESCRIPTION
## Summary

Reported bug: the countdown plugin always shows "No Active" even with a countdown configured and enabled — because every save silently unchecked it ("everytime I save it, it unchecks my timer").

**Root cause:** the `array-table` widget's boolean column renders a hidden sentinel input (needed so unchecked checkboxes still submit `"false"`, since browsers omit unchecked checkboxes from form submission entirely) sharing the same `name` as the visible checkbox. The hidden was hardcoded to `value="false"` with no sync to the checkbox's actual state. Whichever of the two same-named inputs the save request's form-collection logic happens to prefer, the hidden's stale `"false"` could silently override an actually-checked box on every save — independent of what the user set.

Confirmed via an isolated Jinja render of the exact snippet: before the fix, the hidden was always `value="false"` regardless of the countdown's actual `enabled` state; after the fix, it correctly matches (`"true"` when checked, `"false"` when not).

## Changes

- **`plugin_config.html`**: the initial server-rendered row for every array-table boolean column (affects countdown's per-countdown `enabled` and the custom-feeds widget's per-feed `enabled`) — sets the hidden's initial value from the actual data, and syncs it via `onchange` on every toggle.
- **`array-table.js`**: the client-side row renderer used when adding/rebuilding rows in the browser — same fix, keeping both inputs in sync at render time and via a `change` listener.

## Scope check

Audited every other checkbox/hidden-input pattern in `plugin_config.html` and confirmed they're unrelated or already safe:
- Default single-checkbox renderer (no hidden pair — relies on standard omission-means-false)
- `checkbox-group` widget (array-bracket names, its own explicit sync already wired)
- The array-table advanced-props modal editor (single hidden per name, explicitly written on Save button click)
- The top-level plugin enable/disable toggle (separate immediate `hx-post`, not part of the main save form)
- The no-schema fallback checkbox

`custom-feeds.js`'s own client-side row renderer never creates a hidden sentinel at all, so it isn't affected by this bug either — only its server-rendered counterpart in `plugin_config.html` was, which is fixed above.

## Test plan

- [x] `python3 -c "from jinja2 import Environment, FileSystemLoader; ..."` — full template still parses
- [x] Isolated Jinja render of the exact fixed snippet with `enabled: True` and `enabled: False` — hidden and checkbox now agree in both cases (previously hidden was always `"false"`)
- [x] Manual review of the JS diff (no JS runtime available in this environment to execute it directly, but the change is a small, mechanical mirror of the same fix applied to the Jinja template, plus the already-correct `getValue()` read path is untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEZK1P1Q1fu5pcuVrkrCFZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed checkbox-based boolean fields in table-style forms so saved values now match the current on-screen state.
  * Improved handling of hidden companion inputs to prevent outdated `true`/`false` values from being submitted.
  * Applied the fix across both generic table widgets and plugin configuration tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->