### PR TITLE
fix(plugin-harness): add no-op process_deferred_updates to test double

### DIFF
--- a/src/plugin_system/testing/visual_display_manager.py
+++ b/src/plugin_system/testing/visual_display_manager.py
@@ -454,6 +454,18 @@ class VisualTestDisplayManager:
         """Check if display is currently scrolling."""
         return self._scrolling_state['is_scrolling']
 
+    def process_deferred_updates(self):
+        """Process any deferred updates (no-op for testing).
+
+        Several ticker-style plugins (news, odds-ticker, leaderboard,
+        stock-news, stocks) call this unconditionally between
+        set_scrolling_state() and their scroll-position update, mirroring the
+        real display_manager's deferred-update queue. This double has no such
+        queue, so there is nothing to process — the no-op just lets those
+        plugins render under the harness instead of raising AttributeError.
+        """
+        pass
+
     # ------------------------------------------------------------------
     # Utility methods
     # ------------------------------------------------------------------

--- a/test/plugins/test_visual_rendering.py
+++ b/test/plugins/test_visual_rendering.py
@@ -172,6 +172,16 @@ class TestVisualDisplayManager:
         vdm.set_scrolling_state(False)
         assert vdm.is_currently_scrolling() is False
 
+    def test_process_deferred_updates_is_noop(self):
+        # Ticker-style plugins (news, odds-ticker, leaderboard, stock-news,
+        # stocks) call this unconditionally alongside set_scrolling_state();
+        # it must exist and be harmless so those plugins render under the
+        # harness instead of raising AttributeError.
+        vdm = VisualTestDisplayManager(width=128, height=32)
+        vdm.set_scrolling_state(True)
+        vdm.process_deferred_updates()  # should not raise
+        assert vdm.is_currently_scrolling() is True
+
     def test_format_date_with_ordinal(self):
         from datetime import datetime
         vdm = VisualTestDisplayManager(width=128, height=32)


### PR DESCRIPTION
## Summary

The plugin-safety harness's `VisualTestDisplayManager` (base class of
`BoundsCheckingDisplayManager`) doesn't implement `process_deferred_updates()`.
Five first-party plugins in `ledmatrix-plugins` call it unconditionally,
right alongside `set_scrolling_state()`, before updating scroll position:
`news`, `odds-ticker`, `ledmatrix-leaderboard`, `stock-news`, and
`ledmatrix-stocks`. Any of them fails the harness with `AttributeError`
the instant it's touched, even though the call is completely safe against
the real production `display_manager.py` (which has always had this
method).

This surfaced concretely in [ledmatrix-plugins#177](https://github.com/ChuckBuilds/ledmatrix-plugins/pull/177),
which had to add a local `hasattr(self.display_manager, "process_deferred_updates")`
guard in `ledmatrix-stocks/manager.py` just to get CI green — a workaround
for this exact gap, not a real plugin bug. The other 4 plugins are still
unguarded and will hit the same failure the next time any of them is
touched.

## Fix

Add `process_deferred_updates()` to `VisualTestDisplayManager` as a no-op,
mirroring the existing "no-op for testing" pattern already used a few lines
above for `set_scrolling_state()`. This double has no deferred-update queue
to process, so there's nothing to do — the point is just to stop raising
`AttributeError` for callers that assume the method exists (as production
code always can).

## Test plan

- Added `test_process_deferred_updates_is_noop` to `test/plugins/test_visual_rendering.py`,
  next to the existing `test_scrolling_state` test, asserting the call
  doesn't raise and doesn't disturb scrolling state.
- `python3 -m py_compile` on both touched files.
- Read through `test/plugins/test_harness.py`, `test_visual_rendering.py`,
  and `test_plugin_matrix.py` to confirm none of them do exhaustive
  method-set introspection that this addition would break.
- Existing CI (`test.yml` → `pytest test/plugins/test_harness.py
  test/plugins/test_visual_rendering.py test/plugins/test_plugin_matrix.py`)
  will exercise this on the PR.

## Follow-up (not in this PR)

Once this merges, the local `hasattr` guard added in
`ledmatrix-plugins#177` becomes unnecessary (though harmless to leave). The
other 4 affected plugins (news, odds-ticker, leaderboard, stock-news) need
no changes at all — they'll simply stop failing the harness next time
they're touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with ticker-style visual plugins by safely handling deferred update calls during scrolling.
  * Prevented test rendering failures when deferred updates are requested.

* **Tests**
  * Added coverage confirming deferred update handling is harmless and preserves scrolling state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->