### PR TITLE
fix(web): stop an unrelated config edit from erasing a plugin's secret

### DIFF
--- a/test/web_interface/test_api_v3_secret_roundtrip.py
+++ b/test/web_interface/test_api_v3_secret_roundtrip.py
@@ -194,15 +194,46 @@ class TestSavePluginConfig:
 
     def test_secret_count_message_counts_top_level_keys(self, env):
         # Pinned: the "(N secret field(s))" message counts TOP-LEVEL keys of
-        # the separated secrets dict. Here that is 2: the posted accounts
-        # array (all its item tokens count as ONE key) plus the schema's
-        # api_key default ("") that merge_with_defaults adds before
-        # separation.
+        # the separated secrets dict. Here that is 1: the posted accounts
+        # array, whose item tokens all count as ONE key.
+        #
+        # It was 2 before blank secrets were dropped, the second being the
+        # schema's api_key default (""), which merge_with_defaults adds to
+        # every save. Counting it was the visible edge of a real bug: that
+        # injected blank was merged over the stored api_key, so saving any
+        # unrelated field destroyed the credential. See
+        # test_an_unrelated_edit_does_not_erase_a_stored_secret.
         resp = self._save(env, {
             "accounts": [{"name": "a", "token": "t"}],
         })
         message = resp.get_json()["message"]
-        assert "(2 secret field(s) saved to config_secrets.json)" in message
+        assert "(1 secret field(s) saved to config_secrets.json)" in message
+
+    def test_an_unrelated_edit_does_not_erase_a_stored_secret(self, env):
+        """Editing one field must not wipe the plugin's API key.
+
+        The config form renders secrets masked, so the browser posts them
+        back blank; merge_with_defaults injects a blank api_key even when
+        the client omits it entirely. Either way a "" reached the secrets
+        file and deep_merge wrote it over the stored credential.
+        """
+        assert self._save(env, {"api_key": "REAL-KEY-0123456789",
+                                "city": "Austin"}).status_code == 200
+        assert _on_disk(env.secrets_file)[PLUGIN_ID]["api_key"] == \
+            "REAL-KEY-0123456789"
+
+        # the user changes the city; the masked api_key rides along blank
+        assert self._save(env, {"api_key": "", "city": "Dallas"}).status_code == 200
+
+        assert _on_disk(env.secrets_file)[PLUGIN_ID]["api_key"] == \
+            "REAL-KEY-0123456789", "an unrelated edit destroyed the API key"
+        assert env.fresh_load()[PLUGIN_ID]["city"] == "Dallas"
+
+    def test_a_secret_can_still_be_changed(self, env):
+        """Dropping blanks must not stop a real new value from being saved."""
+        self._save(env, {"api_key": "first-key"})
+        self._save(env, {"api_key": "second-key"})
+        assert _on_disk(env.secrets_file)[PLUGIN_ID]["api_key"] == "second-key"
 
     def test_resave_replaces_stored_secrets_list_wholesale(self, env):
         # Characterized: api_v3's deep_merge intentionally replaces lists,

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -21,7 +21,8 @@ logger = logging.getLogger(__name__)
 # Import new infrastructure
 from src.web_interface.api_helpers import success_response, error_response, validate_request_json
 from src.web_interface.errors import ErrorCode
-from src.web_interface.secret_helpers import find_secret_fields, separate_secrets
+from src.web_interface.secret_helpers import (find_secret_fields, remove_empty_secrets,
+                                              separate_secrets)
 from src.web_interface.error_handler import describe_exception, redact_text
 from src.plugin_system.operation_types import OperationType
 from src.web_interface.validators import (
@@ -1216,6 +1217,11 @@ def save_main_config():
 
                 # Separate secrets from regular config (same logic as save_plugin_config)
                 regular_config, secrets_config = separate_secrets(plugin_config, secret_fields)
+                # The config form renders secrets masked, so every save posts
+                # them back blank. Without this the blank is merged over the
+                # stored value and the credential is destroyed by the act of
+                # changing an unrelated setting. A blank means "unchanged".
+                secrets_config = remove_empty_secrets(secrets_config)
 
                 # PRE-PROCESSING: Preserve 'enabled' state if not in regular_config
                 # This prevents overwriting the enabled state when saving config from a form that doesn't include the toggle
@@ -5599,6 +5605,11 @@ def save_plugin_config():
         # Separate secrets from regular config (handles nested configs and
         # array-item secrets — see src/web_interface/secret_helpers.py)
         regular_config, secrets_config = separate_secrets(plugin_config, secret_fields)
+        # The config form renders secrets masked, so every save posts
+        # them back blank. Without this the blank is merged over the
+        # stored value and the credential is destroyed by the act of
+        # changing an unrelated setting. A blank means "unchanged".
+        secrets_config = remove_empty_secrets(secrets_config)
 
         # Get current configs
         current_config = api_v3.config_manager.load_config()


### PR DESCRIPTION
## Saving any plugin setting erases that plugin's API key

Change the city on the weather plugin, and the weather API key is gone. The
plugin keeps rendering until its next fetch, then fails with no indication that
a credential was destroyed — and the field it was typed into still looks the
same afterwards, because it renders masked either way.

Reproduced end to end through the real endpoint, not the helpers:

```
after saving the key : 'REAL-KEY-0123456789'
after editing city   : ''            <-- on pristine main
```

## Why nothing stopped it

Every step is individually reasonable, which is why this survived:

| step | behaviour |
|---|---|
| `pages_v3.py:740` | masks secrets before rendering the form — fail closed, correct |
| the form | `hx-post`, so htmx submits *every* field, including the blanked one |
| `_parse_value` | "preserve empty string instead of None" for optional strings — deliberate |
| `separate_secrets` | routes `{'api_key': ''}` into `secrets_config`, a truthy dict |
| `deep_merge` | writes the blank over the stored credential |

The blank does not even require the round-trip. `merge_with_defaults` injects
the schema's `api_key` default (`""`) into every save, so a client that never
sends the field still erases it.

## The fix already existed

`remove_empty_secrets()` is in `secret_helpers.py` with seven unit tests and a
docstring describing this exact scenario:

> clients "will send those empty strings back. This filter strips them so that
> existing stored secrets are not overwritten with blanks."

It was called from **no production code**. Its counterpart `mask_secret_fields`
was wired in; the half that protects the write path was not. This wires it into
both save paths that merge into the secrets file (`save_plugin_config` and the
plugin branch of `save_main_config`).

## What changes for users

A blank now means "unchanged" rather than "delete" — the contract the helper's
own tests already describe. The cost is that a secret can no longer be cleared
by emptying the field. That needs its own affordance, and it should: a control
that destroys credentials as a side effect of ordinary edits is not a way to
clear them.

## Verification

- New `test_an_unrelated_edit_does_not_erase_a_stored_secret` drives the real
  Flask endpoint; **reverting the guard makes it fail** with `''` read back.
- `test_a_secret_can_still_be_changed` guards the over-correction — a real new
  value must still save.
- `test_secret_count_message_counts_top_level_keys` changed 2 → 1. It was
  counting the injected blank as a "saved secret field", pinning the bug's
  visible edge as expected behaviour; the comment now records that.
- 262 web tests pass.

## Related, not fixed here

`save_main_config` logs the entire POSTed body at ERROR on every save
(`logging.error(f"DEBUG: save_main_config received data: {data}")`, plus full
request headers). That puts credentials in the journal and is debug output
shipped at ERROR level. Separate change.
