### PR TITLE
fix(plugin-manager): fix TypeError breaking every plugin's scheduled update

### DIFF
--- a/src/plugin_system/plugin_manager.py
+++ b/src/plugin_system/plugin_manager.py
@@ -12,6 +12,7 @@ import sys
 import subprocess
 import time
 import threading
+import types
 from pathlib import Path
 from typing import Dict, List, Optional, Any
 import logging
@@ -828,8 +829,18 @@ class PluginManager:
                         # If resource monitor exists, wrap the call
                         def monitored_update():
                             self.resource_monitor.monitor_call(plugin_id, plugin_instance.update)
+                        # SimpleNamespace stores `update` as an *instance*
+                        # attribute, so attribute lookup returns the plain
+                        # function object as-is. A dynamically-built class
+                        # (`type(..., {'update': monitored_update})`) instead
+                        # stores it as a *class* attribute, which the
+                        # descriptor protocol turns into a bound method on
+                        # access -- silently prepending the instance as an
+                        # implicit first argument to a function that takes
+                        # none, raising "monitored_update() takes 0
+                        # positional arguments but 1 was given" on every call.
                         success = self.plugin_executor.execute_update(
-                            type('obj', (object,), {'update': monitored_update})(),
+                            types.SimpleNamespace(update=monitored_update),
                             plugin_id
                         )
                     else:

--- a/test/test_plugin_system.py
+++ b/test/test_plugin_system.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 from pathlib import Path
 from src.plugin_system.plugin_manager import PluginManager
 from src.plugin_system.plugin_state import PluginState
+from src.plugin_system.resource_monitor import PluginResourceMonitor
 
 class TestPluginManager:
     """Test PluginManager functionality."""
@@ -74,9 +75,57 @@ class TestPluginManager:
             
             # No manifest in pm.plugin_manifests
             result = pm.load_plugin("non_existent_plugin")
-            
+
             assert result is False
             assert pm.state_manager.get_state("non_existent_plugin") == PluginState.ERROR
+
+    def test_run_scheduled_updates_calls_update_with_resource_monitor(
+        self, mock_config_manager, mock_display_manager, mock_cache_manager
+    ):
+        """Regression test: run_scheduled_updates() must actually call a
+        plugin's update() when self.resource_monitor is set (as it is in
+        every real deployment -- display_controller.py and web_interface/
+        app.py both assign a real PluginResourceMonitor after construction).
+
+        Previously, the resource_monitor branch wrapped the call in a
+        function stored as a *class* attribute on a dynamically-built type
+        (`type('obj', (object,), {'update': monitored_update})()`), which
+        the descriptor protocol turns into a bound method on access --
+        silently passing the synthetic instance as an implicit first
+        argument to monitored_update(), which takes none. Every plugin's
+        scheduled update failed with "monitored_update() takes 0 positional
+        arguments but 1 was given" and was silently swallowed into a
+        circuit-breaker retry loop that never succeeded, so plugin data
+        (scores, odds, etc.) never refreshed.
+        """
+        with patch('src.plugin_system.plugin_manager.ensure_directory_permissions'):
+            pm = PluginManager(
+                plugins_dir="plugins",
+                config_manager=mock_config_manager,
+                display_manager=mock_display_manager,
+                cache_manager=mock_cache_manager
+            )
+
+            plugin_instance = MagicMock()
+            plugin_instance.enabled = True
+            plugin_instance.update = MagicMock()
+
+            pm.plugins["test_plugin"] = plugin_instance
+            pm.plugin_manifests["test_plugin"] = {"update_interval": 10}
+            pm.state_manager.set_state("test_plugin", PluginState.ENABLED)
+            # Plain MagicMock, not the mock_cache_manager fixture: this test
+            # is about run_scheduled_updates() actually invoking update()
+            # through the resource-monitor wrapper, not about
+            # PluginResourceMonitor's own cache-backed metrics persistence
+            # (which calls cache_manager.get(..., memory_ttl=...) --
+            # a kwarg the fixture's mock_get() doesn't accept).
+            pm.resource_monitor = PluginResourceMonitor(MagicMock())
+
+            pm.run_scheduled_updates(current_time=time.time())
+
+            plugin_instance.update.assert_called_once()
+            assert "test_plugin" in pm.plugin_last_update
+            assert pm.state_manager.get_state("test_plugin") == PluginState.ENABLED
 
 
 class TestPluginLoader:


### PR DESCRIPTION
## Summary

Investigating a user report that the odds-ticker plugin doesn't update
scores or game status. Root cause: `PluginManager.run_scheduled_updates()`
has been throwing a `TypeError` on **every single plugin's** scheduled
update since PR #388 merged, for any deployment where `resource_monitor`
is set (i.e. all of them — both `display_controller.py` and
`web_interface/app.py` assign a real `PluginResourceMonitor` after
construction).

## Root cause

```python
if self.resource_monitor:
    def monitored_update():
        self.resource_monitor.monitor_call(plugin_id, plugin_instance.update)
    success = self.plugin_executor.execute_update(
        type('obj', (object,), {'update': monitored_update})(),
        plugin_id
    )
```

`monitored_update` is stored as a **class** attribute on a dynamically-built
type. Python's descriptor protocol turns a function found via class-attribute
lookup into a bound method when accessed on an instance — so
`plugin_executor`'s `plugin.update()` call silently becomes
`monitored_update(<synthetic instance>)`, but `monitored_update` takes zero
parameters. Every call raises:

```
monitored_update() takes 0 positional arguments but 1 was given
```

This gets caught by `run_scheduled_updates`'s try/except and recorded as an
update failure — so **no plugin's `update()` has succeeded** since a device
picked up #388 (2026-07-09). Circuit breakers cycle through
half-open → immediate failure → reopened forever, and every plugin's data
(scores, odds, prices, etc.) goes stale at whatever was last fetched before
the upgrade.

**Confirmed live** on a running instance — `odds-ticker` (and `stock-news`,
`ledmatrix-stocks`, `baseball-scoreboard`, `ledmatrix-leaderboard`,
`of-the-day`) failing this exact way on every 5-minute circuit-breaker retry,
matching the reported symptom precisely.

The buggy line itself dates back to 2025-12-27, but `self.resource_monitor`
was `None` (dormant) until #388 wired it up — so this is a very recent
regression despite the code being old.

## Fix

`types.SimpleNamespace(update=monitored_update)` instead of a dynamic class.
`SimpleNamespace` stores attributes on the *instance*, so attribute lookup
returns the plain function unchanged — it never goes through the
class-attribute descriptor protocol that injects an implicit `self`.

## Test plan

- Added `test_run_scheduled_updates_calls_update_with_resource_monitor` using
  a **real** `PluginResourceMonitor` (not a mock of it), so the test actually
  exercises the descriptor-binding behavior that caused this.
- Verified the new test fails with the exact reported error
  (`monitored_update() takes 0 positional arguments but 1 was given`)
  against the pre-fix code, and passes against the fix.
- Full `test_plugin_system.py` suite: all passing tests still pass (the one
  pre-existing failure, `TestPluginHealth::test_circuit_breaker`, is a known
  stale-mock issue unrelated to this change — same one PR #390's test plan
  already called out).
- Full CI plugin-safety suite (`test_harness.py`, `test_visual_rendering.py`,
  `test_plugin_matrix.py`): 52 passed, 2 pre-existing skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scheduled plugin updates when resource monitoring is enabled.
  * Ensured plugin updates execute correctly, record the latest update, and preserve the plugin’s enabled state.

* **Tests**
  * Added regression coverage for resource-monitored scheduled updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->