### PR TITLE
Add system diagnostics, power controls, and WiFi radio toggle to Tools tab

### DIFF
--- a/src/wifi_manager.py
+++ b/src/wifi_manager.py
@@ -1920,7 +1920,7 @@ class WiFiManager:
             'available': available,
         }
 
-    def set_wifi_radio(self, enabled: bool, force: bool = False) -> Tuple[bool, str]:
+    def set_wifi_radio(self, enabled: bool, force: bool = False) -> Tuple[bool, str, Optional[str]]:
         """
         Turn the WiFi radio on or off.
 
@@ -1937,12 +1937,15 @@ class WiFiManager:
         command is introduced.
 
         Returns:
-            (success, human-readable message)
+            (success, human-readable message, reason_code). reason_code is
+            'no_ethernet' when a disable is refused for lockout safety, or a
+            short failure code otherwise; None on success. The web UI keys on
+            'no_ethernet' to decide whether to offer a force-off prompt.
         """
         if enabled:
             if self._ensure_wifi_radio_enabled():
-                return True, "WiFi radio enabled."
-            return False, "Failed to enable WiFi radio. Check logs for details."
+                return True, "WiFi radio enabled.", None
+            return False, "Failed to enable WiFi radio. Check logs for details.", 'enable_failed'
 
         # Disabling — guard against locking the user out of the web interface.
         if not force and not self._is_ethernet_connected():
@@ -1950,7 +1953,7 @@ class WiFiManager:
                 "Refusing to disable WiFi: no wired (Ethernet) connection was "
                 "detected, so turning off WiFi would disconnect you from this "
                 "page. Connect Ethernet first, or force it if you're sure."
-            )
+            ), 'no_ethernet'
 
         try:
             result = subprocess.run(
@@ -1961,14 +1964,14 @@ class WiFiManager:
             )
             if result.returncode == 0:
                 logger.info("WiFi radio disabled via web interface (force=%s)", force)
-                return True, "WiFi radio disabled."
+                return True, "WiFi radio disabled.", None
             logger.warning("Failed to disable WiFi radio: %s", result.stderr.strip())
-            return False, "Failed to disable WiFi radio. Check logs for details."
+            return False, "Failed to disable WiFi radio. Check logs for details.", 'command_failed'
         except subprocess.TimeoutExpired:
-            return False, "Command timed out while disabling WiFi radio."
+            return False, "Command timed out while disabling WiFi radio.", 'timeout'
         except Exception as e:
             logger.error("Error disabling WiFi radio: %s", e)
