### PR TITLE
fix(web): don't validate double-sided settings when the feature is disabled

### DIFF
--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -225,6 +225,27 @@ class TestConfigAPI:
         assert 'chain length' in response.get_json()['message']
         mock_config_manager.save_config_atomic.assert_not_called()
 
+    def test_save_double_sided_vertical_checks_parallel(self, client, mock_config_manager):
+        """The vertical axis is checked against parallel, not chain_length."""
+        mock_config_manager.load_config.return_value['display']['hardware'] = {
+            'chain_length': 2, 'parallel': 3,
+        }
+
+        response = client.post(
+            '/api/v3/config/main',
+            data={
+                'double_sided_enabled': 'true',
+                'double_sided_copies': '2',
+                'double_sided_axis': 'vertical',
+            },
+            content_type='application/x-www-form-urlencoded',
+        )
+
+        # chain_length 2 would divide evenly — only parallel 3 rejects this.
+        assert response.status_code == 400
+        assert 'parallel' in response.get_json()['message']
+        mock_config_manager.save_config_atomic.assert_not_called()
+
     def test_save_double_sided_disabled_ignores_bad_values(self, client, mock_config_manager):
         """While disabled, unusable copies/axis are dropped rather than rejected."""
         mock_config_manager.load_config.return_value['display']['double_sided'] = {

--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -146,6 +146,11 @@ class TestConfigAPI:
 
     def test_save_double_sided_settings(self, client, mock_config_manager):
         """Double-sided form fields are persisted under display.double_sided."""
+        # 2 copies on the vertical axis needs parallel to be a multiple of 2.
+        mock_config_manager.load_config.return_value['display']['hardware'] = {
+            'chain_length': 2, 'parallel': 2,
+        }
+
         response = client.post(
             '/api/v3/config/main',
             data={
@@ -174,6 +179,70 @@ class TestConfigAPI:
         ds = mock_config_manager.save_config_atomic.call_args[0][0]['display']['double_sided']
         assert ds['enabled'] is False
         assert ds['copies'] == 4
+
+    def test_save_double_sided_disabled_skips_divisibility_check(self, client, mock_config_manager):
+        """A copies/chain_length mismatch must not block saves while disabled.
+
+        The Display form posts copies/axis on every save, so validating them
+        with the feature off locked users out of every other display setting.
+        """
+        mock_config_manager.load_config.return_value['display']['hardware'] = {
+            'chain_length': 3, 'parallel': 1,
+        }
+
+        response = client.post(
+            '/api/v3/config/main',
+            data={
+                'double_sided_copies': '2',
+                'double_sided_axis': 'horizontal',
+                'brightness': '75',
+            },
+            content_type='application/x-www-form-urlencoded',
+        )
+
+        assert response.status_code == 200
+        ds = mock_config_manager.save_config_atomic.call_args[0][0]['display']['double_sided']
+        assert ds['enabled'] is False
+        assert ds['copies'] == 2
+
+    def test_save_double_sided_enabled_enforces_divisibility(self, client, mock_config_manager):
+        """The same mismatch is still rejected once the feature is turned on."""
+        mock_config_manager.load_config.return_value['display']['hardware'] = {
+            'chain_length': 3, 'parallel': 1,
+        }
+
+        response = client.post(
+            '/api/v3/config/main',
+            data={
+                'double_sided_enabled': 'true',
+                'double_sided_copies': '2',
+                'double_sided_axis': 'horizontal',
+            },
+            content_type='application/x-www-form-urlencoded',
+        )
+
+        assert response.status_code == 400
+        assert 'chain length' in response.get_json()['message']
+        mock_config_manager.save_config_atomic.assert_not_called()
+
+    def test_save_double_sided_disabled_ignores_bad_values(self, client, mock_config_manager):
+        """While disabled, unusable copies/axis are dropped rather than rejected."""
+        mock_config_manager.load_config.return_value['display']['double_sided'] = {
+            'enabled': True, 'copies': 2, 'axis': 'horizontal',
+        }
+
+        response = client.post(
+            '/api/v3/config/main',
+            data={'double_sided_copies': 'abc', 'double_sided_axis': 'diagonal'},
+            content_type='application/x-www-form-urlencoded',
+        )
+
+        assert response.status_code == 200
+        ds = mock_config_manager.save_config_atomic.call_args[0][0]['display']['double_sided']
+        assert ds['enabled'] is False
+        # Stored values left untouched rather than overwritten with junk.
+        assert ds['copies'] == 2
+        assert ds['axis'] == 'horizontal'
 
     def test_save_double_sided_invalid_copies_rejected(self, client, mock_config_manager):
         """copies < 2 is rejected with a 400 before any save."""

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -13,7 +13,7 @@ import uuid
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from urllib.parse import urlparse, urlunparse
 
 logger = logging.getLogger(__name__)
@@ -871,7 +871,7 @@ def save_main_config():
             enabled = _coerce_to_bool(data.get('double_sided_enabled'))
             ds_config['enabled'] = enabled
 
-            def _copies_fits_hardware(copies):
+            def _copies_fits_hardware(copies: int) -> Optional[str]:
                 """Error message if copies doesn't divide the panel evenly, else None."""
                 # Use axis from this request if provided, else from stored config.
                 hw = current_config.get('display', {}).get('hardware', {})

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -864,16 +864,15 @@ def save_main_config():
             ds_config = current_config['display']['double_sided']
 
             # Enabled checkbox: omitted from the form when unchecked.
-            ds_config['enabled'] = _coerce_to_bool(data.get('double_sided_enabled'))
+            # The Display form posts copies/axis on every save regardless of this
+            # checkbox, so when the feature is off we accept the values without
+            # rejecting the whole save — otherwise a stale copies/chain_length
+            # mismatch locks the user out of every other display setting.
+            enabled = _coerce_to_bool(data.get('double_sided_enabled'))
+            ds_config['enabled'] = enabled
 
-            if 'double_sided_copies' in data and data['double_sided_copies'] not in ('', None):
-                try:
-                    copies = int(data['double_sided_copies'])
-                except (ValueError, TypeError):
-                    return jsonify({'status': 'error', 'message': "Double-sided copies must be an integer"}), 400
-                if not (2 <= copies <= 8):
-                    return jsonify({'status': 'error', 'message': "Double-sided copies must be between 2 and 8"}), 400
-                # Validate divisibility against the relevant hardware dimension.
+            def _copies_fits_hardware(copies):
+                """Error message if copies doesn't divide the panel evenly, else None."""
                 # Use axis from this request if provided, else from stored config.
                 hw = current_config.get('display', {}).get('hardware', {})
                 effective_axis = (data.get('double_sided_axis')
@@ -881,18 +880,41 @@ def save_main_config():
                 if effective_axis == 'horizontal':
                     chain_length = int(hw.get('chain_length', 2) or 2)
                     if chain_length % copies != 0:
-                        return jsonify({'status': 'error', 'message': f"Double-sided copies ({copies}) must divide chain length ({chain_length}) evenly"}), 400
+                        return f"Double-sided copies ({copies}) must divide chain length ({chain_length}) evenly"
                 elif effective_axis == 'vertical':
                     parallel = int(hw.get('parallel', 1) or 1)
                     if parallel % copies != 0:
-                        return jsonify({'status': 'error', 'message': f"Double-sided copies ({copies}) must divide parallel ({parallel}) evenly"}), 400
-                ds_config['copies'] = copies
+                        return f"Double-sided copies ({copies}) must divide parallel ({parallel}) evenly"
+                return None
+
+            if 'double_sided_copies' in data and data['double_sided_copies'] not in ('', None):
+                copies = None
+                try:
+                    copies = int(data['double_sided_copies'])
+                except (ValueError, TypeError):
+                    if enabled:
+                        return jsonify({'status': 'error', 'message': "Double-sided copies must be an integer"}), 400
+                if copies is not None and not (2 <= copies <= 8):
+                    if enabled:
+                        return jsonify({'status': 'error', 'message': "Double-sided copies must be between 2 and 8"}), 400
+                    # Disabled: leave the stored value alone rather than writing junk.
+                    copies = None
+                if copies is not None:
+                    # Divisibility is a hardware-relational check — only meaningful
+                    # when the feature is actually on.
+                    if enabled:
+                        fit_error = _copies_fits_hardware(copies)
+                        if fit_error:
+                            return jsonify({'status': 'error', 'message': fit_error}), 400
+                    ds_config['copies'] = copies
 
             if 'double_sided_axis' in data:
                 axis = data['double_sided_axis']
                 if axis not in ('horizontal', 'vertical'):
-                    return jsonify({'status': 'error', 'message': "Double-sided axis must be 'horizontal' or 'vertical'"}), 400
-                ds_config['axis'] = axis
+                    if enabled:
+                        return jsonify({'status': 'error', 'message': "Double-sided axis must be 'horizontal' or 'vertical'"}), 400
+                else:
+                    ds_config['axis'] = axis
 
         # Handle Vegas scroll mode settings
         vegas_fields = ['vegas_scroll_enabled', 'vegas_scroll_speed', 'vegas_separator_width',

--- a/web_interface/templates/v3/partials/display.html
+++ b/web_interface/templates/v3/partials/display.html
@@ -30,7 +30,7 @@
           hx-ext="json-enc"
           hx-headers='{"Content-Type": "application/json"}'
           hx-swap="none"
-          hx-on:htmx:after-request="showNotification(event.detail.xhr.responseJSON?.message || 'Display settings saved', event.detail.xhr.responseJSON?.status || 'success')"
+          hx-on:htmx:after-request="showDisplaySaveResult(event.detail.xhr)"
           class="space-y-6"
           novalidate
           onsubmit="fixInvalidNumberInputs(this); return true;">
@@ -475,22 +475,26 @@
             <h3 class="text-md font-medium text-gray-900 mb-1">Double-Sided Display</h3>
             <p class="text-sm text-gray-600 mb-4">Show the same content on every panel in the chain &mdash; e.g. two 64&times;32 panels mirrored, or four panels as two identical screens. Rendered once and duplicated, so it adds no extra CPU. Takes effect after a display restart.</p>
 
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div class="form-group" id="setting-display-double_sided_enabled" data-setting-key="display.double_sided.enabled">
-                    <label class="flex items-center gap-2">
-                        <input type="checkbox"
-                               id="double_sided_enabled"
-                               name="double_sided_enabled"
-                               value="true"
-                               {% if main_config.display.get('double_sided', {}).get('enabled') %}checked{% endif %}
-                               class="form-control h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
-                        <span class="text-sm font-medium text-gray-700">Enabled</span>
-                        {{ ui.help_tip('Show the same content mirrored across every panel in the chain.\nRendered once and duplicated, so it adds no extra CPU. Takes effect after a display restart.', 'Double-Sided Enabled') }}
-                    </label>
-                </div>
+            <div class="form-group mb-4" id="setting-display-double_sided_enabled" data-setting-key="display.double_sided.enabled">
+                <label class="flex items-center gap-2">
+                    <input type="checkbox"
+                           id="double_sided_enabled"
+                           name="double_sided_enabled"
+                           value="true"
+                           {% if main_config.display.get('double_sided', {}).get('enabled') %}checked{% endif %}
+                           class="form-control h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
+                    <span class="text-sm font-medium text-gray-700">Enabled</span>
+                    {{ ui.help_tip('Show the same content mirrored across every panel in the chain.\nRendered once and duplicated, so it adds no extra CPU. Takes effect after a display restart.', 'Double-Sided Enabled') }}
+                </label>
+            </div>
 
+            <!-- Hidden (not disabled) when the feature is off, so the values are
+                 still submitted and round-trip through a save. -->
+            <div id="double_sided_settings"
+                 class="grid grid-cols-1 md:grid-cols-2 gap-4"
+                 {% if not main_config.display.get('double_sided', {}).get('enabled') %}style="display: none;"{% endif %}>
                 <div class="form-group" id="setting-display-double_sided_copies" data-setting-key="display.double_sided.copies">
-                    <label for="double_sided_copies" class="block text-sm font-medium text-gray-700">Copies{{ ui.help_tip('How many identical screens to split the panel area into (2–8).\nMust divide the panel evenly — e.g. 2 for a two-sided cube.', 'Copies') }}</label>
+                    <label for="double_sided_copies" class="block text-sm font-medium text-gray-700">Copies{{ ui.help_tip('How many identical screens to split the panel area into (2–8).\nWhen enabled, this must divide the panel evenly — e.g. 2 for a two-sided cube.', 'Copies') }}</label>
                     <input type="number"
                            id="double_sided_copies"
                            name="double_sided_copies"
@@ -607,6 +611,22 @@ if (typeof window.fixInvalidNumberInputs !== 'function') {
     };
 }
 
+// Report the outcome of a display-settings save. XMLHttpRequest has no
+// `responseJSON` (that's a jQuery property) — read `responseText` and the real
+// status code, otherwise a failed save reports success.
+window.showDisplaySaveResult = function(xhr) {
+    let message = 'Display settings saved';
+    let status = xhr.status >= 400 ? 'error' : 'success';
+    try {
+        const data = JSON.parse(xhr.responseText);
+        if (data.message) message = data.message;
+        if (data.status) status = data.status;
+    } catch {
+        // Non-JSON body — fall back to the status-code verdict above.
+    }
+    showNotification(message, status);
+};
+
 // Vegas Scroll Mode Settings
 (function() {
     // Escape HTML to prevent XSS
@@ -628,6 +648,18 @@ if (typeof window.fixInvalidNumberInputs !== 'function') {
     if (vegasEnabledCheckbox && vegasSettings) {
         vegasEnabledCheckbox.addEventListener('change', function() {
             vegasSettings.style.display = this.checked ? 'block' : 'none';
+        });
+    }
+
+    // Double-sided: copies/axis only mean anything while the feature is on.
+    // Hidden rather than disabled so the fields keep submitting and the server
+    // still sees an 'off' state to persist.
+    const doubleSidedCheckbox = document.getElementById('double_sided_enabled');
+    const doubleSidedSettings = document.getElementById('double_sided_settings');
+
+    if (doubleSidedCheckbox && doubleSidedSettings) {
+        doubleSidedCheckbox.addEventListener('change', function() {
+            doubleSidedSettings.style.display = this.checked ? 'grid' : 'none';
         });
     }
 

--- a/web_interface/templates/v3/partials/display.html
+++ b/web_interface/templates/v3/partials/display.html
@@ -615,12 +615,18 @@ if (typeof window.fixInvalidNumberInputs !== 'function') {
 // `responseJSON` (that's a jQuery property) — read `responseText` and the real
 // status code, otherwise a failed save reports success.
 window.showDisplaySaveResult = function(xhr) {
-    let message = 'Display settings saved';
-    let status = xhr.status >= 400 ? 'error' : 'success';
+    // Only 2xx counts as saved. A network failure reports status 0, which any
+    // `>= 400` test would wave through as success.
+    const httpSuccess = xhr.status >= 200 && xhr.status < 300;
+    let message = httpSuccess
+        ? 'Display settings saved'
+        : 'Display settings were not saved. Check your connection and try again.';
+    let status = httpSuccess ? 'success' : 'error';
     try {
         const data = JSON.parse(xhr.responseText);
         if (data.message) message = data.message;
-        if (data.status) status = data.status;
+        // A body can refine a successful verdict but never overturn a failed one.
+        if (httpSuccess && data.status) status = data.status;
     } catch {
         // Non-JSON body — fall back to the status-code verdict above.
     }


### PR DESCRIPTION
# Pull Request

## Summary

Saving anything on the Display tab failed with a `400 Double-sided copies (2) must divide chain length (3) evenly` while double-sided mode was **off**. The Display form posts every field in one request — including `double_sided_copies` (default `2`) and `double_sided_axis` — regardless of the Enabled checkbox, and the server block was gated only on *"is any double-sided field present in the payload"*: it **wrote** `ds_config['enabled']` but never **read** it. A user with `chain_length: 3` and the untouched default `copies: 2` was locked out of saving *any* display setting — brightness, GPIO slowdown, Vegas, sync. This gates the checks on the enabled flag and tidies up two related UI problems visible in the same console log.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor (no functional change)
- [ ] Build / CI
- [ ] Plugin work (link to the plugin)

## Related issues

None filed — reported directly with the browser console output showing the 400 alongside a green "Display settings saved" toast.

## What changed

**`web_interface/blueprints/api_v3.py`** — read `enabled` first, then branch:

- **Divisibility** against `chain_length` / `parallel` is a hardware-relational check and now only runs when the feature is on. This is the check that produced the reported error.
- **Structural** checks (copies parses as an `int` in 2–8, axis in the whitelist) still return 400 when enabled. When disabled they drop the offending value and leave the stored one untouched, so the save succeeds and the config stays well-formed.
- Error message strings and the `effective_axis` resolution are unchanged; the two divisibility branches moved into a small local helper returning the message or `None`.

The runtime was already correct — `_resolve_double_sided()` returns `None` immediately when disabled (`src/display_manager.py:109`), so nothing is composited or wrapped. No change there.

**`web_interface/templates/v3/partials/display.html`**

- Copies / Split Axis are hidden until Enabled is ticked, mirroring the existing Vegas Scroll Mode toggle. Hidden rather than `disabled` on purpose: `disabled` inputs aren't submitted, and if all three keys vanished from the payload the server block would be skipped entirely and a previously-enabled config would never be flipped to `false`.
- Fixed the save toast. The form's handler read `xhr.responseJSON` — a jQuery property that does not exist on a native `XMLHttpRequest` — so it was always `undefined` and every save fired a green "Display settings saved", including the 400s. It now parses `responseText` and uses the real status code.

## Test plan

- [ ] Ran on a real Raspberry Pi with hardware
- [ ] Ran in emulator mode (`EMULATOR=true python3 run.py`)
- [ ] Ran the dev preview server (`scripts/dev_server.py`)
- [x] Ran the test suite (`pytest`)
- [ ] Manually verified the affected code path in the web UI

`pytest test/ --ignore=test/plugins` → **1071 passed, 1 skipped**. Two failures in `test/web_interface/test_state_reconciliation.py` are pre-existing — they fail identically on a clean checkout of `main`.

Two existing double-sided tests were asserting `200` on payloads that the divisibility check (added later, in #373) turns into `400`s, so they were failing before this change:

- `test_save_double_sided_settings` posted `copies=2, axis=vertical` against a fixture with no `display.hardware`, so `parallel` fell back to `1` and `1 % 2 != 0`. It now supplies matching hardware values in the test rather than editing the shared fixture.
- `test_save_double_sided_unchecked_disables` posted `copies=4` with `chain_length` defaulting to `2`. It passes as written now that a disabled save skips the check.

Added three tests: the reported regression (disabled + `copies=2` + `chain_length=3` → 200), unparseable/unknown values while disabled (→ 200, stored values untouched), and the check still firing when enabled (→ 400).

Not automated, worth a manual pass: toggling the Enabled checkbox shows/hides the two fields, and a failed save now shows a single red toast with no accompanying green one.

## Documentation

- [ ] I updated `README.md` if user-facing behavior changed
- [ ] I updated the relevant doc in `docs/` if developer behavior changed
- [ ] I added/updated docstrings on new public functions
- [x] N/A — no docs needed

## Plugin compatibility

- [x] No plugin breakage expected
- [ ] Some plugins will need updates — listed below
- [ ] N/A — change doesn't touch the plugin system

Plugins see the logical per-screen size through `_LogicalMatrix`, and that path is unchanged.

## Checklist

- [x] My commits follow the message convention in `CONTRIBUTING.md`
- [x] I read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] I've not committed any secrets or hardcoded API keys
- [x] If this adds a new config key, the form in the web UI was verified — no new keys; `display.double_sided` is unchanged in shape

## Notes for reviewer

**Two divisibility rules disagree, and I left them that way.** The API validates against **panel counts** (`chain_length` / `parallel`) while the runtime validates against **physical pixels** (`cols*chain_length`, `rows*parallel`, `display_manager.py:128-143`). So `chain_length=3, copies=2` is rejected by the API but the runtime would accept it — 192 px / 2 gives a 96 px logical screen spanning 1.5 panels. The API's rule is the stricter and more physically meaningful one, so I kept both as they are, but it's worth a second opinion on whether they should be unified.

**The duplicate toast is still there.** `web_interface/static/v3/app.js:41-51` has a global `htmx:afterRequest` listener that already parses `responseText` correctly, so any response carrying a `message` now produces two toasts. Repairing the form handler in place rather than deleting it was a deliberate call — it's still the only thing that reports 2xx responses whose body has no `message` — but deleting it would collapse both toasts into one if you'd prefer that.

**The same `responseJSON` bug lives elsewhere.** `web_interface/templates/v3/partials/durations.html:14` has the identical handler, and `web_interface/static/v3/js/app-shell.js` reads `xhr.responseJSON` in four places. Left alone to keep this diff scoped to the reported issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_016aUvzTXpEYhNEWYQvFqQU9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer controls for enabling and configuring double-sided displays.
  * Double-sided settings are now shown or hidden automatically based on the selected option.

* **Bug Fixes**
  * Disabled double-sided mode no longer blocks saving because of invalid or mismatched settings.
  * Enabled mode now validates copies against the display’s hardware dimensions.
  * Invalid disabled-mode values no longer overwrite previously saved settings.
  * Improved save notifications for success and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->