### PR TITLE
fix(testing): add MockCacheManager.get_cached_data_with_strategy/save_cache

### DIFF
--- a/src/plugin_system/testing/mocks.py
+++ b/src/plugin_system/testing/mocks.py
@@ -137,6 +137,7 @@ class MockCacheManager:
         self.get_calls = []
         self.set_calls = []
         self.delete_calls = []
+        self.get_cached_data_with_strategy_calls = []
 
 
 class MockConfigManager:

--- a/src/plugin_system/testing/mocks.py
+++ b/src/plugin_system/testing/mocks.py
@@ -71,6 +71,7 @@ class MockCacheManager:
         self.get_calls = []
         self.set_calls = []
         self.delete_calls = []
+        self.get_cached_data_with_strategy_calls = []
         # Real temp dir for plugins that write/read files under cache_dir.
         # Registered for cleanup so each mock instance doesn't leak a tmp dir.
         self.cache_dir = tempfile.mkdtemp(prefix="ledmatrix-mock-cache-")
@@ -108,6 +109,24 @@ class MockCacheManager:
         self.delete_calls.append(key)
         if key in self._cache:
             del self._cache[key]
+
+    def get_cached_data_with_strategy(self, key: str, data_type: str = 'default') -> Optional[Any]:
+        """Mock of CacheManager.get_cached_data_with_strategy (src/cache_manager.py).
+
+        The real method picks a max_age/memory_ttl strategy per data_type
+        (and extends it during market-closed hours for market data) before
+        delegating to get_cached_data(). None of that timing nuance matters
+        for a mock -- plugins under test just need the method to exist and
+        return whatever was cached, so this delegates straight to get().
+        """
+        self.get_cached_data_with_strategy_calls.append({'key': key, 'data_type': data_type})
+        return self.get(key)
+
+    def save_cache(self, key: str, data: Any) -> None:
+        """Mock of CacheManager.save_cache (src/cache_manager.py) -- the
+        write-side counterpart to get_cached_data_with_strategy, used by the
+        same real-CacheManager-oriented plugins. Delegates to set()."""
+        self.set(key, data)
         if key in self._cache_timestamps:
             del self._cache_timestamps[key]
     

--- a/test/test_testing_mocks.py
+++ b/test/test_testing_mocks.py
@@ -37,3 +37,9 @@ class TestMockCacheManagerStrategyMethod:
         cm = MockCacheManager()
         cm.save_cache("standings_nfl", {"teams": ["KC", "BUF"]})
         assert cm.get_cached_data_with_strategy("standings_nfl") == {"teams": ["KC", "BUF"]}
+
+    def test_reset_clears_strategy_call_tracking(self):
+        cm = MockCacheManager()
+        cm.get_cached_data_with_strategy("k", "sports_live")
+        cm.reset()
+        assert cm.get_cached_data_with_strategy_calls == []

--- a/test/test_testing_mocks.py
+++ b/test/test_testing_mocks.py
@@ -1,0 +1,39 @@
+"""
+Unit tests for src/plugin_system/testing/mocks.py.
+
+MockCacheManager/MockPluginManager stand in for the real production
+managers under the plugin safety harness -- a missing method here isn't a
+harness bug in the abstract, it's a plugin silently failing to render
+under test (confirmed on ledmatrix-leaderboard, which calls
+get_cached_data_with_strategy() and previously hit an AttributeError that
+its own broad except swallowed, producing an empty-but-green render).
+"""
+
+from src.plugin_system.testing.mocks import MockCacheManager
+
+
+class TestMockCacheManagerStrategyMethod:
+    def test_get_cached_data_with_strategy_returns_cached_value(self):
+        cm = MockCacheManager()
+        cm.set("standings_nfl", {"teams": ["KC", "BUF"]})
+        result = cm.get_cached_data_with_strategy("standings_nfl", "sports_live")
+        assert result == {"teams": ["KC", "BUF"]}
+
+    def test_get_cached_data_with_strategy_returns_none_when_missing(self):
+        cm = MockCacheManager()
+        assert cm.get_cached_data_with_strategy("missing_key") is None
+
+    def test_get_cached_data_with_strategy_defaults_data_type(self):
+        cm = MockCacheManager()
+        cm.set("k", "v")
+        assert cm.get_cached_data_with_strategy("k") == "v"
+
+    def test_calls_are_tracked(self):
+        cm = MockCacheManager()
+        cm.get_cached_data_with_strategy("k", "sports_live")
+        assert cm.get_cached_data_with_strategy_calls == [{"key": "k", "data_type": "sports_live"}]
+
+    def test_save_cache_is_readable_via_strategy_lookup(self):
+        cm = MockCacheManager()
+        cm.save_cache("standings_nfl", {"teams": ["KC", "BUF"]})
+        assert cm.get_cached_data_with_strategy("standings_nfl") == {"teams": ["KC", "BUF"]}


### PR DESCRIPTION
## Summary
- `ledmatrix-leaderboard`'s `data_fetcher.py` calls `cache_manager.get_cached_data_with_strategy()` and `cache_manager.save_cache()` — both real methods on `src/cache_manager.py` (lines 817 and 313) — but `MockCacheManager` implemented neither.
- Every harness/CI render of this plugin hit `AttributeError` inside `update()`, caught by the plugin's own broad `except Exception`, logged, and silently produced an empty-but-`PASS`ing leaderboard — never actually exercising real standings data under test.
- Added both methods to `MockCacheManager`, delegating to the mock's existing `get()`/`set()` (a mock doesn't need the real strategy's per-data-type max_age/market-hours timing logic — plugins under test just need the methods to exist and round-trip cached values).

## Test plan
- New `test/test_testing_mocks.py` — 5 unit tests for both new methods.
- `pytest test/plugins/test_plugin_matrix.py` (deselecting the independently rate-limited `f1-scoreboard`) — 23 passed, no regressions.
- Manually confirmed `check_plugin.py --plugin ledmatrix-leaderboard --sizes 192x48` no longer logs any `AttributeError`/cache errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded cache behavior support for plugin testing, including strategy-based lookups and cache-saving operations.
  * Added call tracking for strategy-based cache requests.

* **Tests**
  * Added coverage for cached values, missing keys, default data types, call tracking, and saved-cache retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->