### PR TITLE
fix(espn): send an identifying User-Agent so ESPN stops returning 403

### DIFF
--- a/src/base_classes/data_sources.py
+++ b/src/base_classes/data_sources.py
@@ -44,9 +44,16 @@ class DataSource(ABC):
         """Fetch standings for a sport/league."""
     
     def get_headers(self) -> Dict[str, str]:
-        """Get headers for API requests."""
+        """Get headers for API requests.
+
+        The agent carries the project URL deliberately. Around 2026-08-04 ESPN
+        began returning 403 for bare custom tokens like 'LEDMatrix/1.0' — and
+        for browser-style strings — while accepting an agent that identifies
+        the client and links to it. An Accept header alone does not rescue the
+        bare form when the request goes out through requests.
+        """
         return {
-            'User-Agent': 'LEDMatrix/1.0',
+            'User-Agent': 'LEDMatrix/1.0 (+https://github.com/ChuckBuilds/LEDMatrix)',
             'Accept': 'application/json'
         }
 

--- a/src/common/api_helper.py
+++ b/src/common/api_helper.py
@@ -56,7 +56,9 @@ class APIHelper:
         
         # Default headers
         self.session.headers.update({
-            'User-Agent': 'LEDMatrix-Common/1.0',
+            # Identifies the client and links to it: ESPN began 403ing bare
+            # custom tokens (and browser strings) around 2026-08-04.
+            'User-Agent': 'LEDMatrix/1.0 (+https://github.com/ChuckBuilds/LEDMatrix)',
             'Accept': 'application/json',
             'Accept-Language': 'en-US,en;q=0.9',
             'Accept-Encoding': 'gzip, deflate, br',


### PR DESCRIPTION
Around 11:00 EDT on 2026-08-04, ESPN's `site.api` began rejecting the User-Agent strings this repo sends. Every scoreboard that goes through the shared data sources returned `403 Client Error: Forbidden` — standings, game summaries and scoreboards alike. A device that had been running fine logged **287 ESPN errors** in a day.

## The filter is the opposite of the usual one

Probed `site.api` across agents and libraries, using `requests` as the plugins do:

| User-Agent | result |
| --- | --- |
| bare `LEDMatrix/1.0` | **403** (with or without `Accept`) |
| bare `LEDMatrix-Common/1.0` | **403** |
| browser string (Chrome/Safari) | **403** — no header rescues it |
| `LEDMatrix/1.0 (+https://github.com/ChuckBuilds/LEDMatrix)` | 200 |
| `requests` / `urllib` / `curl` defaults | 200 |

ESPN rejects browser-style strings outright and bare custom tokens, while accepting honest client tokens or an agent that identifies the client and links to it. The reflex fix — "send a browser User-Agent" — is now the one change guaranteed to stay blocked.

Confirmed independently: [ha-teamtracker#355](https://github.com/vasqued2/ha-teamtracker/pull/355) hit the same wall and switched from a browser agent to `curl/8.20.0` (merged 2026-08-05).

The library matters too, which is worth recording. Under `urllib`, a bare token plus an `Accept` header still returned 200; under `requests` it does not. The data sources here were already sending `Accept: application/json` and were still refused.

## The change

Two call sites sent a bare token:

- `src/base_classes/data_sources.py` — `LEDMatrix/1.0`, the agent behind the failing standings and summary calls
- `src/common/api_helper.py` — `LEDMatrix-Common/1.0`

Both now send an agent carrying the project URL. That form is accepted with or without `Accept`, on `/scoreboard`, `/standings` and `/summary`, and it gives ESPN a client to identify and contact rather than an anonymous token to rate-limit — which seems the likelier way to stay working than blending in as curl.

`LEDMatrix-Plugin-Manager/1.0` is left alone: it talks to the GitHub API, not ESPN.

## Verification

On a live 512x64 device, across a service restart:

- ESPN errors: **287 in the preceding day → 0**
- live MLB games fetching again (`mlb_live=True, MLB=4 live`)
- standings and game summaries no longer 403

## Companion PR

The plugins monorepo carries the same bug in 24 files across 14 plugins and needs to land too, otherwise plugins that bundle their own `data_sources.py` stay broken: ChuckBuilds/ledmatrix-plugins#254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Udr6MfaFLUPhX5Fgo67Jf5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated network request identification to include the project URL in the User-Agent.
  * Added documentation clarifying the client identification required for data-source requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->