-            return False, "An error occurred while disabling WiFi radio."
+            return False, "An error occurred while disabling WiFi radio.", 'error'
 
     def enable_ap_mode(self, force: bool = False) -> Tuple[bool, str]:
         """

--- a/src/wifi_manager.py
+++ b/src/wifi_manager.py
@@ -1883,7 +1883,93 @@ class WiFiManager:
         
         logger.warning(f"Failed to enable WiFi radio after {max_retries} attempts")
         return False
-    
+
+    def get_wifi_radio_state(self) -> Dict:
+        """
+        Report whether the WiFi radio is currently enabled, plus whether a wired
+        fallback exists. Used by the web UI's radio toggle so it can warn before
+        an action that could disconnect the browser.
+
+        Returns:
+            {
+                'enabled': Optional[bool],   # True/False, or None if undeterminable
+                'ethernet_connected': bool,  # wired fallback present
+                'available': bool,           # nmcli present / radio state readable
+            }
+        """
+        ethernet_connected = self._is_ethernet_connected()
+        enabled: Optional[bool] = None
+        available = False
+        try:
+            result = subprocess.run(
+                ["nmcli", "radio", "wifi"],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            if result.returncode == 0:
+                status = result.stdout.strip().lower()
+                if status in ("enabled", "disabled"):
+                    enabled = status == "enabled"
+                    available = True
+        except Exception as e:
+            logger.debug(f"Could not read WiFi radio state: {e}")
+        return {
+            'enabled': enabled,
+            'ethernet_connected': ethernet_connected,
+            'available': available,
+        }
+
+    def set_wifi_radio(self, enabled: bool, force: bool = False) -> Tuple[bool, str]:
+        """
+        Turn the WiFi radio on or off.
+
+        Turning the radio OFF from the web interface is dangerous: if the device
+        is reachable only over WiFi, disabling it disconnects the very page that
+        issued the request. To prevent that lockout, disabling is refused unless a
+        wired (Ethernet) fallback is present, or the caller explicitly passes
+        force=True to acknowledge the risk.
+
+        Enabling reuses the hardened _ensure_wifi_radio_enabled() path (handles
+        rfkill soft-blocks + retries). Both directions rely only on
+        `nmcli radio wifi on|off`, which is already covered by the passwordless
+        sudoers allowlist (configure_wifi_permissions.sh) — no new privileged
+        command is introduced.
+
+        Returns:
+            (success, human-readable message)
+        """
+        if enabled:
+            if self._ensure_wifi_radio_enabled():
+                return True, "WiFi radio enabled."
+            return False, "Failed to enable WiFi radio. Check logs for details."
+
+        # Disabling — guard against locking the user out of the web interface.
+        if not force and not self._is_ethernet_connected():
+            return False, (
+                "Refusing to disable WiFi: no wired (Ethernet) connection was "
+                "detected, so turning off WiFi would disconnect you from this "
+                "page. Connect Ethernet first, or force it if you're sure."
+            )
+
+        try:
+            result = subprocess.run(
+                ["sudo", "nmcli", "radio", "wifi", "off"],
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+            if result.returncode == 0:
+                logger.info("WiFi radio disabled via web interface (force=%s)", force)
+                return True, "WiFi radio disabled."
+            logger.warning("Failed to disable WiFi radio: %s", result.stderr.strip())
+            return False, "Failed to disable WiFi radio. Check logs for details."
+        except subprocess.TimeoutExpired:
+            return False, "Command timed out while disabling WiFi radio."
+        except Exception as e:
+            logger.error("Error disabling WiFi radio: %s", e)
+            return False, "An error occurred while disabling WiFi radio."
+
     def enable_ap_mode(self, force: bool = False) -> Tuple[bool, str]:
         """
         Enable access point mode

--- a/src/wifi_manager.py
+++ b/src/wifi_manager.py
@@ -1969,8 +1969,8 @@ class WiFiManager:
             return False, "Failed to disable WiFi radio. Check logs for details.", 'command_failed'
         except subprocess.TimeoutExpired:
             return False, "Command timed out while disabling WiFi radio.", 'timeout'
-        except Exception as e:
-            logger.error("Error disabling WiFi radio: %s", e)
+        except (OSError, subprocess.SubprocessError) as e:
+            logger.error("Error disabling WiFi radio: %s", e, exc_info=True)
             return False, "An error occurred while disabling WiFi radio.", 'error'
 
     def enable_ap_mode(self, force: bool = False) -> Tuple[bool, str]:

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -7184,6 +7184,69 @@ def set_auto_enable_ap_mode():
             'message': 'An error occurred; see logs for details'
         }), 500
 
