### PR TITLE
harden: cap malloc arenas, warn on unit drift, and grant the portal's sudo commands

### DIFF
--- a/scripts/install/configure_wifi_permissions.sh
+++ b/scripts/install/configure_wifi_permissions.sh
@@ -40,7 +40,6 @@ SUDOERS_FILE="/etc/sudoers.d/ledmatrix_wifi"
 SYSCTL_PATH=$(command -v sysctl || echo /usr/sbin/sysctl)
 NFT_PATH=$(command -v nft || echo /usr/sbin/nft)
 RFKILL_PATH=$(command -v rfkill || echo /usr/sbin/rfkill)
-IPTABLES_PATH=$(command -v iptables || echo /usr/sbin/iptables)
 MKDIR_PATH=$(command -v mkdir || echo /usr/bin/mkdir)
 
 # Create a temporary sudoers file using mktemp (handles permissions better)
@@ -84,11 +83,19 @@ $WEB_USER ALL=(ALL) NOPASSWD: $SYSCTL_PATH -w net.ipv4.ip_forward=1
 $WEB_USER ALL=(ALL) NOPASSWD: $NFT_PATH add table ip ledmatrix
 $WEB_USER ALL=(ALL) NOPASSWD: $NFT_PATH delete table ip ledmatrix
 $WEB_USER ALL=(ALL) NOPASSWD: $RFKILL_PATH unblock wifi
-# The portal also inserts and removes its own iptables rules and creates
-# NetworkManager's dnsmasq drop-in directory. Wildcards rather than exact
-# argument lists: those rules are built from the live interface name and port.
-$WEB_USER ALL=(ALL) NOPASSWD: $IPTABLES_PATH *
+# NetworkManager's dnsmasq drop-in directory, exact path.
 $WEB_USER ALL=(ALL) NOPASSWD: $MKDIR_PATH -p /etc/NetworkManager/dnsmasq-shared.d
+#
+# iptables is deliberately NOT granted here. Its rules are built from the live
+# interface name and port, so a rule covering them needs a trailing wildcard --
+# and `iptables --modprobe=/path/to/anything` runs that path as root, so
+# `NOPASSWD: iptables *` is a root shell for the web user by another name. That
+# is a worse outcome than the gap it would close, which today is masked anyway
+# by the blanket NOPASSWD rule on stock Pi images.
+#
+# Closing it safely means a wrapper script that builds the rules itself and
+# takes only an interface and a port, granted the way safe_plugin_rm.sh already
+# is. That belongs in its own change rather than being smuggled into this one.
 
 # Allow copying hostapd and dnsmasq config files into place
 $WEB_USER ALL=(ALL) NOPASSWD: /usr/bin/cp /tmp/hostapd.conf /etc/hostapd/hostapd.conf

--- a/scripts/install/configure_wifi_permissions.sh
+++ b/scripts/install/configure_wifi_permissions.sh
@@ -37,6 +37,11 @@ echo "  systemctl: $SYSTEMCTL_PATH"
 echo ""
 echo "Step 1: Configuring sudo permissions for nmcli..."
 SUDOERS_FILE="/etc/sudoers.d/ledmatrix_wifi"
+SYSCTL_PATH=$(command -v sysctl || echo /usr/sbin/sysctl)
+NFT_PATH=$(command -v nft || echo /usr/sbin/nft)
+RFKILL_PATH=$(command -v rfkill || echo /usr/sbin/rfkill)
+IPTABLES_PATH=$(command -v iptables || echo /usr/sbin/iptables)
+MKDIR_PATH=$(command -v mkdir || echo /usr/bin/mkdir)
 
 # Create a temporary sudoers file using mktemp (handles permissions better)
 TEMP_SUDOERS=$(mktemp) || {
@@ -62,6 +67,28 @@ $WEB_USER ALL=(ALL) NOPASSWD: $SYSTEMCTL_PATH start dnsmasq
 $WEB_USER ALL=(ALL) NOPASSWD: $SYSTEMCTL_PATH stop dnsmasq
 $WEB_USER ALL=(ALL) NOPASSWD: $SYSTEMCTL_PATH restart dnsmasq
 $WEB_USER ALL=(ALL) NOPASSWD: $SYSTEMCTL_PATH restart NetworkManager
+# The captive portal turns IP forwarding on while the access point is up and
+# restores the previous value when it comes down (wifi_manager._setup_iptables_
+# redirect / _teardown_iptables_redirect). Without this rule that sudo call
+# needs a password, so forwarding stays off and clients associate to the AP but
+# cannot route. It goes unnoticed on a stock Raspberry Pi image, where
+# /etc/sudoers.d/010_pi-nopasswd grants the default user blanket NOPASSWD and
+# masks every gap in this file -- it only bites once that blanket rule is
+# removed.
+$WEB_USER ALL=(ALL) NOPASSWD: $SYSCTL_PATH -w net.ipv4.ip_forward=0
+$WEB_USER ALL=(ALL) NOPASSWD: $SYSCTL_PATH -w net.ipv4.ip_forward=1
+# The portal's redirect lives in its own nftables table, created when the AP
+# comes up and deleted when it goes down, and the radio has to be unblocked
+# before the AP can start at all. Same story as the sysctl rules above: called
+# with sudo, never granted here, and invisible on a stock Pi image.
+$WEB_USER ALL=(ALL) NOPASSWD: $NFT_PATH add table ip ledmatrix
+$WEB_USER ALL=(ALL) NOPASSWD: $NFT_PATH delete table ip ledmatrix
+$WEB_USER ALL=(ALL) NOPASSWD: $RFKILL_PATH unblock wifi
+# The portal also inserts and removes its own iptables rules and creates
+# NetworkManager's dnsmasq drop-in directory. Wildcards rather than exact
+# argument lists: those rules are built from the live interface name and port.
+$WEB_USER ALL=(ALL) NOPASSWD: $IPTABLES_PATH *
+$WEB_USER ALL=(ALL) NOPASSWD: $MKDIR_PATH -p /etc/NetworkManager/dnsmasq-shared.d
 
 # Allow copying hostapd and dnsmasq config files into place
 $WEB_USER ALL=(ALL) NOPASSWD: /usr/bin/cp /tmp/hostapd.conf /etc/hostapd/hostapd.conf

--- a/scripts/install/configure_wifi_permissions.sh
+++ b/scripts/install/configure_wifi_permissions.sh
@@ -25,9 +25,44 @@ if [ "$EUID" -eq 0 ]; then
     exit 1
 fi
 
+# Resolve command paths against a fixed PATH, and check what we resolved.
+#
+# Every path found here is written into a sudoers file as a NOPASSWD grant, so
+# whoever controls the binary at that path controls root. first_time_install.sh
+# re-execs itself with `sudo -E`, which preserves the invoking user's
+# environment -- PATH included -- so without pinning it, `which nmcli` can
+# resolve to anything on that PATH: a writable directory early in it turns a
+# compromise of the low-privilege web user into permanent root.
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+export PATH
+
+# A binary named in a sudoers rule must be root-owned and writable by nobody
+# else, or the grant hands root to whoever can rewrite it.
+require_trusted_binary() {
+    local label="$1" path="$2"
+    if [ ! -x "$path" ]; then
+        echo "✗ $label: $path is not an executable file"
+        exit 1
+    fi
+    local owner perms
+    owner=$(stat -c '%u' "$path") || exit 1
+    perms=$(stat -c '%a' "$path") || exit 1
+    if [ "$owner" != "0" ]; then
+        echo "✗ $label: $path is not owned by root (uid $owner); refusing to"
+        echo "  grant it NOPASSWD sudo."
+        exit 1
+    fi
+    # Group- or world-writable means someone other than root can replace it.
+    case "$perms" in
+        *[2367]) echo "✗ $label: $path is writable by group or other ($perms);"
+                 echo "  refusing to grant it NOPASSWD sudo."
+                 exit 1 ;;
+    esac
+}
+
 # Get the full paths to commands
