### PR TITLE
fix(web): ask for the restart that makes an update take effect

### DIFF
--- a/test/test_update_prompts_restart.py
+++ b/test/test_update_prompts_restart.py
@@ -1,0 +1,84 @@
+"""A pull that changed nothing on the running system is not an applied update.
+
+git_pull replaces files on disk and restarts nothing -- there is no systemctl
+call anywhere in the handler. The display and web services keep running the
+code they loaded at boot, so the user is told "Code updated successfully" and
+sees no change until they happen to reboot. The response now says whether a
+restart is owed, and the UI raises the existing restart-pending banner.
+"""
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from web_interface.blueprints import api_v3 as mod  # noqa: E402
+from web_interface.blueprints.api_v3 import api_v3  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.register_blueprint(api_v3, url_prefix='/api/v3')
+    # The handler consults these after a successful pull; None is the
+    # "not wired up" case it already guards for.
+    api_v3.plugin_store_manager = None
+    api_v3.config_manager = None
+    return app.test_client()
+
+
+def _git(heads, pull_rc=0, pull_out='Updating a1b2c3..d4e5f6\n'):
+    """Fake git. `heads` are the successive answers to rev-parse HEAD."""
+    seq = list(heads)
+
+    def run(args, **kwargs):
+        def ok(stdout='', rc=0, b=False):
+            return subprocess.CompletedProcess(
+                args, rc, stdout=(stdout.encode() if b else stdout),
+                stderr=(b'' if b else ''))
+        if args[:2] == ['git', 'rev-parse'] and args[-1] == 'HEAD':
+            return ok(seq.pop(0) + '\n' if seq else 'deadbeef\n')
+        if 'symbolic-full-name' in args or '@{u}' in args:
+            return ok('origin/main\n')
+        if args[:2] == ['git', 'status']:
+            return ok('')
+        if args[:2] == ['git', 'diff']:
+            return ok('')
+        if args[:2] == ['git', 'pull']:
+            return ok(pull_out, pull_rc)
+        return ok('')
+    return run
+
+
+def _pull(client):
+    return client.post('/api/v3/system/action',
+                       json={'action': 'git_pull'}).get_json()
+
+
+class TestRestartIsRequestedWhenCodeChanged:
+    def test_a_pull_that_moved_head_asks_for_a_restart(self, client):
+        with patch.object(mod.subprocess, 'run', _git(['aaa111', 'bbb222'])):
+            data = _pull(client)
+        assert data['status'] == 'success'
+        assert data['restart_required'] is True, (
+            "new code on disk, services still running the old code, and "
+            "nothing told the user to restart")
+
+    def test_already_up_to_date_does_not(self, client):
+        with patch.object(mod.subprocess, 'run',
+                          _git(['aaa111', 'aaa111'], pull_out='Already up to date.\n')):
+            data = _pull(client)
+        assert data['status'] == 'success'
+        assert data['restart_required'] is False, (
+            "prompting after a no-op update trains users to ignore the prompt")
+
+    def test_a_failed_pull_does_not(self, client):
+        with patch.object(mod.subprocess, 'run', _git(['aaa111'], pull_rc=1)):
+            data = _pull(client)
+        assert data['status'] == 'error'
+        assert data['restart_required'] is False

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -1996,6 +1996,11 @@ def execute_system_action():
             except subprocess.TimeoutExpired:
                 logger.warning("git rev-parse timed out before pull")
 
+            # Whether the pull actually brought new code in. "Already up to
+            # date" is a success too, and prompting for a restart then would
+            # train users to ignore the prompt.
+            code_changed = False
+
             # Perform the git pull. Branches without an upstream were given
             # an explicit "origin <branch>" above so the update still works.
             result = subprocess.run(
@@ -2039,6 +2044,7 @@ def execute_system_action():
                                            capture_output=True, text=True, timeout=10, cwd=project_dir)
                     new_head = _post.stdout.strip() if _post.returncode == 0 else None
                     if old_head and new_head and old_head != new_head:
+                        code_changed = True
                         diff = subprocess.run(
                             ['git', 'diff', '--name-only', f'{old_head}..{new_head}'],
                             capture_output=True, text=True, timeout=15, cwd=project_dir)
@@ -2098,9 +2104,14 @@ def execute_system_action():
                                if ln.strip()), '')
                 pull_message = f"Update failed: {detail}" if detail else "Update failed; check logs for details"
 
+            # Nothing here restarts anything: the pull replaces files on
+            # disk while the display and web services keep running the code
+            # they loaded at boot. Without this the user is told the update
+            # succeeded and sees no change until they happen to reboot.
             return jsonify({
                 'status': 'success' if result.returncode == 0 else 'error',
                 'message': pull_message,
+                'restart_required': bool(result.returncode == 0 and code_changed),
             })
         elif action == 'checkout_branch':
             # Switch branches from the Tools tab. Needed because a checkout

