### PR TITLE
Fix PermissionError reading config_secrets.json in web interface

### DIFF
--- a/src/common/permission_utils.py
+++ b/src/common/permission_utils.py
@@ -146,6 +146,60 @@ def ensure_file_permissions(path: Path, mode: int = 0o644) -> None:
         raise
 
 
+_shared_group_gid_cache: Optional[int] = None
+
+
+def get_shared_group_gid() -> Optional[int]:
+    """
+    Return the gid that should own config/secrets files shared between the
+    root-run ``ledmatrix.service`` (main display) and the non-root user that
+    ``ledmatrix-web.service`` runs as (see install_web_service.sh, which sets
+    ``User=$SUDO_USER``).
+
+    Resolved once from the project root directory's current group (normally
+    the login user's group from the initial ``git clone``), since that user
+    is stable across reinstalls unlike any single file's ownership.
+
+    Returns:
+        The gid, or None if it cannot be determined.
+    """
+    global _shared_group_gid_cache
+    if _shared_group_gid_cache is not None:
+        return _shared_group_gid_cache
+    try:
+        project_root = Path(__file__).resolve().parent.parent.parent
+        _shared_group_gid_cache = project_root.stat().st_gid
+        return _shared_group_gid_cache
+    except OSError:
+        return None
+
+
+def ensure_shared_group_ownership(path: Path) -> None:
+    """
+    Best-effort chgrp of ``path`` to the shared group (see
+    :func:`get_shared_group_gid`) when running as root.
+
+    Only root can change a file's group to one the calling process isn't a
+    member of, which is exactly the case that causes the web interface
+    (running as a non-root user) to get ``PermissionError`` reading files
+    the root-run display service just wrote with a 0o640/2775 mode: the mode
+    is group-readable, but without this the group is root's, not the web
+    user's. Silently does nothing if not running as root or on any error —
+    this is a hardening step, not a required one.
+    """
+    if os.geteuid() != 0:
+        return
+    gid = get_shared_group_gid()
+    if gid is None:
+        return
+    try:
+        if path.exists() and path.stat().st_gid != gid:
+            os.chown(path, -1, gid)
+            logger.debug(f"Set shared group ownership (gid {gid}) on {path}")
+    except OSError as e:
+        logger.debug(f"Could not set shared group ownership on {path}: {e}")
+
+
 def get_config_file_mode(file_path: Path) -> int:
     """
     Return appropriate permission mode for config files.

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -38,6 +38,7 @@ from src.config_manager_atomic import (
 from src.common.permission_utils import (
     ensure_directory_permissions,
     ensure_file_permissions,
+    ensure_shared_group_ownership,
     get_config_file_mode,
     get_config_dir_mode
 )
@@ -234,6 +235,11 @@ class ConfigManager:
 
             # Load and merge secrets if they exist (be permissive on errors)
             if os.path.exists(self.secrets_path):
+                # Self-heal stale group ownership (e.g. the root-run display
+                # service wrote this file before the web user was granted
+                # group access) before every load attempt; no-op unless
+                # running as root and the group is already wrong.
+                ensure_shared_group_ownership(Path(self.secrets_path))
                 try:
                     with open(self.secrets_path, 'r') as f:
                         secrets = json.load(f)
@@ -363,6 +369,7 @@ class ConfigManager:
         # Set proper file permissions after creation
         config_path_obj = Path(self.config_path)
         ensure_file_permissions(config_path_obj, get_config_file_mode(config_path_obj))
+        ensure_shared_group_ownership(config_path_obj)
         
         self.logger.info(f"Created config.json from template at {os.path.abspath(self.config_path)}")
 
@@ -475,6 +482,11 @@ class ConfigManager:
             self.logger.error(error_msg)
             raise ConfigError(error_msg, config_path=path_to_load)
 
+        if file_type == "secrets":
+            # Best-effort self-heal: no-op unless running as root and the
+            # group is stale (see load_config for why this can happen).
+            ensure_shared_group_ownership(Path(path_to_load))
+
         try:
             with open(path_to_load, 'r') as f:
                 return json.load(f)
@@ -482,7 +494,18 @@ class ConfigManager:
             error_msg = f"Error parsing {file_type} configuration file: {path_to_load}"
             self.logger.error(error_msg, exc_info=True)
             raise ConfigError(error_msg, config_path=path_to_load) from e
-        except (IOError, OSError, PermissionError) as e:
+        except PermissionError as e:
+            if file_type == "secrets":
+                # Match load_config()'s tolerance: a secrets file the web
+                # process can't read (e.g. written 0640 by the root-run
+                # display service before the group was fixed up) shouldn't
+                # 500 the settings page — degrade to "no secrets" instead.
+                self.logger.warning(f"Secrets file not readable ({path_to_load}): {e}. Returning empty secrets.")
+                return {}
+            error_msg = f"Error loading {file_type} configuration file {path_to_load}: {str(e)}"
+            self.logger.error(error_msg, exc_info=True)
+            raise ConfigError(error_msg, config_path=path_to_load) from e
+        except (IOError, OSError) as e:
             error_msg = f"Error loading {file_type} configuration file {path_to_load}: {str(e)}"
             self.logger.error(error_msg, exc_info=True)
             raise ConfigError(error_msg, config_path=path_to_load) from e
@@ -539,6 +562,7 @@ class ConfigManager:
                 # Ensure final file has correct permissions
                 try:
                     ensure_file_permissions(path_obj, file_mode)
+                    ensure_shared_group_ownership(path_obj)
                 except OSError as perm_error:
                     # If we can't set permissions but file was written, log warning but don't fail
                     self.logger.warning(

--- a/src/config_manager_atomic.py
+++ b/src/config_manager_atomic.py
@@ -17,6 +17,7 @@ from enum import Enum
 
 from src.exceptions import ConfigError
 from src.logging_config import get_logger
+from src.common.permission_utils import ensure_shared_group_ownership
 
 
 class SaveResultStatus(Enum):
@@ -410,6 +411,13 @@ class AtomicConfigManager:
             # This is important because temp files may have different permissions
             # and we need root service to be able to read config.json
             os.chmod(destination, target_mode)
+
+            # Also fix group ownership when this save is running as root
+            # (the display service): 0o640 alone only helps the non-root web
+            # user read a root-written secrets file if its group already
+            # matches the web user's group, which isn't guaranteed. See
+            # permission_utils.ensure_shared_group_ownership for why.
+            ensure_shared_group_ownership(destination)
             
         except Exception as e:
             raise ConfigError(f"Error during atomic move: {e}") from e


### PR DESCRIPTION
## Summary

`ledmatrix.service` (main display) runs as `root`, while `ledmatrix-web.service` runs as the non-root install user (see `install_web_service.sh`, which templates `User=${ACTUAL_USER}`). `config/config_secrets.json` was only ever `chmod`'d to `0o640` on write, never `chgrp`'d, so when the root-run display service created/rewrote the file it ended up group-owned by `root` — unreadable by the non-root web user. That produced the reported `PermissionError: [Errno 13] Permission denied: 'config/config_secrets.json'` and a raw 500 traceback out of `pages_v3.py`'s settings page (`get_raw_file_content('secrets')`).

## Type of change

- [x] Bug fix

## Related issues

N/A

## Changes

- `src/common/permission_utils.py`: added `get_shared_group_gid()` (resolves the project root directory's owning gid — stable across reinstalls) and `ensure_shared_group_ownership()` (best-effort `chgrp` to that gid, root-only, no-op otherwise).
- `src/config_manager.py`: calls the new helper after every secrets/config write (`save_raw_file_content`, `_create_config_from_template`) and self-heals stale group ownership on every `load_config()`/`get_raw_file_content()` call, so a previously-broken install repairs itself the next time the root-run service touches the file.
- `src/config_manager_atomic.py`: same `chgrp` fix in `_atomic_move`, the atomic save path used by the settings UI.
- `src/config_manager.py`: `get_raw_file_content('secrets')` now tolerates `PermissionError` the same way `load_config()` already does — degrades to `{}` with a warning log instead of raising `ConfigError`/500, so a still-unreadable file (e.g. before the root service next runs the self-heal) no longer crashes the settings page.

## Test plan

- [x] Ran the test suite (`pytest`) — n/a subset touching these files has no existing coverage; verified with `python3 -m py_compile` on the changed modules (sandbox lacks `pytest`/`PIL`)
- [ ] Ran on a real Raspberry Pi with hardware
- [ ] Ran in emulator mode
- [ ] Ran the dev preview server
- [ ] Manually verified the affected code path in the web UI

## Documentation

- [x] N/A — no docs needed

## Plugin compatibility

- [x] N/A — change doesn't touch the plugin system

## Checklist

- [x] I've not committed any secrets or hardcoded API keys

## Notes for reviewer

This is a best-effort self-heal, not a hard guarantee: it only fixes ownership when the *root*-run process (`ledmatrix.service`) touches the file (root can `chown` to any group; the non-root web process cannot). If a user's install never restarts/reloads the root service, an already-broken `config_secrets.json` stays unreadable to the web UI until it does — but the settings page will no longer crash, it'll just show empty secrets in the meantime.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ULHgT822KCdNx5Ji4iCehX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reading and saving configuration and secrets files.
  * Automatically corrects file ownership when permissions drift, helping services maintain access.
  * Configuration updates now handle unreadable secrets files more gracefully.
  * Atomic saves preserve the appropriate shared ownership settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->