### PR TITLE
fix(vegas): stop capping plugin width by default

### DIFF
--- a/config/config.template.json
+++ b/config/config.template.json
@@ -149,7 +149,7 @@
             "min_plugin_width": 8,
             "lead_in_width": 0,
             "plugins_per_cycle": 6,
-            "max_plugin_width_ratio": 3.0,
+            "max_plugin_width_ratio": 0.0,
             "overflow_mode": "rotate",
             "dynamic_duration_enabled": true,
             "min_cycle_duration": 60,

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -127,7 +127,7 @@ Read by `src/vegas_mode/config.py` (`VegasScrollConfig.from_config`). See
 | `min_plugin_width` | int, `8` |
 | `lead_in_width` | int, `0` |
 | `plugins_per_cycle` | int, `6` |
-| `max_plugin_width_ratio` | float, `3.0` |
+| `max_plugin_width_ratio` | float, `0.0` |
 | `overflow_mode` | string, `"rotate"` |
 | `dynamic_duration_enabled` | bool, `true` |
 | `min_cycle_duration` | int, `60` |

--- a/src/vegas_mode/config.py
+++ b/src/vegas_mode/config.py
@@ -104,10 +104,22 @@ class VegasModeConfig:
     overflow_mode: str = "rotate"
 
     # Cap on one plugin's share of a cycle, as a multiple of display width.
-    # A single ticker returning 7,000px would otherwise hold the panel for over
-    # two minutes. Overflow is deferred to later cycles rather than discarded.
-    # 0 disables the cap.
-    max_plugin_width_ratio: float = 3.0
+    # 0 (the default) disables the cap, so every plugin contributes all of its
+    # content and is always entered at its beginning.
+    #
+    # Capping was the default until it proved to cost more than it bought.
+    # Measured over a 17-plugin fleet on a 512px panel, only four plugins were
+    # ever wide enough to hit a 3.0 cap; for those four it produced two visible
+    # faults. Content resumed mid-item on each appearance (a news ticker entered
+    # at column 6027 of its own strip), and the final window of a rotation was
+    # whatever happened to be left — 348px of a 1840px stocks ticker, seven
+    # seconds of panel time. Both read as the display being broken rather than
+    # as deferral working.
+    #
+    # A wide plugin does hold the panel for a long time uncapped: set the cap
+    # per plugin with vegas_max_width_screens where that matters, rather than
+    # globally where it mostly hurts plugins that were never the problem.
+    max_plugin_width_ratio: float = 0.0
 
     # Plugin management
     plugin_order: List[str] = field(default_factory=list)
@@ -159,7 +171,7 @@ class VegasModeConfig:
             lead_in_width=int(vegas_config.get('lead_in_width', 0)),
             plugins_per_cycle=int(vegas_config.get('plugins_per_cycle', 6)),
             max_plugin_width_ratio=float(
-                vegas_config.get('max_plugin_width_ratio', 3.0)),
+                vegas_config.get('max_plugin_width_ratio', 0.0)),
             overflow_mode=str(vegas_config.get('overflow_mode', 'rotate')),
             plugin_order=list(vegas_config.get('plugin_order', [])),
             excluded_plugins=set(vegas_config.get('excluded_plugins', [])),

--- a/test/test_vegas_density.py
+++ b/test/test_vegas_density.py
@@ -781,6 +781,12 @@ class TestNewConfigKeys:
         assert cfg.render_width_pct == 100
         assert cfg.min_content_separation == 24
 
