### PR TITLE
perf(systemd): cap glibc malloc arenas on the display service

### DIFF
--- a/systemd/ledmatrix.service
+++ b/systemd/ledmatrix.service
@@ -8,6 +8,18 @@ Type=simple
 User=root
 WorkingDirectory=__PROJECT_ROOT_DIR__
 Environment=PYTHONDONTWRITEBYTECODE=1
+# glibc gives each allocating thread its own malloc arena, up to 8 x CPU count,
+# and an arena that has grown is never handed back to the OS. This process runs
+# 9 threads on a 3-core Pi, so the ceiling is 24 arenas -- and a rig measured at
+# 1030 MB resident held 23 large anonymous mappings on 64 MB-aligned addresses,
+# 920 MB of them, while the live data it was actually holding (widest scroll
+# strip seen: 35,746 x 64) accounts for roughly 15 MB. That gap is arena bloat,
+# not leaked objects: RSS was flat across repeated sampling, not climbing.
+#
+# Capping the arenas trades a little allocator concurrency for a large amount of
+# resident memory on a device that has neither to spare. 2 is the usual value;
+# raise it if frame times regress.
+Environment=MALLOC_ARENA_MAX=2
 ExecStart=/usr/bin/python3 __PROJECT_ROOT_DIR__/run.py
 # Restart=always, not on-failure: run.py exiting 0 (a clean shutdown path taken
 # for a reason that no longer applies, e.g. a config reload) would otherwise leave

