### PR TITLE
fix(web): stop checkbox groups posting back options they cannot show

### DIFF
--- a/test/test_checkbox_group_stale_values.py
+++ b/test/test_checkbox_group_stale_values.py
@@ -1,0 +1,113 @@
+"""A checkbox group must not post back options it cannot show.
+
+The enum that lets the widget draw checkboxes is also what validates the
+saved value. When a league retires a team code -- OAK for the Athletics, ARI
+for the Coyotes -- or a schema drops an option, a config that still holds the
+old value has nothing to render for it. The value stayed in the hidden
+``_data`` input regardless, because that input is seeded from the stored array
+and only rebuilt by ``updateCheckboxGroupData()`` on change. Editing any other
+field on that plugin therefore posted the stale value back, the schema
+rejected it, and the save endpoint returned 400
+``CONFIG_VALIDATION_FAILED`` -- so the whole plugin became uneditable until
+the user worked out which invisible entry was at fault.
+
+Runtime was never affected: plugin loading treats schema violations as
+warn/degrade, and the stale code already matched no team. Only the web UI
+blocked.
+
+These tests render the checkbox-group block lifted *out of the shipped
+template*, following test_enum_option_labels.py, so they exercise the
+production expression rather than a copy that could drift from it.
+"""
+import json
+import re
+from pathlib import Path
+
+from jinja2 import DictLoader, Environment
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_FORM = (PROJECT_ROOT / 'web_interface' / 'templates' / 'v3' / 'partials'
+               / 'plugin_config.html')
+
+# The checkbox-group branch: from its `{% elif %}` guard through the sentinel
+# hidden input that closes it. Anchored on the guard so the match cannot run on
+# into a neighbouring widget branch.
+BLOCK_RE = re.compile(
+    r"\{%\s*elif x_widget == 'checkbox-group'\s*%\}(.*?)"
+    r"<input type=\"hidden\" name=\"\{\{ full_key \}\}\[\]\" value=\"\">",
+    re.S,
+)
+
+
+def _shipped_block() -> str:
+    """Return the live checkbox-group block lifted from plugin_config.html."""
+    source = CONFIG_FORM.read_text(encoding='utf-8')
+    match = BLOCK_RE.search(source)
+    assert match, (
+        'could not find the checkbox-group block in plugin_config.html — the '
+        'template changed shape and this guard needs updating'
+    )
+    block = match.group(1)
+    assert 'data-option-value' in block, 'extracted the wrong branch'
+    assert '{% elif' not in block, 'extraction ran past the checkbox-group branch'
+    return block
+
+
+def _render(prop: dict, value=None) -> str:
+    env = Environment(loader=DictLoader({'f': _shipped_block()}), autoescape=True)
+    return env.get_template('f').render(
+        prop=prop, value=value, field_id='fid', full_key='k'
+    )
+
+
+def _submitted(html: str) -> list:
+    """The array the form will actually post: the hidden _data input."""
+    match = re.search(r'id="fid_data"[^>]*\svalue=\'([^\']*)\'', html)
+    assert match, f'hidden _data input not found in:\n{html}'
+    return json.loads(match.group(1).replace('&#39;', "'"))
+
+
+def _checked(html: str) -> list:
+    return re.findall(r'data-option-value="([^"]+)"[^>]*checked', html)
+
+
+MLB = {'type': 'array', 'items': {'type': 'string', 'enum': ['NYY', 'BOS', 'ATH']},
+       'x-widget': 'checkbox-group'}
+
+
+def test_a_retired_code_is_not_posted_back() -> None:
+    """The regression: OAK became ATH, and OAK used to ride along on save."""
+    html = _render(MLB, ['NYY', 'OAK'])
+    assert _submitted(html) == ['NYY'], 'stale value would still be submitted'
+
+
+def test_the_dropped_value_is_named_rather_than_vanishing() -> None:
+    html = _render(MLB, ['NYY', 'OAK'])
+    assert 'OAK' in html
+    assert 'data-stale-options' in html
+
+
+def test_valid_values_are_untouched_and_still_checked() -> None:
+    html = _render(MLB, ['NYY', 'ATH'])
+    assert _submitted(html) == ['NYY', 'ATH']
+    assert sorted(_checked(html)) == ['ATH', 'NYY']
+    assert 'data-stale-options' not in html
+
+
+def test_an_all_stale_selection_clears_rather_than_blocking() -> None:
+    html = _render(MLB, ['OAK', 'SD'])
+    assert _submitted(html) == []
+
+
+def test_an_empty_enum_leaves_the_value_alone() -> None:
+    """No options means nothing to validate against — filtering would wipe it."""
+    prop = {'type': 'array', 'items': {'type': 'string'}, 'x-widget': 'checkbox-group'}
+    html = _render(prop, ['ANYTHING', 'GOES'])
+    assert _submitted(html) == ['ANYTHING', 'GOES']
+
+
+def test_unset_value_falls_back_to_the_default() -> None:
+    prop = dict(MLB, default=['BOS'])
+    html = _render(prop, None)
+    assert _submitted(html) == ['BOS']
+    assert _checked(html) == ['BOS']