+@api_v3.route('/wifi/radio', methods=['GET'])
+def get_wifi_radio():
+    """Get current WiFi radio state (enabled/disabled) and wired-fallback status."""
+    try:
+        from src.wifi_manager import WiFiManager
+
+        wifi_manager = WiFiManager()
+        state = wifi_manager.get_wifi_radio_state()
+
+        return jsonify({
+            'status': 'success',
+            'data': state
+        })
+    except Exception as e:
+        logger.error("Error getting WiFi radio state", exc_info=True)
+        return jsonify({
+            'status': 'error',
+            'message': 'An error occurred; see logs for details'
+        }), 500
+
+@api_v3.route('/wifi/radio', methods=['POST'])
+def set_wifi_radio():
+    """Turn the WiFi radio on or off.
+
+    Body: {"enabled": bool, "force": bool (optional)}. Disabling is refused
+    unless Ethernet is connected or force=True, to avoid locking the user out
+    of this web interface.
+    """
+    try:
+        from src.wifi_manager import WiFiManager
+
+        data = request.get_json(silent=True) or {}
+        if 'enabled' not in data:
+            return jsonify({
+                'status': 'error',
+                'message': 'enabled is required'
+            }), 400
+
+        enabled = bool(data['enabled'])
+        _force_raw = data.get('force', False)
+        force = _force_raw is True or (isinstance(_force_raw, str) and _force_raw.lower() in ('true', '1', 'yes'))
+
+        wifi_manager = WiFiManager()
+        success, message = wifi_manager.set_wifi_radio(enabled, force=force)
+
+        if success:
+            return jsonify({
+                'status': 'success',
+                'message': message,
+                'data': wifi_manager.get_wifi_radio_state()
+            })
+        else:
+            return jsonify({
+                'status': 'error',
+                'message': message
+            }), 400
+    except Exception as e:
+        logger.error("Error setting WiFi radio state", exc_info=True)
+        return jsonify({
+            'status': 'error',
+            'message': 'An error occurred; see logs for details'
+        }), 500
+
 @api_v3.route('/cache/list', methods=['GET'])
 def list_cache_files():
     """List all cache files with metadata"""

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -7222,12 +7222,16 @@ def set_wifi_radio():
                 'message': 'enabled is required'
             }), 400
 
-        enabled = bool(data['enabled'])
+        # Parse defensively: bool("false") is True, so mirror the string-aware
+        # coercion used for `force` — the endpoint is a public contract, not just
+        # the shipped UI (which always sends real JSON booleans).
+        _enabled_raw = data['enabled']
+        enabled = _enabled_raw is True or (isinstance(_enabled_raw, str) and _enabled_raw.lower() in ('true', '1', 'yes'))
         _force_raw = data.get('force', False)
         force = _force_raw is True or (isinstance(_force_raw, str) and _force_raw.lower() in ('true', '1', 'yes'))
 
         wifi_manager = WiFiManager()
