### PR TITLE
fix(web): stop dumping the config and request headers to the journal

### DIFF
--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -715,10 +715,12 @@ def save_main_config():
         if not data:
             return jsonify({'status': 'error', 'message': 'No data provided'}), 400
 
-        import logging
-        logging.error(f"DEBUG: save_main_config received data: {data}")
-        logging.error(f"DEBUG: Content-Type header: {request.content_type}")
-        logging.error(f"DEBUG: Headers: {dict(request.headers)}")
+        # What arrives here is the config itself, and the headers carry the
+        # session cookie -- neither belongs in the journal, least of all at
+        # ERROR on every save. The shape of the request is the part with
+        # diagnostic value, so log that, at the level it deserves.
+        logger.debug("save_main_config: %s, %d top-level key(s)",
+                     request.content_type or 'no content-type', len(data))
 
         # Merge with existing config (similar to original implementation)
         current_config = api_v3.config_manager.load_config()


### PR DESCRIPTION
`save_main_config` logged its whole POST body and full request headers at **ERROR**, on every save:

```python
logging.error(f"DEBUG: save_main_config received data: {data}")
logging.error(f"DEBUG: Content-Type header: {request.content_type}")
logging.error(f"DEBUG: Headers: {dict(request.headers)}")
```

The body is the configuration itself; the headers carry the session cookie. A routine settings change wrote both to the journal, at a level that survives any sane log filter.

They are leftover debug output — they say `DEBUG:` in the message while calling `logging.error`, and they use the root logger rather than the module logger, so the level configured for this blueprint never applied.

Replaced with a `logger.debug` line recording the request's shape, which is the part with diagnostic value. The local `import logging` went too: it shadowed a module-level import already present at line 13.

260 web tests pass.

Found while investigating #478, which fixes the credential erasure in the same function.