+    def test_width_cap_is_off_by_default(self):
+        # Capping made wide plugins resume mid-content on every appearance and
+        # emit runt final windows; it is now opt-in per plugin instead.
+        assert VegasModeConfig().max_plugin_width_ratio == 0.0
+        assert VegasModeConfig.from_config({}).max_plugin_width_ratio == 0.0
+
     @pytest.mark.parametrize('overrides,bad_key', [
         ({'render_width_pct': 5}, 'render_width_pct'),
         ({'render_width_pct': 101}, 'render_width_pct'),

--- a/test/test_vegas_density.py
+++ b/test/test_vegas_density.py
@@ -787,6 +787,14 @@ class TestNewConfigKeys:
         assert VegasModeConfig().max_plugin_width_ratio == 0.0
         assert VegasModeConfig.from_config({}).max_plugin_width_ratio == 0.0
 
+    def test_width_cap_is_still_available_when_asked_for(self):
+        # Defaulting the cap off must not remove it: a user who sets a ratio
+        # still gets one, and 0 still means uncapped.
+        cfg = VegasModeConfig.from_config(
+            {'display': {'vegas_scroll': {'max_plugin_width_ratio': 3.0}}})
+        assert cfg.max_plugin_width_ratio == 3.0
+        assert cfg.validate() == []
+
     @pytest.mark.parametrize('overrides,bad_key', [
         ({'render_width_pct': 5}, 'render_width_pct'),
         ({'render_width_pct': 101}, 'render_width_pct'),

--- a/web_interface/templates/v3/partials/display.html
+++ b/web_interface/templates/v3/partials/display.html
@@ -556,11 +556,11 @@
                         </div>
 
                         <div class="form-group" id="setting-display-vegas_max_plugin_width_ratio" data-setting-key="display.vegas_scroll.max_plugin_width_ratio">
-                            <label for="vegas_max_plugin_width_ratio" class="block text-sm font-medium text-gray-700">Max Plugin Width (screens){{ ui.help_tip('Caps how much of one cycle a single plugin may occupy, measured in screen widths (0–20).\nDefault: 3. A long ticker such as a news feed or leaderboard is trimmed to this and the remainder shown on later cycles, so one plugin cannot hold the display for minutes. Set 0 for no limit.', 'Max Plugin Width') }}</label>
+                            <label for="vegas_max_plugin_width_ratio" class="block text-sm font-medium text-gray-700">Max Plugin Width (screens){{ ui.help_tip('Caps how much of one cycle a single plugin may occupy, measured in screen widths (0–20).\nDefault: 0 (no limit) — every plugin shows all of its content and always starts at the beginning.\nSet a limit to stop one long ticker holding the display for minutes: it is cut to this width and the remainder shown on later cycles. The trade-off is that such a plugin then resumes mid-content on each appearance instead of starting fresh.', 'Max Plugin Width') }}</label>
                             <input type="number"
                                    id="vegas_max_plugin_width_ratio"
                                    name="vegas_max_plugin_width_ratio"
-                                   value="{{ main_config.display.get('vegas_scroll', {}).get('max_plugin_width_ratio', 3.0) }}"
+                                   value="{{ main_config.display.get('vegas_scroll', {}).get('max_plugin_width_ratio', 0.0) }}"
                                    min="0"
                                    max="20"
                                    step="0.5"


### PR DESCRIPTION
## Why

Vegas plugins read as "cut off early" or "starting in the middle". That is the per-plugin width budget in `plugin_adapter.py`, not the scroll engine — `overflow_mode=rotate` is *designed* to resume mid-content on each appearance, so the symptom was the feature working as specified.

Measured over a 17-plugin fleet on a 512px panel, the cap turned out to be a bad trade. Only four plugins were ever wide enough to hit the `3.0` default:

| Plugin | Content | Time @ 50px/s | vs 1536px cap |
|---|---|---|---|
| ledmatrix-leaderboard | 11,518px | 3m50s | over |
| news | 10,021px | 3m20s | over |
| odds-ticker | 4,643px | 1m33s | over |
| hockey-scoreboard | 1,508px | 30s | at the line |
| ledmatrix-weather | 650px | 13s | never touched |
| ledmatrix-flights | 512px | ~10s | never touched |
| 11 others | 87–1,104px | 2–22s | never touched |

So it bought nothing on thirteen plugins while costing two visible faults on four:

- **Content entered mid-item.** A news ticker started at column 6027 of its own strip.
- **The final rotation window was whatever was left.** An 1,840px stocks ticker against a 1,536px budget split 1,492 + **348px** — seven seconds of panel time before it cut.

## What changed

`max_plugin_width_ratio` defaults to `0` (uncapped), so every plugin contributes all of its content and is always entered at its beginning. Updated in the dataclass, the `from_config` fallback, `config.template.json`, `CONFIG_REFERENCE.md`, and the web UI's help text and fallback value.

The cap is unchanged and still available. `vegas_max_width_screens` still caps an individual plugin, which is where the knob belongs — a genuinely long ticker is a property of that plugin, not of the fleet.

## Verification

- `test_width_cap_is_off_by_default` added; **195 tests pass** across `test_vegas_density.py`, `test_vegas_continuous_refresh.py`, `test_vegas_render_pipeline_recompose.py`.
- Live on a 512px device: **327 budget crops in the preceding six hours, none after.**

## Not addressed here

Two defects in the capping path, now dormant at the default but live for anyone who sets a cap:

1. `_crop_to_budget` has no minimum window size, hence the 348px runt above.
2. The stored pixel offset is reused after a plugin re-renders at a different width (news went 9,793 → 9,505px mid-rotation), so the offset points at different content — breaking the "everything is seen eventually" promise for any ticker that refreshes.

Happy to follow up on those separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Udr6MfaFLUPhX5Fgo67Jf5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Vegas Scroll now allows plugin content to use unlimited width by default.
  * The “Max Plugin Width” setting and configuration documentation now clarify that `0.0` means unlimited width.
  * When a width limit is applied, content can continue through the middle of the display.

* **Tests**
  * Added coverage confirming the new unlimited-width default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->