-        success, message = wifi_manager.set_wifi_radio(enabled, force=force)
+        success, message, reason = wifi_manager.set_wifi_radio(enabled, force=force)
 
         if success:
             return jsonify({
@@ -7238,7 +7242,8 @@ def set_wifi_radio():
         else:
             return jsonify({
                 'status': 'error',
-                'message': message
+                'message': message,
+                'reason': reason
             }), 400
     except Exception as e:
         logger.error("Error setting WiFi radio state", exc_info=True)

--- a/web_interface/templates/v3/partials/tools.html
+++ b/web_interface/templates/v3/partials/tools.html
@@ -1,5 +1,23 @@
 <div class="space-y-6" id="tools-root">
 
+    <!-- System Diagnostics -->
+    <div class="bg-white rounded-lg shadow p-6">
+        <div class="border-b border-gray-200 pb-4 mb-6 flex items-start justify-between gap-4">
+            <div>
+                <h2 class="text-lg font-semibold text-gray-900">System Diagnostics</h2>
+                <p class="mt-1 text-sm text-gray-600">Live CPU, memory, temperature, disk, and uptime for this Raspberry Pi.</p>
+            </div>
+            <button id="btn-diag-refresh" onclick="loadSystemDiagnostics()"
+                    class="shrink-0 inline-flex items-center px-3 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
+                <i class="fas fa-sync-alt mr-2"></i>Refresh
+            </button>
+        </div>
+
+        <div id="diag-panel" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div class="animate-pulse text-gray-400 col-span-full">Loading diagnostics…</div>
+        </div>
+    </div>
+
     <!-- Git & Updates -->
     <div class="bg-white rounded-lg shadow p-6">
         <div class="border-b border-gray-200 pb-4 mb-6">
@@ -123,6 +141,46 @@
         </div>
     </div>
 
+    <!-- Network Radio -->
+    <div class="bg-white rounded-lg shadow p-6">
+        <div class="border-b border-gray-200 pb-4 mb-6">
+            <h2 class="text-lg font-semibold text-gray-900">Network Radio</h2>
+            <p class="mt-1 text-sm text-gray-600">Turn the WiFi radio on or off. Full WiFi setup (scan, connect, hotspot) lives on the <span class="font-medium">WiFi</span> tab.</p>
+        </div>
+
+        <div class="flex items-start justify-between gap-4">
+            <div>
+                <p class="text-sm font-medium text-gray-900">WiFi radio</p>
+                <p id="wifi-radio-note" class="text-xs text-gray-500 mt-0.5">Checking current state…</p>
+            </div>
+            <div class="shrink-0 flex flex-col items-end gap-2">
+                <!-- Toggle switch -->
+                <button id="wifi-radio-toggle" type="button" role="switch" aria-checked="false"
+                        onclick="onWifiRadioToggleClick()" disabled
+                        class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent bg-gray-200 transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 opacity-60">
+                    <span id="wifi-radio-knob" aria-hidden="true"
+                          class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out translate-x-0"></span>
+                </button>
+
+                <!-- Force-off confirm row (shown only when disabling without Ethernet is refused) -->
+                <div id="wifi-radio-force-row" class="hidden flex-col items-end gap-2">
+                    <span class="text-xs text-red-700 font-medium text-right max-w-xs">No wired connection detected — turning WiFi off will disconnect you from this page. Continue anyway?</span>
+                    <div class="flex items-center gap-2">
+                        <button onclick="forceDisableWifiRadio()"
+                                class="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700">
+                            Turn WiFi off anyway
+                        </button>
+                        <button onclick="hideWifiForceRow()"
+                                class="inline-flex items-center px-3 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div id="result-wifi-radio" class="hidden"></div>
+    </div>
+
     <!-- Services -->
     <div class="bg-white rounded-lg shadow p-6">
         <div class="border-b border-gray-200 pb-4 mb-6">
@@ -154,6 +212,68 @@
                 </button>
             </div>
             <div id="result-restart-web" class="hidden"></div>
+        </div>
+    </div>
+
+    <!-- System Power -->
+    <div class="bg-white rounded-lg shadow p-6">
+        <div class="border-b border-gray-200 pb-4 mb-6">
+            <h2 class="text-lg font-semibold text-gray-900">System Power</h2>
+            <p class="mt-1 text-sm text-gray-600">Reboot or shut down the Raspberry Pi. The web interface will go offline.</p>
+        </div>
+
+        <div class="space-y-4">
+            <!-- Reboot -->
+            <div class="flex items-start justify-between gap-4">
+                <div>
+                    <p class="text-sm font-medium text-gray-900">Reboot</p>
+                    <p class="text-xs text-gray-500 mt-0.5">Runs <code class="bg-gray-100 px-1 rounded">sudo reboot</code>. The Pi will restart and come back online in a minute or two.</p>
+                </div>
+                <div class="shrink-0 flex flex-col items-end gap-2">
+                    <button id="btn-reboot" onclick="showPowerConfirm('reboot')"
+                            class="inline-flex items-center px-3 py-2 border border-amber-300 text-sm font-medium rounded-md text-amber-700 bg-white hover:bg-amber-50">
+                        <i class="fas fa-power-off mr-2"></i>Reboot…
+                    </button>
+                    <div id="reboot-confirm-row" class="hidden flex items-center gap-2">
+                        <span class="text-xs text-amber-700 font-medium">Reboot now?</span>
+                        <button onclick="powerAction('reboot_system', 'btn-reboot', 'result-reboot', 'Reboot command sent — the Pi is restarting. This page will go offline and should return in a minute or two.'); hidePowerConfirm('reboot')"
+                                class="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-amber-600 hover:bg-amber-700">
+                            Yes, reboot
+                        </button>
+                        <button onclick="hidePowerConfirm('reboot')"
+                                class="inline-flex items-center px-3 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div id="result-reboot" class="hidden"></div>
+
+            <!-- Shutdown -->
+            <div class="flex items-start justify-between gap-4 pt-4 border-t border-gray-100">
+                <div>
+                    <p class="text-sm font-medium text-gray-900">Shut down</p>
+                    <p class="text-xs text-gray-500 mt-0.5">Runs <code class="bg-gray-100 px-1 rounded">sudo poweroff</code>. The Pi will power off and must be unplugged/replugged (or power-cycled) to turn back on.</p>
+                </div>
+                <div class="shrink-0 flex flex-col items-end gap-2">
+                    <button id="btn-shutdown" onclick="showPowerConfirm('shutdown')"
+                            class="inline-flex items-center px-3 py-2 border border-red-300 text-sm font-medium rounded-md text-red-700 bg-white hover:bg-red-50">
+                        <i class="fas fa-plug mr-2"></i>Shut Down…
+                    </button>
+                    <div id="shutdown-confirm-row" class="hidden flex items-center gap-2">
+                        <span class="text-xs text-red-700 font-medium">Power off now?</span>
+                        <button onclick="powerAction('shutdown_system', 'btn-shutdown', 'result-shutdown', 'Shutdown command sent — the Pi is powering off. You will need to power-cycle it to turn it back on.'); hidePowerConfirm('shutdown')"
+                                class="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700">
+                            Yes, shut down
+                        </button>
+                        <button onclick="hidePowerConfirm('shutdown')"
+                                class="inline-flex items-center px-3 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div id="result-shutdown" class="hidden"></div>
         </div>
     </div>
 
@@ -397,7 +517,208 @@
         });
     }
 