--- a/test/test_systemd_malloc_arenas.py
+++ b/test/test_systemd_malloc_arenas.py
@@ -1,0 +1,83 @@
+"""The display unit must cap glibc's malloc arenas.
+
+glibc hands each allocating thread its own malloc arena, up to 8 x CPU count,
+and an arena that has grown is never returned to the OS. This process runs
+threads for the render loop, the update workers and the background fetchers, so
+on a 3-core Pi the ceiling is 24 arenas.
+
+Measured on a live rig, 2.5 hours in:
+
+    RSS                 1030 MB
+    Private_Dirty        988 MB
+    anonymous mappings > 10 MB     23     (ceiling is 8 x 3 = 24)
+    largest few          104, 79, 66, 63, 63 MB, on 64 MB-aligned addresses
+
+against live data that accounts for perhaps 15 MB -- the widest scroll strip
+observed was 35,746 x 64, about 7 MB as RGB and the same again for its numpy
+mirror. Repeated sampling showed RSS flat between 990 and 1030 MB rather than
+climbing, so this is arena bloat rather than a leak: memory Python has freed
+but glibc is holding per-arena.
+
+The device had 59 MB free at the time.
+
+Capping the arena count trades a little allocator concurrency for that resident
+memory. The render loop is latency-sensitive, so if p99 frame time regresses the
+right response is to raise this rather than remove it.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+UNIT = (Path(__file__).resolve().parent.parent / "systemd" / "ledmatrix.service")
+
+
+def _environment(unit_text):
+    return dict(
+        line.split("=", 2)[1:3] if line.count("=") >= 2 else (line.split("=", 1)[1], "")
+        for line in unit_text.splitlines()
+        if line.startswith("Environment=")
+    )
+
+
+def test_the_unit_exists():
+    assert UNIT.is_file(), f"{UNIT} is missing"
+
+
+def test_malloc_arena_max_is_capped():
+    env = _environment(UNIT.read_text(encoding="utf-8"))
+    assert "MALLOC_ARENA_MAX" in env, (
+        "the display unit does not cap glibc arenas; on a 3-core Pi the default "
+        "ceiling is 24 and a measured rig held 23 of them, 920 MB"
+    )
+    value = int(env["MALLOC_ARENA_MAX"])
+    assert 1 <= value <= 4, (
+        f"MALLOC_ARENA_MAX={value} is outside the useful range: 1-4 keeps the "
+        "resident saving, and anything larger gives most of it back"
+    )
+
+
+def test_the_reason_is_recorded_next_to_it():
+    """A bare tuning knob invites removal by whoever meets it next."""
+    text = UNIT.read_text(encoding="utf-8")
+    index = text.index("Environment=MALLOC_ARENA_MAX")
+    preamble = text[:index].splitlines()[-12:]
+    comment = "\n".join(line for line in preamble if line.startswith("#"))
+    assert "arena" in comment.lower(), "no explanation precedes the setting"
+    assert re.search(r"\d", comment), (
+        "the explanation cites no measurement, so a reader cannot tell whether "
+        "it still applies to their hardware"
+    )
+
+
+@pytest.mark.parametrize("unit", ["ledmatrix.service"])
+def test_the_unit_still_parses_as_ini(unit):
+    """systemd will refuse a malformed unit, and the panel stays dark."""
+    import configparser
+
+    path = UNIT.parent / unit
+    parser = configparser.ConfigParser(strict=False)
+    # systemd allows repeated keys; ConfigParser needs them merged, not rejected.
+    parser.read_string(path.read_text(encoding="utf-8"))
+    assert parser.has_section("Service")
+    assert parser.has_option("Service", "ExecStart")

--- a/test/test_systemd_malloc_arenas.py
+++ b/test/test_systemd_malloc_arenas.py
@@ -31,6 +31,11 @@ import pytest
 
 UNIT = (Path(__file__).resolve().parent.parent / "systemd" / "ledmatrix.service")
 
+#: The value the unit is expected to carry. 2 is the usual choice for a
+#: threaded Python process; 1-4 all keep some of the saving, but only one of
+#: them is what this project ships.
+EXPECTED_ARENA_MAX = 2
+
 
 def _environment(unit_text):
     return dict(
@@ -51,9 +56,16 @@ def test_malloc_arena_max_is_capped():
         "ceiling is 24 and a measured rig held 23 of them, 920 MB"
     )
     value = int(env["MALLOC_ARENA_MAX"])
-    assert 1 <= value <= 4, (
-        f"MALLOC_ARENA_MAX={value} is outside the useful range: 1-4 keeps the "
-        "resident saving, and anything larger gives most of it back"
+    # Pinned, not a range. A range let a change to 4 -- which hands most of the
+    # saving back -- pass unnoticed, which was the point of the finding that
+    # prompted this. Raising it is a legitimate response to a frame-time
+    # regression, but it should be a visible edit here rather than a silent
+    # drift, so the number lives in one place and changing it shows up in
+    # review.
+    assert value == EXPECTED_ARENA_MAX, (
+        f"MALLOC_ARENA_MAX={value}, expected {EXPECTED_ARENA_MAX}. If this was "
+        "raised deliberately because frame times regressed, update "
+        "EXPECTED_ARENA_MAX here and say so in the commit."
     )
 
 


### PR DESCRIPTION
Found while looking for a memory leak. It isn't one — it's allocator bloat, and there's a one-line lever for it.

## Measured on a live rig, 2.5 hours after start

| | |
|---|---|
| RSS | **1030 MB** |
| Private_Dirty | 988 MB |
| anonymous mappings > 10 MB | **23** |
| largest | 104, 79, 66, 63, 63 MB — on **64 MB-aligned** addresses |
| threads | 9 |
| cores | 3 → glibc ceiling = 8 × 3 = **24 arenas** |

23 against a ceiling of 24, all 64 MB-aligned. Those are glibc's per-thread malloc arenas, not live objects.

For comparison, the data the process was actually holding accounts for perhaps **15 MB** — the widest scroll strip observed was 35,746 × 64, about 7 MB as RGB plus the same again for its numpy mirror.

**It is bloat, not a leak.** Sampled four times across 135 seconds, RSS sat between 990 and 1030 MB rather than climbing. glibc gives each allocating thread its own arena, grows them to peak demand, and never returns them. A process that builds and drops large images across several threads is exactly that shape.

The device had **59 MB free**, on 1845 MB total.

## The change

`MALLOC_ARENA_MAX=2` — trades a little allocator concurrency for that resident memory.

This is a tuning knob, not a defect fix, so the measurements sit next to it in the unit file and a test asserts they stay there. A bare environment variable invites removal by whoever meets it next and can't tell whether it still applies to their hardware.

## Two things this is NOT — both checked, not assumed

- **Not an OOM problem today.** Grepping the service journal for "oom" returned 24 matches — every one of them the radar logging `zoom=9` / `zoom=7`. The kernel OOM killer has never fired (dmesg: zero).
- **Not currently bounded by `MemoryMax=85%` either.** That directive is in this file but **absent from the unit installed on the rig**, which reports `MemoryMax=infinity`. Worth knowing separately: the repo's intent isn't reaching installed devices.

## Honest limits

The saving is **unmeasured on hardware**. Applying it needs a service restart, which blanks the panel — the user's call, not something to do mid-audit. I'd expect a large drop based on the arena arithmetic, but I haven't proven it here.

If p99 frame time regresses, **raise the value rather than remove it**. There isn't much headroom: frame time sits at 18.4 ms against a 16.7 ms budget for 60 FPS.

## Verification

4 tests: the setting exists, is in the useful range (1–4), the rationale with measurements sits beside it, and the unit still parses as INI (a malformed unit leaves the panel dark).

Mutation-checked — removing the setting fails 2, setting it to 24 fails the range check, and stripping the rationale fails the third.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STMbQE4YctTacQXfbYqKuW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Configured the service to limit glibc memory allocator arenas, helping control memory usage.

* **Documentation**
  * Added an explanation of the allocator setting and its memory-management considerations.

* **Tests**
  * Added validation that the service configuration exists, remains parseable, includes required fields, and uses an appropriate allocator limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->