--- a/web_interface/templates/v3/partials/plugin_config.html
+++ b/web_interface/templates/v3/partials/plugin_config.html
@@ -296,7 +296,27 @@
                 {% set enum_items = items_schema.get('enum') or [] %}
                 {% set x_options = prop.get('x-options') or {} %}
                 {% set labels = x_options.get('labels') or {} %}
-                
+                {# A saved value that is no longer one of the options -- a team
+                   code the league retired, an option dropped from the schema --
+                   has no checkbox to render, so it would sit unseen in the
+                   hidden input below and be posted back on save. The schema
+                   rejects it and the save endpoint returns 400, which blocks
+                   editing any other field on the plugin until the stale entry
+                   is found and removed. Drop them here instead, and say which,
+                   so the value is not lost silently. Only when the widget
+                   actually has options: an empty enum means nothing to check
+                   against, and filtering on it would wipe the field. #}
+                {% set stale_values = (array_value | reject('in', enum_items) | list) if enum_items else [] %}
+                {% set array_value = (array_value | select('in', enum_items) | list) if enum_items else array_value %}
+
+                {% if stale_values %}
+                <div class="mt-1 mb-2 rounded border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+                     data-stale-options="{{ field_id }}">
+                    No longer offered, and will be removed when you save:
+                    <span class="font-mono">{{ stale_values | join(', ') }}</span>.
+                </div>
+                {% endif %}
+
                 <div class="mt-1 space-y-2">
                     {% for option in enum_items %}
                     {% set is_checked = option in array_value %}


### PR DESCRIPTION
## The bug

The enum that lets a checkbox group draw its options is also what validates the saved value. When an option goes away — a league retires a team code, a schema drops a choice — a config still holding the old value has **no checkbox to render for it**, but the value stayed in the payload anyway.

The chain, in `plugin_config.html`:

1. The hidden `_data` input is seeded with the **stored** array, unfiltered:
   ```jinja
   <input type="hidden" id="{{ field_id }}_data" ... value='{{ (array_value|tojson|safe)... }}'>
   ```
2. `updateCheckboxGroupData()` rebuilds it from checked boxes — but only `onchange`.
3. So if the user doesn't touch that widget, the stale value posts back verbatim.
4. `api_v3.py` validates on save and returns **400 `CONFIG_VALIDATION_FAILED`**.

Net effect: a user with a retired code cannot save **any** change to that plugin — including edits to completely unrelated fields — and nothing on screen tells them why, because the offending value is precisely the one with no checkbox.

**Runtime was never affected.** `load_plugin()` treats schema violations as warn/degrade ("never blocks loading"), and a retired code already matched no team. Only the web UI blocked.

## The fix

Drop values that aren't in the enum before seeding the hidden input, and list them above the group so the selection isn't lost silently:

```jinja
{% set stale_values = (array_value | reject('in', enum_items) | list) if enum_items else [] %}
{% set array_value  = (array_value | select('in', enum_items) | list) if enum_items else array_value %}
```

Guarded on `enum_items` deliberately — an empty enum means there is nothing to validate against, and filtering on it would wipe the field.

## This is not hypothetical

Two ledmatrix-plugins PRs are this same failure mode, fixed one league at a time:

- **#212** — *"correct team abbreviations so config save no longer 400s"*: 11 codes across NFL/NBA/MLB/NHL rejected on save.
- **#234** — removed `UTA`, a retired NHL code, from a picker across four plugins.

Real codes that trip it today: `OAK` (Athletics, renamed 2025), `ARI` (Coyotes → Utah, 2024), `SD`/`STL` (NFL relocations), plus common non-ESPN spellings like `CWS`, `GSW`, `LAK`.

**Nine shipped plugins use `checkbox-group`** — baseball, basketball, football, hockey, f1, news, odds-ticker, ledmatrix-flights, jellyfin-now-playing — and all of them get the fix.

## Tests

`test/test_checkbox_group_stale_values.py` renders the checkbox-group block **lifted out of the shipped template**, following the pattern in `test_enum_option_labels.py`, so it exercises the production expression rather than a copy that could drift.

Mutation-checked — each fails the right test:

| mutation | result |
|---|---|
| remove the filter (restore the bug) | 2 tests fail |
| filter unconditionally | empty-enum test fails |
| drop the notice | the "value is named" test fails |

31 passed across `test_enum_option_labels`, `test_web_settings_ui`, `test_template_targets`, `test_widget_scripts` and the new file. All 20 templates still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STMbQE4YctTacQXfbYqKuW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Checkbox groups now identify saved options that are no longer available.
  * Stale options are excluded from submitted selections and clearly surfaced with a warning.
  * Valid saved selections remain checked.
  * Empty option lists preserve existing selections.
  * Default values are applied when no selection has been saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->