+    // ── system diagnostics panel ──────────────────────────────────────────────
+    // Reads the existing /api/v3/system/status JSON endpoint (10s cached) for
+    // richer metrics (disk, uptime, memory MB) than the SSE stats stream carries.
+
+    function diagTile(icon, iconColor, label, value, sub) {
+        return `
+            <div class="bg-gray-50 rounded-lg p-4">
+                <div class="flex items-center">
+                    <div class="flex-shrink-0"><i class="fas ${icon} ${iconColor} text-xl"></i></div>
+                    <div class="ml-3 w-0 flex-1">
+                        <dt class="text-sm font-medium text-gray-500 truncate">${escHtml(label)}</dt>
+                        <dd class="text-lg font-medium text-gray-900">${escHtml(value)}</dd>
+                        ${sub ? `<dd class="text-xs text-gray-400 mt-0.5">${escHtml(sub)}</dd>` : ''}
+                    </div>
+                </div>
+            </div>`;
+    }
+
+    window.loadSystemDiagnostics = function() {
+        const panel = document.getElementById('diag-panel');
+        if (!panel) return;
+
+        fetch('/api/v3/system/status')
+            .then(r => {
+                if (!r.ok) return r.json()
+                    .then(d => Promise.reject(d.message || `HTTP ${r.status}`))
+                    .catch(() => Promise.reject(`HTTP ${r.status}`));
+                return r.json();
+            })
+            .then(res => {
+                const d = (res && res.data) || {};
+                const mUsedGb = d.memory_used_mb != null ? (d.memory_used_mb / 1024).toFixed(1) : null;
+                const mTotGb  = d.memory_total_mb != null ? (d.memory_total_mb / 1024).toFixed(1) : null;
+                const temp    = d.cpu_temp != null ? d.cpu_temp + '°C' : 'N/A';
+                panel.innerHTML =
+                    diagTile('fa-microchip', 'text-blue-600', 'CPU Usage',
+                        (d.cpu_percent != null ? d.cpu_percent : '--') + '%', null) +
+                    diagTile('fa-memory', 'text-green-600', 'Memory',
+                        (d.memory_used_percent != null ? d.memory_used_percent : '--') + '%',
+                        (mUsedGb && mTotGb) ? `${mUsedGb} / ${mTotGb} GB` : null) +
+                    diagTile('fa-thermometer-half', 'text-red-600', 'CPU Temp', temp, null) +
+                    diagTile('fa-hdd', 'text-indigo-600', 'Disk',
+                        (d.disk_used_percent != null ? d.disk_used_percent : '--') + '%',
+                        (d.disk_used_gb != null && d.disk_total_gb != null) ? `${d.disk_used_gb} / ${d.disk_total_gb} GB` : null) +
+                    diagTile('fa-clock', 'text-purple-600', 'Uptime', d.uptime || '--', null) +
+                    diagTile('fa-desktop', d.service_active ? 'text-green-600' : 'text-gray-400',
+                        'Display Service', d.service_active ? 'Active' : 'Inactive', null);
+            })
+            .catch(err => {
+                panel.innerHTML = `<div class="col-span-full text-sm text-red-600">Diagnostics unavailable: ${escHtml(String(err))}</div>`;
+            });
+    };
+
+    // ── system power (reboot / shutdown) ──────────────────────────────────────
+    // Like toolsAction, but a dropped connection is the expected, successful
+    // outcome (the Pi is going down), so it is reported as info, not an error.
+
+    window.powerAction = function(action, btnId, resultId, offlineMsg) {
+        setBusy(btnId, true);
+        const el = document.getElementById(resultId);
+        if (el) el.classList.add('hidden');
+
+        fetch('/api/v3/system/action', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({action})
+        })
+        .then(r => r.json().catch(() => ({status: 'success'})))
+        .then(data => {
+            if (data.status === 'error') {
+                showResult(resultId, false, data.message || 'Command failed');
+            } else {
+                showResult(resultId, true, offlineMsg);
+            }
+        })
+        .catch(() => {
+            // Connection dropped mid-request — expected when the Pi reboots/powers off.
+            showResult(resultId, true, offlineMsg);
+        })
+        .finally(() => setBusy(btnId, false));
+    };
+
+    window.showPowerConfirm = function(kind) {
+        document.getElementById(kind + '-confirm-row').classList.remove('hidden');
+        document.getElementById('btn-' + kind).classList.add('hidden');
+    };
+    window.hidePowerConfirm = function(kind) {
+        document.getElementById(kind + '-confirm-row').classList.add('hidden');
+        document.getElementById('btn-' + kind).classList.remove('hidden');
+    };
+
+    // ── WiFi radio toggle ─────────────────────────────────────────────────────
+
+    function renderWifiRadio(state) {
+        const toggle = document.getElementById('wifi-radio-toggle');
+        const knob   = document.getElementById('wifi-radio-knob');
+        const note   = document.getElementById('wifi-radio-note');
+        if (!toggle || !knob || !note) return;
+
+        const setKnob = (on) => {
+            if (on) {
+                knob.classList.remove('translate-x-0'); knob.classList.add('translate-x-5');
+                toggle.classList.remove('bg-gray-200'); toggle.classList.add('bg-blue-600');
+            } else {
+                knob.classList.remove('translate-x-5'); knob.classList.add('translate-x-0');
+                toggle.classList.remove('bg-blue-600'); toggle.classList.add('bg-gray-200');
+            }
+        };
+
+        if (!state || state.available === false) {
+            toggle.disabled = true;
+            toggle.classList.add('opacity-60');
+            toggle.setAttribute('aria-checked', 'false');
+            setKnob(false);
+            note.textContent = 'WiFi radio control is not available on this system (nmcli not found).';
+            note.className = 'text-xs text-gray-500 mt-0.5';
+            return;
+        }
+
+        const on = state.enabled === true;
+        toggle.disabled = false;
+        toggle.classList.remove('opacity-60');
+        toggle.setAttribute('aria-checked', on ? 'true' : 'false');
+        setKnob(on);
+        const eth = state.ethernet_connected
+            ? 'Wired connection detected — safe to turn WiFi off.'
+            : 'No wired connection — turning WiFi off will disconnect this page.';
+        note.textContent = `Radio is ${on ? 'on' : 'off'}. ${eth}`;
+        note.className = 'text-xs mt-0.5 ' + (state.ethernet_connected ? 'text-gray-500' : 'text-amber-600');
+    }
+
+    window.loadWifiRadio = function() {
+        fetch('/api/v3/wifi/radio')
+            .then(r => r.json())
+            .then(res => renderWifiRadio(res && res.data))
+            .catch(() => renderWifiRadio(null));
+    };
+
+    window.onWifiRadioToggleClick = function() {
+        const toggle = document.getElementById('wifi-radio-toggle');
+        if (!toggle || toggle.disabled) return;
+        const currentlyOn = toggle.getAttribute('aria-checked') === 'true';
+        setWifiRadio(!currentlyOn, false);
+    };
+
+    function setWifiRadio(enabled, force) {
+        const toggle = document.getElementById('wifi-radio-toggle');
+        const resultEl = document.getElementById('result-wifi-radio');
+        if (toggle) toggle.disabled = true;
+        if (resultEl) resultEl.classList.add('hidden');
+        hideWifiForceRow();
+
+        fetch('/api/v3/wifi/radio', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({enabled, force})
+        })
+        .then(r => r.json().then(d => ({ok: r.ok, d})))
+        .then(({ok, d}) => {
+            if (ok && d.status === 'success') {
+                if (d.data) renderWifiRadio(d.data); else window.loadWifiRadio();
+                showResult('result-wifi-radio', true, d.message || 'Done');
+            } else if (!enabled && !force) {
+                // Disable refused for safety (no wired fallback) — offer the force path.
+                showWifiForceRow();
+                window.loadWifiRadio();
+            } else {
+                showResult('result-wifi-radio', false, d.message || 'Failed to change WiFi radio.');
+                window.loadWifiRadio();
+            }
+        })
+        .catch(err => {
+            showResult('result-wifi-radio', false, 'Request failed: ' + err.message);
+            window.loadWifiRadio();
+        })
+        .finally(() => { if (toggle) toggle.disabled = false; });
+    }
+
+    window.forceDisableWifiRadio = function() {
+        hideWifiForceRow();
+        setWifiRadio(false, true);
+    };
+
+    function showWifiForceRow() {
+        const row = document.getElementById('wifi-radio-force-row');
+        if (row) { row.classList.remove('hidden'); row.classList.add('flex'); }
+    }
+    window.hideWifiForceRow = function() {
+        const row = document.getElementById('wifi-radio-force-row');
+        if (row) { row.classList.add('hidden'); row.classList.remove('flex'); }
+    };
+
     // Load on first render; HTMX will have already swapped us in by this point.
     loadGitInfo();