-NMCLI_PATH=$(which nmcli || echo "/usr/bin/nmcli")
-SYSTEMCTL_PATH=$(which systemctl)
+NMCLI_PATH=$(command -v nmcli || echo "/usr/bin/nmcli")
+SYSTEMCTL_PATH=$(command -v systemctl)
 
 echo "Command paths:"
 echo "  nmcli: $NMCLI_PATH"
@@ -41,6 +76,14 @@ SYSCTL_PATH=$(command -v sysctl || echo /usr/sbin/sysctl)
 NFT_PATH=$(command -v nft || echo /usr/sbin/nft)
 RFKILL_PATH=$(command -v rfkill || echo /usr/sbin/rfkill)
 MKDIR_PATH=$(command -v mkdir || echo /usr/bin/mkdir)
+
+# Checked before any of them reaches the sudoers file.
+require_trusted_binary "nmcli"     "$NMCLI_PATH"
+require_trusted_binary "systemctl" "$SYSTEMCTL_PATH"
+require_trusted_binary "sysctl"    "$SYSCTL_PATH"
+require_trusted_binary "nft"       "$NFT_PATH"
+require_trusted_binary "rfkill"    "$RFKILL_PATH"
+require_trusted_binary "mkdir"     "$MKDIR_PATH"
 
 # Create a temporary sudoers file using mktemp (handles permissions better)
 TEMP_SUDOERS=$(mktemp) || {

--- a/src/startup_validator.py
+++ b/src/startup_validator.py
@@ -134,13 +134,22 @@ class StartupValidator:
 
     @staticmethod
     def _unit_body(text: str) -> str:
-        """A unit's meaningful lines: no comments, no blanks, no ordering noise."""
+        """A unit's meaningful lines, in order: no comments, no blanks.
+
+        Order is preserved deliberately. This used to sort, which made the
+        comparison insensitive to two changes that matter in a systemd unit:
+        repeated directives such as ExecStartPre= and ExecStartPost= run in
+        the order they appear, and a directive that moves between [Unit],
+        [Service] and [Install] means something different -- or nothing --
+        where it lands. A drift check that normalises those away reports no
+        drift for a unit that has genuinely changed.
+        """
         lines = []
         for line in text.splitlines():
             line = line.strip()
             if line and not line.startswith("#"):
                 lines.append(line)
-        return "\n".join(sorted(lines))
+        return "\n".join(lines)
 
     def _validate_config(self) -> None:
         """Validate configuration files."""

--- a/src/startup_validator.py
+++ b/src/startup_validator.py
@@ -62,6 +62,9 @@ class StartupValidator:
         # Validate plugins if plugin manager is available
         if self.plugin_manager:
             self._validate_plugins()
+
+        # Warn when the running systemd unit no longer matches the repo's
+        self._validate_systemd_units()
         
         is_valid = len(self.errors) == 0
         
@@ -74,6 +77,71 @@ class StartupValidator:
         
         return (is_valid, self.errors.copy(), self.warnings.copy())
     
+    #: Units this project installs, and where each is installed to.
+    _UNITS = (
+        ("systemd/ledmatrix.service", "/etc/systemd/system/ledmatrix.service"),
+        ("systemd/ledmatrix-web.service", "/etc/systemd/system/ledmatrix-web.service"),
+    )
+
+    def _validate_systemd_units(self) -> None:
+        """Warn when an installed unit has drifted from the repo's template.
+
+        Nothing re-applies these after the first install. `git pull` -- which is
+        what the web UI's update button runs -- brings a new template into the
+        checkout, but nothing copies it to /etc/systemd/system and nothing runs
+        `systemctl daemon-reload`, so the unit that actually runs is whatever
+        first_time_install.sh wrote on day one.
+
+        That makes every hardening added to a unit inert on existing installs.
+        Measured on one rig: the installed unit was thirteen days older than the
+        repo's and differed in content, so a MemoryMax the repo had specified
+        was not being enforced at all -- `systemctl show` reported
+        MemoryMax=infinity.
+
+        A warning rather than an error, and certainly not a silent rewrite:
+        editing files under /etc and restarting services is the installer's job,
+        not something a display process should do to a machine while it boots.
+        The remedy is to re-run scripts/install/install_service.sh.
+        """
+        try:
+            project_root = Path(__file__).resolve().parent.parent
+            for template_rel, installed_path in self._UNITS:
+                template = project_root / template_rel
+                installed = Path(installed_path)
+                if not template.is_file() or not installed.is_file():
+                    continue
+
+                # The template carries placeholders the installer substitutes,
+                # so compare the substituted form rather than the raw file.
+                expected = template.read_text(encoding="utf-8")
+                expected = expected.replace("__PROJECT_ROOT_DIR__", str(project_root))
+                expected = expected.replace("__USER__", "root")
+
+                try:
+                    actual = installed.read_text(encoding="utf-8")
+                except PermissionError:
+                    continue
+
+                if self._unit_body(expected) != self._unit_body(actual):
+                    self.warnings.append(
+                        f"{installed.name} differs from {template_rel}; the "
+                        "installed unit is not refreshed by an update, so "
+                        "settings added to the template are not in effect. "
+                        "Re-run scripts/install/install_service.sh to apply them."
+                    )
+        except OSError as e:
+            self.logger.debug("Could not compare systemd units: %s", e)
+
+    @staticmethod
+    def _unit_body(text: str) -> str:
+        """A unit's meaningful lines: no comments, no blanks, no ordering noise."""
+        lines = []
+        for line in text.splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                lines.append(line)
+        return "\n".join(sorted(lines))
+
     def _validate_config(self) -> None:
         """Validate configuration files."""
         try:

--- a/systemd/ledmatrix.service
+++ b/systemd/ledmatrix.service
@@ -8,6 +8,18 @@ Type=simple
 User=root
 WorkingDirectory=__PROJECT_ROOT_DIR__
 Environment=PYTHONDONTWRITEBYTECODE=1
+# glibc gives each allocating thread its own malloc arena, up to 8 x CPU count,
+# and an arena that has grown is never handed back to the OS. This process runs
+# 9 threads on a 3-core Pi, so the ceiling is 24 arenas -- and a rig measured at
+# 1030 MB resident held 23 large anonymous mappings on 64 MB-aligned addresses,
+# 920 MB of them, while the live data it was actually holding (widest scroll
+# strip seen: 35,746 x 64) accounts for roughly 15 MB. That gap is arena bloat,
+# not leaked objects: RSS was flat across repeated sampling, not climbing.
+#
+# Capping the arenas trades a little allocator concurrency for a large amount of
+# resident memory on a device that has neither to spare. 2 is the usual value;
+# raise it if frame times regress.
+Environment=MALLOC_ARENA_MAX=2
 ExecStart=/usr/bin/python3 __PROJECT_ROOT_DIR__/run.py
 # Restart=always, not on-failure: run.py exiting 0 (a clean shutdown path taken
 # for a reason that no longer applies, e.g. a config reload) would otherwise leave

--- a/test/test_sudo_allowlist_covers_calls.py
+++ b/test/test_sudo_allowlist_covers_calls.py
@@ -1,0 +1,134 @@
+"""Every sudo the code runs must be granted by an installer allow-list.
+
+The installers write two files -- /etc/sudoers.d/ledmatrix_web and
+/etc/sudoers.d/ledmatrix_wifi -- each an explicit allow-list. Anything the code
+calls with sudo that is not in one of them needs a password, which a service
+cannot supply, so the call fails.
+
+That failure is invisible on a stock Raspberry Pi image, because
+/etc/sudoers.d/010_pi-nopasswd grants the default user
+
+    <user> ALL=(ALL) NOPASSWD: ALL
+
+which masks every gap in both files. It only surfaces on a system where that
+blanket rule has been removed, or where the service runs as a different user --
+so a missing entry can sit there for a long time before anyone hits it.
+
+One was: wifi_manager turns IP forwarding on while the captive portal's access
+point is up and restores it afterwards, calling `sudo sysctl -w
+net.ipv4.ip_forward=...`. Neither allow-list granted sysctl. On such a system
+clients would associate to the AP and then fail to route.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+INSTALLERS = (
+    ROOT / "first_time_install.sh",
+    ROOT / "scripts" / "install" / "configure_wifi_permissions.sh",
+)
+SOURCES = (ROOT / "src", ROOT / "web_interface")
+
+# argv-style sudo calls: ["sudo", <binary-or-var>, "arg", ...]
+CALL = re.compile(r"""\[\s*["']sudo["']\s*,\s*(?P<rest>[^\]]+)\]""")
+
+
+def _first_two_args(rest):
+    """The binary and its first argument, as written."""
+    parts = [p.strip() for p in rest.split(",")]
+    # Drop sudo's own flags: `sudo -n <tool>` is a call to <tool>, and
+    # treating "-n" as the binary reports a gap that does not exist.
+    flag = re.compile(r'[\'"]-[a-zA-Z]+[\'"]')
+    while parts and flag.fullmatch(parts[0]):
+        parts = parts[1:]
+    # Always two entries: `["sudo", "reboot"]` has no subcommand, and the
+    # caller unpacks a fixed pair.
+    out = []
+    for part in (parts + ["", ""])[:2]:
+        if not part:
+            out.append("")
+            continue
+        literal = re.fullmatch(r"""["'](.+)["']""", part)
+        if literal:
+            out.append(literal.group(1))
+        else:
+            # A variable such as sysctl_bin: reduce to the tool it resolves to.
+            out.append(part.split(".")[-1].replace("_bin", "").replace("_path", ""))
+    return out
+
+
+def _sudo_calls():
+    found = {}
+    for base in SOURCES:
+        for path in base.rglob("*.py"):
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for match in CALL.finditer(text):
+                args = _first_two_args(match.group("rest"))
+                if not args:
+                    continue
+                line = text[:match.start()].count("\n") + 1
+                found.setdefault(tuple(args), f"{path.relative_to(ROOT)}:{line}")
+    return found
+
+
+def _allowlisted_text():
+    """The allow-list rules, with binary-path variables reduced to tool names.
+
+    The installers write rules like `$SYSTEMCTL_PATH enable ledmatrix.service`,
+    so matching on the literal "systemctl" finds nothing and every systemctl
+    rule looks absent. Normalise $FOO_PATH and /usr/bin/foo down to foo before
+    comparing, or the check reports gaps that are not there -- which it did on
+    the first run.
+    """
+    # NOPASSWD lines only. Taking the whole script would let a variable
+    # definition such as NFT_PATH=$(command -v nft) satisfy the check on its
+    # own, which is how an earlier version of this test passed while the grant
+    # itself had been deleted.
+    lines = []
+    for installer in INSTALLERS:
+        if not installer.is_file():
+            continue
+        for line in installer.read_text(encoding="utf-8", errors="replace").splitlines():
+            if "NOPASSWD:" in line:
+                lines.append(line.split("NOPASSWD:", 1)[1])
+    text = "\n".join(lines)
+    text = re.sub(r"\$\{?([A-Z][A-Z0-9_]*)_PATH\}?",
+                  lambda m: m.group(1).lower(), text)
+    text = re.sub(r"/usr/(?:s?bin)/", "", text)
+    return text
+
+
+def test_the_installers_are_present():
+    missing = [str(p.relative_to(ROOT)) for p in INSTALLERS if not p.is_file()]
+    assert not missing, f"installer(s) missing: {missing}"
+
+
+def test_every_sudo_call_is_granted():
+    allow = _allowlisted_text()
+    calls = _sudo_calls()
+    assert calls, "no sudo calls found; the matcher has stopped working"
+
+    ungranted = []
+    for (binary, first_arg), where in sorted(calls.items()):
+        # A rule mentions the tool and, where it takes a subcommand, that too.
+        if binary not in allow:
+            ungranted.append(f"{binary} ({where})")
+            continue
+        if first_arg and not first_arg.startswith("-"):
+            pattern = rf"{re.escape(binary)}\s+{re.escape(first_arg)}"
+            if binary in ("systemctl",) and not re.search(pattern, allow):
+                ungranted.append(f"{binary} {first_arg} ({where})")
+
+    assert not ungranted, (
+        "these run under sudo but no installer grants them; on a stock Pi the "
+        "blanket 010_pi-nopasswd rule hides this:\n  " + "\n  ".join(ungranted))
+
+
+@pytest.mark.parametrize("needle", ["ip_forward"])
+def test_the_captive_portal_forwarding_rule_is_granted(needle):
+    """The specific gap this test was written for."""
+    assert needle in _allowlisted_text(), (
+        "no allow-list entry for sysctl ip_forward; the captive portal enables "
+        "forwarding while its AP is up and cannot without one")

--- a/test/test_sudo_allowlist_covers_calls.py
+++ b/test/test_sudo_allowlist_covers_calls.py
@@ -66,19 +66,37 @@ def _grant_lines():
     return lines
 
 
-def _normalised_grants():
-    """Grants with binary-path variables reduced to tool names.
+def _normalise(rule):
+    """One rule with binary-path variables reduced to bare tool names.
 
-    Rules are written as `$SYSCTL_PATH -w ...`, so matching the literal
-    "sysctl" finds nothing and every rule looks absent -- which is exactly how
-    an earlier version of this test reported six gaps that did not exist.
-    Only NOPASSWD lines are considered, because taking the whole script let a
-    variable definition such as NFT_PATH=$(command -v nft) satisfy the check on
-    its own while the grant itself had been deleted.
+    Rules are written as `$SYSCTL_PATH -w ...` or `${NFT_PATH} ...`, so
+    matching the literal "sysctl" finds nothing and every rule looks absent --
+    which is exactly how an earlier version of this test reported six gaps
+    that did not exist. Both spellings are handled: shell expands them
+    identically, and a check that understood only one silently skipped the
+    other.
     """
-    text = "\n".join(_grant_lines())
-    text = re.sub(r"\$\{?([A-Z][A-Z0-9_]*)_PATH\}?", lambda m: m.group(1).lower(), text)
-    return re.sub(r"/usr/(?:s?bin)/", "", text)
+    rule = re.sub(r"\$\{?([A-Z][A-Z0-9_]*)_PATH\}?",
+                  lambda m: m.group(1).lower(), rule)
+    return re.sub(r"/usr/(?:s?bin)/", "", rule)
+
+
+def _granted_commands():
+    """The command each NOPASSWD rule actually grants, normalised.
+
+    _grant_lines() already returns everything after "NOPASSWD:", so what
+    arrives here is the command, possibly preceded by the NOEXEC tag and
+    possibly still carrying the closing quote of an `echo "..."` that wrote
+    it. Both are stripped so the result is comparable to a plain command.
+    """
+    commands = []
+    for rule in _grant_lines():
+        command = _normalise(rule).strip()
+        command = re.sub(r"^NOEXEC:\s*", "", command)
+        command = command.rstrip('"').rstrip("'").strip()
+        if command:
+            commands.append(" ".join(command.split()))
+    return commands
 
 
 def test_the_installers_are_present():
@@ -94,9 +112,15 @@ def test_the_command_is_granted(command):
     `sysctl` present anywhere, deleting the ip_forward=0 grant still passed,
     and the portal would then be unable to restore forwarding on teardown.
     """
-    pattern = r"\s+".join(re.escape(word) for word in command)
-    assert re.search(pattern, _normalised_grants()), (
-        f"no installer grants `{' '.join(command)}`")
+    wanted = " ".join(command)
+    granted = _granted_commands()
+    # Exact match, not a prefix. A substring search was satisfied by
+    # `sysctl -w net.ipv4.ip_forward=0 *`, and that trailing wildcard lets the
+    # caller append whatever they like to a command running as root -- a far
+    # wider grant than the one this test is meant to be confirming.
+    assert wanted in granted, (
+        f"no installer grants exactly `{wanted}`; closest matches: "
+        + str([g for g in granted if g.startswith(command[0])])[:200])
 
 
 def test_no_wildcard_on_a_tool_that_can_exec():
@@ -110,7 +134,10 @@ def test_no_wildcard_on_a_tool_that_can_exec():
         rule = rule.strip()
         if not rule.endswith("*"):
             continue
-        haystack = rule.replace("_PATH", "").lower()
+        # Normalised the same way as everything else: `${NFT_PATH} *` left a
+        # brace before the tool name, and the word-boundary check below does
+        # not treat "{" as a boundary, so that spelling slipped through.
+        haystack = _normalise(rule).lower()
         for tool in EXEC_CAPABLE:
             if re.search(rf"(^|/|\s|\$){tool}(\s|$)", haystack):
                 offenders.append(rule)

--- a/test/test_sudo_allowlist_covers_calls.py
+++ b/test/test_sudo_allowlist_covers_calls.py
@@ -1,23 +1,32 @@
-"""Every sudo the code runs must be granted by an installer allow-list.
+"""The captive portal's fixed-argument sudo calls must be granted.
 
-The installers write two files -- /etc/sudoers.d/ledmatrix_web and
-/etc/sudoers.d/ledmatrix_wifi -- each an explicit allow-list. Anything the code
-calls with sudo that is not in one of them needs a password, which a service
-cannot supply, so the call fails.
+The installers write two allow-lists, /etc/sudoers.d/ledmatrix_web and
+ledmatrix_wifi. A sudo call absent from both needs a password, which a service
+cannot supply, so it fails.
 
-That failure is invisible on a stock Raspberry Pi image, because
-/etc/sudoers.d/010_pi-nopasswd grants the default user
+Four such calls were ungranted, all of them captive-portal teardown/setup:
 
-    <user> ALL=(ALL) NOPASSWD: ALL
+    sysctl -w net.ipv4.ip_forward=0|1     wifi_manager.py:788, 883
+    nft add|delete table ip ledmatrix     wifi_manager.py:835, 895
+    rfkill unblock wifi                   wifi_manager.py:1811
+    mkdir -p .../dnsmasq-shared.d         wifi_manager.py:922
 
-which masks every gap in both files. It only surfaces on a system where that
-blanket rule has been removed, or where the service runs as a different user --
-so a missing entry can sit there for a long time before anyone hits it.
+It goes unnoticed because a stock Raspberry Pi image ships
+/etc/sudoers.d/010_pi-nopasswd granting the default user
+`ALL=(ALL) NOPASSWD: ALL`, which satisfies every gap in both files. It only
+bites once that blanket rule is removed or the service runs as another user.
 
-One was: wifi_manager turns IP forwarding on while the captive portal's access
-point is up and restores it afterwards, calling `sudo sysctl -w
-net.ipv4.ip_forward=...`. Neither allow-list granted sysctl. On such a system
-clients would associate to the AP and then fail to route.
+Scope, deliberately narrow: this pins the four commands above, each of which
+can be written out literally. The portal makes further sudo calls whose
+arguments are built at runtime -- iptables and nft rules carrying an interface
+name and a port, `ip addr`, `ip link` -- and those cannot be granted safely
+here. A rule covering them needs a trailing wildcard, and
+`iptables --modprobe=/path/to/anything` runs that path as root, so
+`NOPASSWD: iptables *` is a root shell for the web user by another name.
+Closing that half needs a privileged helper that builds the rules itself and
+takes only an interface and a port, granted the way safe_plugin_rm.sh already
+is. That is a design decision, not a one-line grant, and belongs in its own
+change.
 """
 import re
 from pathlib import Path
@@ -29,63 +38,24 @@ INSTALLERS = (
     ROOT / "first_time_install.sh",
     ROOT / "scripts" / "install" / "configure_wifi_permissions.sh",
 )
-SOURCES = (ROOT / "src", ROOT / "web_interface")
 
-# argv-style sudo calls: ["sudo", <binary-or-var>, "arg", ...]
-CALL = re.compile(r"""\[\s*["']sudo["']\s*,\s*(?P<rest>[^\]]+)\]""")
+#: Commands this change grants, each fully literal in the source.
+REQUIRED = (
+    ("sysctl", "-w", "net.ipv4.ip_forward=0"),
+    ("sysctl", "-w", "net.ipv4.ip_forward=1"),
+    ("nft", "add", "table", "ip", "ledmatrix"),
+    ("nft", "delete", "table", "ip", "ledmatrix"),
+    ("rfkill", "unblock", "wifi"),
+    ("mkdir", "-p", "/etc/NetworkManager/dnsmasq-shared.d"),
+)
 
-
-def _first_two_args(rest):
-    """The binary and its first argument, as written."""
-    parts = [p.strip() for p in rest.split(",")]
-    # Drop sudo's own flags: `sudo -n <tool>` is a call to <tool>, and
-    # treating "-n" as the binary reports a gap that does not exist.
-    flag = re.compile(r'[\'"]-[a-zA-Z]+[\'"]')
-    while parts and flag.fullmatch(parts[0]):
-        parts = parts[1:]
-    # Always two entries: `["sudo", "reboot"]` has no subcommand, and the
-    # caller unpacks a fixed pair.
-    out = []
-    for part in (parts + ["", ""])[:2]:
-        if not part:
-            out.append("")
-            continue
-        literal = re.fullmatch(r"""["'](.+)["']""", part)
-        if literal:
-            out.append(literal.group(1))
-        else:
-            # A variable such as sysctl_bin: reduce to the tool it resolves to.
-            out.append(part.split(".")[-1].replace("_bin", "").replace("_path", ""))
-    return out
+#: Tools with an option that executes a program of the caller's choosing.
+#: A trailing wildcard on any of these is a privilege escalation.
+EXEC_CAPABLE = ("iptables", "ip6tables", "nft", "tcpdump", "find", "awk",
+                "sed", "perl", "python", "python3", "env")
 
 
-def _sudo_calls():
-    found = {}
-    for base in SOURCES:
-        for path in base.rglob("*.py"):
-            text = path.read_text(encoding="utf-8", errors="replace")
-            for match in CALL.finditer(text):
-                args = _first_two_args(match.group("rest"))
-                if not args:
-                    continue
-                line = text[:match.start()].count("\n") + 1
-                found.setdefault(tuple(args), f"{path.relative_to(ROOT)}:{line}")
-    return found
-
-
-def _allowlisted_text():
-    """The allow-list rules, with binary-path variables reduced to tool names.
-
-    The installers write rules like `$SYSTEMCTL_PATH enable ledmatrix.service`,
-    so matching on the literal "systemctl" finds nothing and every systemctl
-    rule looks absent. Normalise $FOO_PATH and /usr/bin/foo down to foo before
-    comparing, or the check reports gaps that are not there -- which it did on
-    the first run.
-    """
-    # NOPASSWD lines only. Taking the whole script would let a variable
-    # definition such as NFT_PATH=$(command -v nft) satisfy the check on its
-    # own, which is how an earlier version of this test passed while the grant
-    # itself had been deleted.
+def _grant_lines():
     lines = []
     for installer in INSTALLERS:
         if not installer.is_file():
@@ -93,11 +63,22 @@ def _allowlisted_text():
         for line in installer.read_text(encoding="utf-8", errors="replace").splitlines():
             if "NOPASSWD:" in line:
                 lines.append(line.split("NOPASSWD:", 1)[1])
-    text = "\n".join(lines)
-    text = re.sub(r"\$\{?([A-Z][A-Z0-9_]*)_PATH\}?",
-                  lambda m: m.group(1).lower(), text)
-    text = re.sub(r"/usr/(?:s?bin)/", "", text)
-    return text
+    return lines
+
+
+def _normalised_grants():
+    """Grants with binary-path variables reduced to tool names.
+
+    Rules are written as `$SYSCTL_PATH -w ...`, so matching the literal
+    "sysctl" finds nothing and every rule looks absent -- which is exactly how
+    an earlier version of this test reported six gaps that did not exist.
+    Only NOPASSWD lines are considered, because taking the whole script let a
+    variable definition such as NFT_PATH=$(command -v nft) satisfy the check on
+    its own while the grant itself had been deleted.
+    """
+    text = "\n".join(_grant_lines())
+    text = re.sub(r"\$\{?([A-Z][A-Z0-9_]*)_PATH\}?", lambda m: m.group(1).lower(), text)
+    return re.sub(r"/usr/(?:s?bin)/", "", text)
 
 
 def test_the_installers_are_present():
@@ -105,30 +86,35 @@ def test_the_installers_are_present():
     assert not missing, f"installer(s) missing: {missing}"
 
 
-def test_every_sudo_call_is_granted():
-    allow = _allowlisted_text()
-    calls = _sudo_calls()
-    assert calls, "no sudo calls found; the matcher has stopped working"
+@pytest.mark.parametrize("command", REQUIRED, ids=lambda c: " ".join(c))
+def test_the_command_is_granted(command):
+    """Whole command, not just the binary.
 
-    ungranted = []
-    for (binary, first_arg), where in sorted(calls.items()):
-        # A rule mentions the tool and, where it takes a subcommand, that too.
-        if binary not in allow:
-            ungranted.append(f"{binary} ({where})")
+    Checking only the binary made this far weaker than it looked: with
+    `sysctl` present anywhere, deleting the ip_forward=0 grant still passed,
+    and the portal would then be unable to restore forwarding on teardown.
+    """
+    pattern = r"\s+".join(re.escape(word) for word in command)
+    assert re.search(pattern, _normalised_grants()), (
+        f"no installer grants `{' '.join(command)}`")
+
+
+def test_no_wildcard_on_a_tool_that_can_exec():
+    """`NOPASSWD: iptables *` hands the web user root.
+
+    iptables --modprobe=/path runs that path as root. This caught a grant added
+    in this very change, which is why it is here.
+    """
+    offenders = []
+    for rule in _grant_lines():
+        rule = rule.strip()
+        if not rule.endswith("*"):
             continue
-        if first_arg and not first_arg.startswith("-"):
-            pattern = rf"{re.escape(binary)}\s+{re.escape(first_arg)}"
-            if binary in ("systemctl",) and not re.search(pattern, allow):
-                ungranted.append(f"{binary} {first_arg} ({where})")
-
-    assert not ungranted, (
-        "these run under sudo but no installer grants them; on a stock Pi the "
-        "blanket 010_pi-nopasswd rule hides this:\n  " + "\n  ".join(ungranted))
-
-
-@pytest.mark.parametrize("needle", ["ip_forward"])
-def test_the_captive_portal_forwarding_rule_is_granted(needle):
-    """The specific gap this test was written for."""
-    assert needle in _allowlisted_text(), (
-        "no allow-list entry for sysctl ip_forward; the captive portal enables "
-        "forwarding while its AP is up and cannot without one")
+        haystack = rule.replace("_PATH", "").lower()
+        for tool in EXEC_CAPABLE:
+            if re.search(rf"(^|/|\s|\$){tool}(\s|$)", haystack):
+                offenders.append(rule)
+                break
+    assert not offenders, (
+        "wildcard grant on a tool that can execute another program:\n  "
+        + "\n  ".join(offenders))

--- a/test/test_systemd_malloc_arenas.py
+++ b/test/test_systemd_malloc_arenas.py
@@ -1,0 +1,83 @@
+"""The display unit must cap glibc's malloc arenas.
+
+glibc hands each allocating thread its own malloc arena, up to 8 x CPU count,
+and an arena that has grown is never returned to the OS. This process runs
+threads for the render loop, the update workers and the background fetchers, so
+on a 3-core Pi the ceiling is 24 arenas.
+
+Measured on a live rig, 2.5 hours in:
+
+    RSS                 1030 MB
+    Private_Dirty        988 MB
+    anonymous mappings > 10 MB     23     (ceiling is 8 x 3 = 24)
+    largest few          104, 79, 66, 63, 63 MB, on 64 MB-aligned addresses
+
+against live data that accounts for perhaps 15 MB -- the widest scroll strip
+observed was 35,746 x 64, about 7 MB as RGB and the same again for its numpy
+mirror. Repeated sampling showed RSS flat between 990 and 1030 MB rather than
+climbing, so this is arena bloat rather than a leak: memory Python has freed
+but glibc is holding per-arena.
+
+The device had 59 MB free at the time.
+
+Capping the arena count trades a little allocator concurrency for that resident
+memory. The render loop is latency-sensitive, so if p99 frame time regresses the
+right response is to raise this rather than remove it.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+UNIT = (Path(__file__).resolve().parent.parent / "systemd" / "ledmatrix.service")
+
+
+def _environment(unit_text):
+    return dict(
+        line.split("=", 2)[1:3] if line.count("=") >= 2 else (line.split("=", 1)[1], "")
+        for line in unit_text.splitlines()
+        if line.startswith("Environment=")
+    )
+
+
+def test_the_unit_exists():
+    assert UNIT.is_file(), f"{UNIT} is missing"
+
+
+def test_malloc_arena_max_is_capped():
+    env = _environment(UNIT.read_text(encoding="utf-8"))
+    assert "MALLOC_ARENA_MAX" in env, (
+        "the display unit does not cap glibc arenas; on a 3-core Pi the default "
+        "ceiling is 24 and a measured rig held 23 of them, 920 MB"
+    )
+    value = int(env["MALLOC_ARENA_MAX"])
+    assert 1 <= value <= 4, (
+        f"MALLOC_ARENA_MAX={value} is outside the useful range: 1-4 keeps the "
+        "resident saving, and anything larger gives most of it back"
+    )
+
+
+def test_the_reason_is_recorded_next_to_it():
+    """A bare tuning knob invites removal by whoever meets it next."""
+    text = UNIT.read_text(encoding="utf-8")
+    index = text.index("Environment=MALLOC_ARENA_MAX")
+    preamble = text[:index].splitlines()[-12:]
+    comment = "\n".join(line for line in preamble if line.startswith("#"))
+    assert "arena" in comment.lower(), "no explanation precedes the setting"
+    assert re.search(r"\d", comment), (
+        "the explanation cites no measurement, so a reader cannot tell whether "
+        "it still applies to their hardware"
+    )
+
+
+@pytest.mark.parametrize("unit", ["ledmatrix.service"])
+def test_the_unit_still_parses_as_ini(unit):
+    """systemd will refuse a malformed unit, and the panel stays dark."""
+    import configparser
+
+    path = UNIT.parent / unit
+    parser = configparser.ConfigParser(strict=False)
+    # systemd allows repeated keys; ConfigParser needs them merged, not rejected.
+    parser.read_string(path.read_text(encoding="utf-8"))
+    assert parser.has_section("Service")
+    assert parser.has_option("Service", "ExecStart")

--- a/test/test_systemd_malloc_arenas.py
+++ b/test/test_systemd_malloc_arenas.py
@@ -31,6 +31,11 @@ import pytest
 
 UNIT = (Path(__file__).resolve().parent.parent / "systemd" / "ledmatrix.service")
 
+#: The value the unit is expected to carry. 2 is the usual choice for a
+#: threaded Python process; 1-4 all keep some of the saving, but only one of
+#: them is what this project ships.
+EXPECTED_ARENA_MAX = 2
+
 
 def _environment(unit_text):
     return dict(
@@ -51,9 +56,16 @@ def test_malloc_arena_max_is_capped():
         "ceiling is 24 and a measured rig held 23 of them, 920 MB"
     )
     value = int(env["MALLOC_ARENA_MAX"])
-    assert 1 <= value <= 4, (
-        f"MALLOC_ARENA_MAX={value} is outside the useful range: 1-4 keeps the "
-        "resident saving, and anything larger gives most of it back"
+    # Pinned, not a range. A range let a change to 4 -- which hands most of the
+    # saving back -- pass unnoticed, which was the point of the finding that
+    # prompted this. Raising it is a legitimate response to a frame-time
+    # regression, but it should be a visible edit here rather than a silent
+    # drift, so the number lives in one place and changing it shows up in
+    # review.
+    assert value == EXPECTED_ARENA_MAX, (
+        f"MALLOC_ARENA_MAX={value}, expected {EXPECTED_ARENA_MAX}. If this was "
+        "raised deliberately because frame times regressed, update "
+        "EXPECTED_ARENA_MAX here and say so in the commit."
     )
 
 

--- a/test/test_systemd_unit_drift.py
+++ b/test/test_systemd_unit_drift.py
@@ -68,11 +68,27 @@ def test_a_changed_directive_is_drift():
     assert StartupValidator._unit_body(a) != StartupValidator._unit_body(b)
 
 
-def test_reordered_directives_are_not_drift():
-    """systemd does not care about order within a section, so neither should this."""
-    a = "[Service]\nExecStart=/x\nRestart=always\n"
-    b = "[Service]\nRestart=always\nExecStart=/x\n"
-    assert StartupValidator._unit_body(a) == StartupValidator._unit_body(b)
+def test_reordered_directives_are_drift():
+    """Order is not noise in a systemd unit.
+
+    Repeated directives -- ExecStartPre=, ExecStartPost= -- run in the order
+    they appear, and a directive that moves between [Unit], [Service] and
+    [Install] means something different, or nothing, where it lands. This
+    check used to sort the lines before comparing, which reported no drift for
+    a unit that had genuinely changed.
+    """
+    a = "[Service]\nExecStartPre=/first\nExecStartPre=/second\n"
+    b = "[Service]\nExecStartPre=/second\nExecStartPre=/first\n"
+    assert StartupValidator._unit_body(a) != StartupValidator._unit_body(b), (
+        "swapping two ExecStartPre= lines changes what runs first, and was "
+        "being normalised away")
+
+
+def test_a_directive_moved_between_sections_is_drift():
+    a = "[Unit]\nDescription=x\n[Service]\nExecStart=/x\n"
+    b = "[Unit]\nDescription=x\nExecStart=/x\n[Service]\n"
+    assert StartupValidator._unit_body(a) != StartupValidator._unit_body(b), (
+        "ExecStart= in [Unit] is not the same unit, and sorting hid it")
 
 
 def test_cosmetic_differences_do_not_warn(validator, tmp_path):
@@ -93,11 +109,14 @@ def test_cosmetic_differences_do_not_warn(validator, tmp_path):
     substituted = (template.read_text(encoding="utf-8")
                    .replace("__PROJECT_ROOT_DIR__", str(project_root))
                    .replace("__USER__", "root"))
-    # Same directives, stripped of comments and blank lines and reordered.
-    directives = sorted(line.strip() for line in substituted.splitlines()
-                        if line.strip() and not line.strip().startswith("#"))
+    # Cosmetic means comments, blank lines and stray indentation -- the things
+    # the installer really does drop. Not reordering: that changes the unit,
+    # and is asserted as drift above.
+    directives = [line.strip() for line in substituted.splitlines()
+                  if line.strip() and not line.strip().startswith("#")]
     installed = tmp_path / "ledmatrix.service"
-    installed.write_text("\n".join(reversed(directives)) + "\n", encoding="utf-8")
+    installed.write_text(
+        "\n\n".join("   " + d for d in directives) + "\n", encoding="utf-8")
 
     validator._UNITS = ((template_rel, str(installed)),)
     validator._validate_systemd_units()

--- a/test/test_systemd_unit_drift.py
+++ b/test/test_systemd_unit_drift.py
@@ -1,0 +1,133 @@
+"""An installed unit that no longer matches the repo's must be reported.
+
+Nothing re-applies systemd units after the first install. `git pull` -- what
+the web UI's update button runs -- brings a new template into the checkout, but
+no code in web_interface/ or src/ copies it to /etc/systemd/system or runs
+`systemctl daemon-reload`. The unit that actually runs is whatever
+first_time_install.sh wrote on day one.
+
+So every hardening added to a unit is inert on existing installs. Measured on a
+live rig: the installed unit was dated 2026-08-06 and the repo's 2026-08-19,
+and they differed -- with the result that a MemoryMax=85% present in the repo's
+template was not being enforced at all. `systemctl show` reported
+MemoryMax=infinity.
+
+This is a warning, not an error, and deliberately not a silent rewrite:
+editing files under /etc and restarting services is the installer's job, not
+something a display process should do to a machine while it boots.
+"""
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.startup_validator import StartupValidator
+
+
+@pytest.fixture
+def validator():
+    v = StartupValidator(config_manager=MagicMock())
+    v.logger = logging.getLogger("test")
+    v.warnings = []
+    v.errors = []
+    return v
+
+
+def test_a_matching_unit_produces_no_warning(validator, tmp_path):
+    """The installed unit, substituted exactly as the installer would."""
+    project_root = Path("src/startup_validator.py").resolve().parent.parent
+    template_rel = "systemd/ledmatrix.service"
+    template = project_root / template_rel
+    if not template.is_file():
+        pytest.skip("repo unit template not present")
+
+    installed = tmp_path / "ledmatrix.service"
+    installed.write_text(
+        template.read_text(encoding="utf-8")
+        .replace("__PROJECT_ROOT_DIR__", str(project_root))
+        .replace("__USER__", "root"),
+        encoding="utf-8")
+
+    validator._UNITS = ((template_rel, str(installed)),)
+    validator._validate_systemd_units()
+    assert not validator.warnings, f"a matching unit warned: {validator.warnings}"
+    assert not validator.errors
+
+
+def test_comments_and_blank_lines_are_not_drift():
+    """Otherwise every comment the repo adds would look like a changed unit."""
+    a = "[Service]\n# explains a setting\nExecStart=/x\nRestart=always\n"
+    b = "[Service]\nExecStart=/x\n\nRestart=always\n"
+    assert StartupValidator._unit_body(a) == StartupValidator._unit_body(b)
+
+
+def test_a_changed_directive_is_drift():
+    a = "[Service]\nExecStart=/x\nMemoryMax=85%\n"
+    b = "[Service]\nExecStart=/x\n"
+    assert StartupValidator._unit_body(a) != StartupValidator._unit_body(b)
+
+
+def test_reordered_directives_are_not_drift():
+    """systemd does not care about order within a section, so neither should this."""
+    a = "[Service]\nExecStart=/x\nRestart=always\n"
+    b = "[Service]\nRestart=always\nExecStart=/x\n"
+    assert StartupValidator._unit_body(a) == StartupValidator._unit_body(b)
+
+
+def test_cosmetic_differences_do_not_warn(validator, tmp_path):
+    """Through the real comparison, not the helper.
+
+    The repo's template carries explanatory comments the installed copy may not
+    have, and the installer does not preserve ordering or blank lines. If those
+    counted as drift, every boot would warn and the warning would be ignored.
+    Asserting this on _unit_body alone would not catch a comparison that stopped
+    calling it -- which is exactly what a careless edit does.
+    """
+    project_root = Path("src/startup_validator.py").resolve().parent.parent
+    template_rel = "systemd/ledmatrix.service"
+    template = project_root / template_rel
+    if not template.is_file():
+        pytest.skip("repo unit template not present")
+
+    substituted = (template.read_text(encoding="utf-8")
+                   .replace("__PROJECT_ROOT_DIR__", str(project_root))
+                   .replace("__USER__", "root"))
+    # Same directives, stripped of comments and blank lines and reordered.
+    directives = sorted(line.strip() for line in substituted.splitlines()
+                        if line.strip() and not line.strip().startswith("#"))
+    installed = tmp_path / "ledmatrix.service"
+    installed.write_text("\n".join(reversed(directives)) + "\n", encoding="utf-8")
+
+    validator._UNITS = ((template_rel, str(installed)),)
+    validator._validate_systemd_units()
+    assert not validator.warnings, (
+        f"cosmetic-only difference reported as drift: {validator.warnings}")
+
+
+def test_drift_is_reported_as_a_warning(validator, tmp_path):
+    """The whole point: a real difference must surface, and only as a warning."""
+    installed = tmp_path / "ledmatrix.service"
+    installed.write_text("[Service]\nExecStart=/usr/bin/python3 /x/run.py\n")
+
+    project_root = Path("src/startup_validator.py").resolve().parent.parent
+    template_rel = "systemd/ledmatrix.service"
+    template = project_root / template_rel
+    if not template.is_file():
+        pytest.skip("repo unit template not present")
+
+    validator._UNITS = ((template_rel, str(installed)),)
+    validator._validate_systemd_units()
+
+    assert validator.warnings, "a differing unit produced no warning"
+    assert "install_service.sh" in validator.warnings[0], (
+        "the warning does not tell the user how to fix it")
+    assert not validator.errors, "drift must not be fatal at startup"
+
+
+def test_a_missing_installed_unit_is_silent(validator, tmp_path):
+    """Development checkouts have no /etc/systemd unit; that is not drift."""
+    validator._UNITS = (("systemd/ledmatrix.service", str(tmp_path / "absent.service")),)
+    validator._validate_systemd_units()
+    assert not validator.warnings
+    assert not validator.errors


### PR DESCRIPTION
**Consolidates #469, #470 and #471** into one review, because CodeRabbit is rate-limiting across the queue. All five commits are cherry-picked with `-x` and unchanged; the originals will be closed pointing here.

Three findings that turned out to be one story: **things the installer writes are never revisited, so nothing added to them takes effect.**

---

## 1. The display process holds ~1 GB of malloc arenas

Measured 2.5 hours after start:

| | |
|---|---|
| RSS / Private_Dirty | 1030 MB / 988 MB |
| anonymous mappings > 10 MB | **23** |
| largest | 104, 79, 66, 63, 63 MB — **64 MB-aligned** |
| threads / cores | 9 / 3 → glibc ceiling = 8 × 3 = **24 arenas** |

23 against a ceiling of 24, all 64 MB-aligned: glibc's per-thread arenas, not live objects. The data actually held accounts for ~15 MB. Sampled four times over 135 seconds, RSS was flat — bloat, not a leak. The device had **59 MB free**.

`MALLOC_ARENA_MAX=2`, with the measurements recorded beside it and a test pinning the value (a range would have let a change to 4 hand most of the saving back).

## 2. …except that would never have reached anyone

Checking whether change 1 would actually apply: it wouldn't.

| | |
|---|---|
| installed `/etc/systemd/system/ledmatrix.service` | **2026-08-06** |
| repo `systemd/ledmatrix.service` | **2026-08-19** |
| contents | **differ** |

`git pull` — what the web UI's update button runs — brings a new template into the checkout, but **nothing copies it to `/etc/systemd/system` and nothing runs `daemon-reload`**. The unit that runs is whatever `first_time_install.sh` wrote on day one.

Concrete consequence: `MemoryMax=85%` is in the repo's template and **was not being enforced** — `systemctl show` reported `MemoryMax=infinity`.

Startup now compares each installed unit against its substituted template and warns, naming `install_service.sh` as the remedy. A warning, not a silent rewrite — editing `/etc` and restarting services is the installer's job.

## 3. The same gap in the sudo allow-lists

Four captive-portal commands are run under sudo and granted nowhere: `sysctl -w net.ipv4.ip_forward=0|1`, `nft add|delete table ip ledmatrix`, `rfkill unblock wifi`, `mkdir -p .../dnsmasq-shared.d`.

**Latent, not an outage:** a stock Pi image ships `010_pi-nopasswd` granting `NOPASSWD: ALL`, which satisfies all of them. Confirmed on the rig. It bites once that rule is removed.

### A hole I opened and review caught

My first version granted `iptables *`. That permits `iptables --modprobe=/path/to/anything`, which iptables runs **as root** — a root shell for the web user, strictly worse than the gap it closed. Removed, and a test now fails on any trailing-wildcard grant to a tool that can exec another program.

**Deliberately not covered:** the portal also runs `iptables`, `nft`, `ip addr`, `ip link` and `cp` with arguments built at runtime. Those need a wildcard, which is the escalation above. Closing that half needs a privileged helper taking only an interface and a port — a design decision, not a one-line grant.

---

## Verification

**41 tests pass** across the systemd, sudoers and startup-validator suites. The installer parses (`bash -n`), and the generated sudoers passes `visudo -c`.

Mutation-checked, ten ways: each of the six grants individually, removing/weakening the arena cap, never reporting unit drift, making drift fatal, and comparing units as raw text (which would warn on every boot over comments alone — that one my first attempt missed, because the comment-insensitivity tests exercised the helper rather than the code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STMbQE4YctTacQXfbYqKuW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Startup validation now warns when installed service configurations differ from the expected versions, while ignoring harmless formatting differences.
  - Captive portal Wi‑Fi operations now have more narrowly scoped passwordless permissions.

- **Performance**
  - Reduced memory overhead for the LED matrix service through allocator tuning.

- **Reliability**
  - Added safeguards and validation to help prevent overly broad system command permissions and detect service configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->