--- a/web_interface/static/v3/app.js
+++ b/web_interface/static/v3/app.js
@@ -116,14 +116,25 @@ document.body.addEventListener('htmx:afterRequest', function(event) {
 // ===== Restart-pending banner =====
 // Shown after restart-requiring saves; persists across tab switches (and
 // reloads, via sessionStorage) until the display restarts or it's dismissed.
-window.showRestartPending = function() {
-    try { sessionStorage.setItem('ledmatrix-restart-pending', '1'); } catch { /* private browsing */ }
+window.showRestartPending = function(message) {
+    try {
+        sessionStorage.setItem('ledmatrix-restart-pending', '1');
+        // Persisted alongside the flag: a code update and a config save want
+        // different wording, and the banner outlives the page that raised it.
+        if (message) sessionStorage.setItem('ledmatrix-restart-pending-text', message);
+        else sessionStorage.removeItem('ledmatrix-restart-pending-text');
+    } catch { /* private browsing */ }
     const banner = document.getElementById('restart-pending-banner');
+    const text = document.getElementById('restart-pending-text');
+    if (text && message) text.textContent = message;
     if (banner) banner.style.display = 'block';
 };
 
 window.dismissRestartPending = function() {
-    try { sessionStorage.removeItem('ledmatrix-restart-pending'); } catch { /* no-op */ }
+    try {
+        sessionStorage.removeItem('ledmatrix-restart-pending');
+        sessionStorage.removeItem('ledmatrix-restart-pending-text');
+    } catch { /* no-op */ }
     const banner = document.getElementById('restart-pending-banner');
     if (banner) banner.style.display = 'none';
 };
@@ -151,6 +162,9 @@ document.addEventListener('DOMContentLoaded', function() {
     try {
         if (sessionStorage.getItem('ledmatrix-restart-pending') === '1') {
             const banner = document.getElementById('restart-pending-banner');
+            const saved = sessionStorage.getItem('ledmatrix-restart-pending-text');
+            const text = document.getElementById('restart-pending-text');
+            if (text && saved) text.textContent = saved;
             if (banner) banner.style.display = 'block';
         }
     } catch { /* no-op */ }

--- a/web_interface/templates/v3/base.html
+++ b/web_interface/templates/v3/base.html
@@ -413,7 +413,8 @@
             <div class="flex items-center justify-between">
                 <div class="flex items-center space-x-3">
                     <i class="fas fa-rotate text-lg"></i>
-                    <span class="text-sm font-medium" aria-live="polite">
+                    <span class="text-sm font-medium" aria-live="polite"
+                          id="restart-pending-text">
                         Configuration saved &mdash; restart the display to apply the changes
                     </span>
                 </div>
@@ -1146,6 +1147,13 @@
             if (data.status === 'success') {
                 document.getElementById('update-banner').style.display = 'none';
                 try { sessionStorage.removeItem('update-sha-dismissed'); } catch(e) {}
+                // The pull replaced files on disk; the running services still
+                // hold the code they loaded at boot. Ask for the restart that
+                // makes the update actually take effect.
+                if (data.restart_required && typeof window.showRestartPending === 'function') {
+                    window.showRestartPending(
+                        'Update installed \u2014 restart the display to run the new code');
+                }
             }
             if (typeof showNotification === 'function') {
                 showNotification(data.message || 'Update complete', data.status || 'success');


### PR DESCRIPTION
Third in the update-path series (#482, #483). Those cover checkouts that cannot pull. This one covers a pull that succeeds and still changes nothing the user can see.

## The update button restarts nothing

The `git_pull` handler is 172 lines and contains **zero** occurrences of `systemctl`, `restart`, `reload`, `reboot` or `service`:

```
git_pull handler: lines 1933-2104 (172 lines)
  'restart': 0 occurrence(s)
  'systemctl': 0 occurrence(s)
  'reload': 0 occurrence(s)
  'reboot': 0 occurrence(s)
  'service': 0 occurrence(s)
```

It stashes, pulls, installs changed requirements, re-removes plugins the user had uninstalled — and returns **"Code updated successfully."**

Both services go on running the code they loaded at boot. The display keeps rendering the old build; the web interface keeps serving the old build. The user is told the update worked, sees no change, and the next reboot is what actually applies it — whenever that happens to be.

## The affordance already exists

The **restart-pending banner** is raised after main-config saves ("Configuration saved — restart the display to apply the changes") with a Restart Now button already wired to `restart_display_service`. A code update is a stronger reason to show it than a config save is, and it was the one path that never did.

## What changed

- The response reports `restart_required`, and `applyUpdate` raises the banner with wording for a code update.
- The banner's message became a parameter, persisted next to the existing flag in `sessionStorage` — it outlives the page that raised it, so the text has to survive a reload too.
- `restart_required` is true **only when the pull actually moved HEAD**. "Already up to date" is a success as well, and prompting after a no-op would train users to dismiss the prompt unread.

## Scope

This covers the **display** service — what the Restart Now button drives, and what users actually notice. The web interface still picks up its own new code on its next restart. Restarting it from inside a request it is currently serving is a bigger change with real failure modes, and it belongs in its own PR rather than smuggled into this one.

## Verification

Three tests driving the endpoint with git mocked: HEAD moved → asks for a restart; already-up-to-date → does not; failed pull → does not. **Reverting the flag fails the first.** 290 tests pass.

Touches a different region of `api_v3.py` than #482 (`resolve_pull_command`) and #483 (`check_for_update`), so all three are independent.