+
+    // System diagnostics: load now, then refresh every 10s while this tab is
+    // mounted. Clear any prior interval so re-swapping the partial doesn't stack.
+    if (window._diagPollInterval) clearInterval(window._diagPollInterval);
+    window.loadSystemDiagnostics();
+    window._diagPollInterval = setInterval(window.loadSystemDiagnostics, 10000);
+
+    // WiFi radio current state.
+    window.loadWifiRadio();
 })();
 </script>

--- a/web_interface/templates/v3/partials/tools.html
+++ b/web_interface/templates/v3/partials/tools.html
@@ -679,7 +679,7 @@
             if (ok && d.status === 'success') {
                 if (d.data) renderWifiRadio(d.data); else window.loadWifiRadio();
                 showResult('result-wifi-radio', true, d.message || 'Done');
-            } else if (!enabled && !force) {
+            } else if (!enabled && !force && d.reason === 'no_ethernet') {
                 // Disable refused for safety (no wired fallback) — offer the force path.
                 showWifiForceRow();
                 window.loadWifiRadio();
@@ -712,11 +712,18 @@
     // Load on first render; HTMX will have already swapped us in by this point.
     loadGitInfo();
 
-    // System diagnostics: load now, then refresh every 10s while this tab is
-    // mounted. Clear any prior interval so re-swapping the partial doesn't stack.
+    // System diagnostics: load now, then refresh every 10s. Clear any prior
+    // interval so re-swapping the partial doesn't stack. The recurring poll is
+    // gated on visibility — the partial stays in the DOM (hidden via x-show)
+    // when another tab is active, so without this it would keep hitting
+    // /api/v3/system/status every 10s and churn the Pi while off-screen.
     if (window._diagPollInterval) clearInterval(window._diagPollInterval);
     window.loadSystemDiagnostics();
-    window._diagPollInterval = setInterval(window.loadSystemDiagnostics, 10000);
+    window._diagPollInterval = setInterval(function () {
+        const panel = document.getElementById('diag-panel');
+        if (!panel || document.hidden || panel.offsetParent === null) return;
+        window.loadSystemDiagnostics();
+    }, 10000);
 
     // WiFi radio current state.
     window.loadWifiRadio();


### PR DESCRIPTION
## Summary

Expands the web UI **Tools** tab with safe, purpose-built controls so users can manage the Pi without SSHing in. This grew out of a request for an in-browser terminal, which was ruled out as too risky (the web UI has no auth and CSRF is disabled, so an arbitrary-command shell would be a remote-code-execution surface). Instead, this wires up a curated set of controls — most of which lean on capabilities that already exist in the backend.

- **System Diagnostics card** — renders the existing-but-previously-unused `GET /api/v3/system/status` endpoint (CPU, memory, temperature, disk, uptime), with a manual Refresh button and a lightweight 10s poll.
- **System Power section** — Reboot / Shutdown buttons wired to the existing `reboot_system` / `shutdown_system` actions, behind a confirm step. A dedicated `powerAction()` helper treats the dropped connection as the expected "going offline" outcome instead of a red error.
- **Network Radio section** — a WiFi on/off toggle backed by new `GET`/`POST /api/v3/wifi/radio` endpoints and `WiFiManager.set_wifi_radio()` / `get_wifi_radio_state()`. Turning WiFi **off** is refused unless a wired (Ethernet) connection is present (reusing the existing lockout guards), with an explicit "force off anyway" confirmation for advanced users.

Bluetooth toggle was intentionally omitted: the installer removes the BlueZ stack because it interferes with LED matrix timing, so there'd be nothing to toggle on a standard install.

## Type of change

- [x] New feature

## Related issues

<!-- none -->

## Test plan

- [ ] Ran on a real Raspberry Pi with hardware
- [ ] Ran in emulator mode (`EMULATOR=true python3 run.py`)
- [x] Manually verified the affected code path in the web UI

Verified against a locally-running web server (off-Pi, so `nmcli`/`vcgencmd` absent — confirms graceful degradation):
- `GET /api/v3/system/status` returns the full diagnostics payload consumed by the new card.
- `GET /api/v3/wifi/radio` → `{available:false, enabled:null, ethernet_connected:false}`.
- `POST /api/v3/wifi/radio {"enabled":false}` is refused with the anti-lockout message (HTTP 400); `POST {}` → `enabled is required` (400).
- `GET /v3/partials/tools` returns HTTP 200 with all new sections; the inline JS passes `node --check`; the Python modules compile.
- `test/web_interface/test_systemctl_sudoers_alignment.py` passes (2/2) — no new privileged commands were introduced (uses the already-allowlisted `nmcli radio wifi on|off` and the existing reboot/poweroff grants).

## Documentation

- [x] I added/updated docstrings on new public functions
- [x] N/A — no README/docs behavior changes beyond the new UI controls

## Plugin compatibility

- [x] No plugin breakage expected (additive UI sections + new endpoints; no changes to BasePlugin, the loader, or the config schema)

## Checklist

- [x] My commits follow the message convention
- [x] I've not committed any secrets or hardcoded API keys
- [x] N/A — no new config key added

## Notes for reviewer

- The WiFi-off guard relies on `_has_connectivity_safety()` / `_is_ethernet_connected()`; on a Pi reachable only via WiFi, disabling is blocked unless the user explicitly forces it (which will drop their connection — that's the documented trade-off).
- Diagnostics/reboot/shutdown intentionally add **no** new backend capability — they surface endpoints and actions that already existed but were unreachable from the UI, so they inherit the current (unauthenticated, local-network) threat model rather than widening it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019X3he87Ggr1qt8y7mnFeuE

---
_Generated by [Claude Code](https://claude.ai/code/session_019X3he87Ggr1qt8y7mnFeuE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Wi‑Fi radio status and control to the tools page, including “force disable” when wired/Ethernet isn’t detected.
  * Introduced a live System Diagnostics panel with periodic refresh (optimized to run only when the panel is visible).
  * Reworked power controls into a dedicated System Power section for reboot and shut down with confirmation prompts.
  * Added API support for Wi‑Fi radio GET/POST to power the new UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->