### PR TITLE
fix(backup): stop a restore repointing the device at another panel

### DIFF
--- a/src/backup_manager.py
+++ b/src/backup_manager.py
@@ -111,6 +111,12 @@ class RestoreOptions:
     """Which sections of a backup should be restored."""
 
     restore_config: bool = True
+    #: Whether to take the backup's display.hardware block as well.
+    #: Off by default: that block describes the panel physically wired to
+    #: *this* device -- its size, chain length, mapping, multiplexing and
+    #: refresh cap. A backup carries the panel of the machine it was taken
+    #: on, and restoring one onto a different rig drives the wrong geometry.
+    restore_hardware: bool = False
     restore_secrets: bool = True
     restore_wifi: bool = True
     restore_fonts: bool = True
@@ -549,6 +555,60 @@ def _copy_file(src: Path, dst: Path) -> None:
         raise
 
 
+_HARDWARE_PATH = ("display", "hardware")
+
+
+def _restore_config_preserving_hardware(src: Path, dst: Path, keep_hardware: bool) -> None:
+    """Copy a backed-up config.json, optionally keeping the local panel block.
+
+    display.hardware describes the panel physically attached to this device:
+    cols, rows, chain_length, hardware_mapping, panel_type, multiplexing and
+    the refresh-rate cap. None of that travels with a configuration -- it is a
+    property of the machine. Restoring a backup taken on a 512x64 rig onto a
+    128x32 one used to overwrite the smaller panel's geometry with the larger
+    one's, which is not a setting the user can see going wrong; the display
+    simply stops being right.
+
+    Falls back to a plain copy when either file cannot be parsed, so a restore
+    never fails because of this.
+    """
+    if not keep_hardware:
+        _copy_file(src, dst)
+        return
+    try:
+        incoming = json.loads(src.read_text(encoding="utf-8"))
+        local = json.loads(dst.read_text(encoding="utf-8")) if dst.exists() else {}
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            "[Backup] Could not merge local panel config (%s); restoring the "
+            "backup's config.json as-is", exc)
+        _copy_file(src, dst)
+        return
+
+    section, key = _HARDWARE_PATH
+    local_hw = (local.get(section) or {}).get(key)
+    if not isinstance(local_hw, dict) or not local_hw:
+        _copy_file(src, dst)
+        return
+
+    if not isinstance(incoming.get(section), dict):
+        incoming[section] = {}
+    incoming_hw = incoming[section].get(key)
+    incoming[section][key] = local_hw
+    if isinstance(incoming_hw, dict) and incoming_hw != local_hw:
+        logger.info(
+            "[Backup] Kept this device's display.hardware; the backup's panel "
+            "was %sx%s chain %s, this one is %sx%s chain %s",
+            incoming_hw.get("cols"), incoming_hw.get("rows"),
+            incoming_hw.get("chain_length"),
+            local_hw.get("cols"), local_hw.get("rows"),
+            local_hw.get("chain_length"))
+
+    tmp_path = dst.with_suffix(dst.suffix + ".restore-tmp")
+    tmp_path.write_text(json.dumps(incoming, indent=2) + "\n", encoding="utf-8")
+    os.replace(tmp_path, dst)
+
+
 def restore_backup(
     zip_path: Path,
     project_root: Path,
@@ -584,7 +644,9 @@ def restore_backup(
         # Main config.
         if options.restore_config and (tmp_dir / _CONFIG_REL).exists():
             try:
-                _copy_file(tmp_dir / _CONFIG_REL, project_root / _CONFIG_REL)
+                _restore_config_preserving_hardware(
+                    tmp_dir / _CONFIG_REL, project_root / _CONFIG_REL,
+                    keep_hardware=not options.restore_hardware)
                 result.restored.append("config")
             except OSError as e:
                 logger.error("[Backup] Failed to restore config.json: %s", e, exc_info=True)

--- a/src/backup_manager.py
+++ b/src/backup_manager.py
@@ -604,9 +604,21 @@ def _restore_config_preserving_hardware(src: Path, dst: Path, keep_hardware: boo
             local_hw.get("cols"), local_hw.get("rows"),
             local_hw.get("chain_length"))
 
-    tmp_path = dst.with_suffix(dst.suffix + ".restore-tmp")
-    tmp_path.write_text(json.dumps(incoming, indent=2) + "\n", encoding="utf-8")
-    os.replace(tmp_path, dst)
+    # Write the merged result to a scratch file and hand it to _copy_file
+    # rather than renaming it into place here. _copy_file preserves the
+    # destination's mode and owner on purpose -- these config files are
+    # installed root-owned while the web interface that runs a restore is not
+    # root -- and a bare write would have replaced a root-owned config.json
+    # with one owned by the web user at whatever the umask allows.
+    scratch = dst.with_suffix(dst.suffix + ".merged-tmp")
+    try:
+        scratch.write_text(json.dumps(incoming, indent=2) + "\n", encoding="utf-8")
+        _copy_file(scratch, dst)
+    finally:
+        try:
+            scratch.unlink()
+        except OSError:
+            pass
 
 
 def restore_backup(

--- a/src/backup_manager.py
+++ b/src/backup_manager.py
@@ -585,6 +585,19 @@ def _restore_config_preserving_hardware(src: Path, dst: Path, keep_hardware: boo
         _copy_file(src, dst)
         return
 
+    # json.loads accepts any JSON value, so a file holding null, [] or "text"
+    # parses fine and then raises AttributeError on the first .get() below.
+    # restore_backup() only catches OSError around this call, so that escaped
+    # as an unhandled error and aborted the whole restore -- the opposite of
+    # the plain-copy fallback this function promises.
+    if not isinstance(incoming, dict) or not isinstance(local, dict):
+        logger.warning(
+            "[Backup] config.json is valid JSON but not an object (backup: %s, "
+            "local: %s); restoring the backup's config.json as-is",
+            type(incoming).__name__, type(local).__name__)
+        _copy_file(src, dst)
+        return
+
     section, key = _HARDWARE_PATH
     local_hw = (local.get(section) or {}).get(key)
     if not isinstance(local_hw, dict) or not local_hw:

--- a/test/test_restore_keeps_panel_hardware.py
+++ b/test/test_restore_keeps_panel_hardware.py
@@ -15,6 +15,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from src.backup_manager import _restore_config_preserving_hardware  # noqa: E402
@@ -29,9 +31,11 @@ SMALL = {"display": {"hardware": {"cols": 64, "rows": 32, "chain_length": 2,
          "timezone": "UTC"}
 
 
-def _run(tmp, keep):
-    src = tmp / "backup_config.json"; src.write_text(json.dumps(BIG))
-    dst = tmp / "config.json"; dst.write_text(json.dumps(SMALL))
+def _run(tmp, keep, local_text=None, backup_text=None):
+    src = tmp / "backup_config.json"
+    src.write_text(backup_text if backup_text is not None else json.dumps(BIG))
+    dst = tmp / "config.json"
+    dst.write_text(local_text if local_text is not None else json.dumps(SMALL))
     _restore_config_preserving_hardware(src, dst, keep_hardware=keep)
     return json.loads(dst.read_text())
 
@@ -59,8 +63,10 @@ def test_opting_in_takes_the_backups_panel(tmp_path):
 
 
 def test_a_device_with_no_local_hardware_takes_the_backups(tmp_path):
-    src = tmp_path / "b.json"; src.write_text(json.dumps(BIG))
-    dst = tmp_path / "c.json"; dst.write_text(json.dumps({"timezone": "UTC"}))
+    src = tmp_path / "b.json"
+    src.write_text(json.dumps(BIG))
+    dst = tmp_path / "c.json"
+    dst.write_text(json.dumps({"timezone": "UTC"}))
     _restore_config_preserving_hardware(src, dst, keep_hardware=True)
     out = json.loads(dst.read_text())
     assert out["display"]["hardware"]["cols"] == 128, (
@@ -68,8 +74,10 @@ def test_a_device_with_no_local_hardware_takes_the_backups(tmp_path):
 
 
 def test_unparseable_local_config_still_restores(tmp_path):
-    src = tmp_path / "b.json"; src.write_text(json.dumps(BIG))
-    dst = tmp_path / "c.json"; dst.write_text("{ not json")
+    src = tmp_path / "b.json"
+    src.write_text(json.dumps(BIG))
+    dst = tmp_path / "c.json"
+    dst.write_text("{ not json")
     _restore_config_preserving_hardware(src, dst, keep_hardware=True)
     assert json.loads(dst.read_text())["timezone"] == "America/New_York", (
         "a restore must never fail because of this merge")
@@ -85,8 +93,10 @@ def test_the_destination_mode_is_preserved(tmp_path):
     """
     import os
     import stat as statmod
-    src = tmp_path / "b.json"; src.write_text(json.dumps(BIG))
-    dst = tmp_path / "c.json"; dst.write_text(json.dumps(SMALL))
+    src = tmp_path / "b.json"
+    src.write_text(json.dumps(BIG))
+    dst = tmp_path / "c.json"
+    dst.write_text(json.dumps(SMALL))
     os.chmod(dst, 0o600)
 
     _restore_config_preserving_hardware(src, dst, keep_hardware=True)
@@ -97,8 +107,39 @@ def test_the_destination_mode_is_preserved(tmp_path):
 
 
 def test_no_scratch_file_is_left_behind(tmp_path):
-    src = tmp_path / "b.json"; src.write_text(json.dumps(BIG))
-    dst = tmp_path / "c.json"; dst.write_text(json.dumps(SMALL))
+    src = tmp_path / "b.json"
+    src.write_text(json.dumps(BIG))
+    dst = tmp_path / "c.json"
+    dst.write_text(json.dumps(SMALL))
     _restore_config_preserving_hardware(src, dst, keep_hardware=True)
     leftovers = [p.name for p in tmp_path.iterdir() if "tmp" in p.name]
     assert not leftovers, f"scratch files left in place: {leftovers}"
+
+
+@pytest.mark.parametrize("shape", ["null", "[1, 2]", '"a string"', "42"])
+def test_a_non_object_local_config_falls_back_to_a_plain_copy(tmp_path, shape):
+    """json.loads accepts any JSON value, not just objects.
+
+    A config.json holding null/[]/"text" parsed fine and then raised
+    AttributeError on the first .get(). restore_backup() only catches OSError
+    around this call, so that escaped unhandled and aborted the entire
+    restore -- the opposite of the plain-copy fallback promised here.
+    """
+    out = _run(tmp_path, keep=True, local_text=shape)
+    assert out == BIG, "the backup was not restored as-is"
+
+
+@pytest.mark.parametrize("shape", ["null", "[1, 2]", '"a string"', "42"])
+def test_a_non_object_backup_config_falls_back_to_a_plain_copy(tmp_path, shape):
+    """Same hazard from the other side: the backup itself may not be an object."""
+    out = _run(tmp_path, keep=True, backup_text=shape)
+    assert out == json.loads(shape), "the backup was not restored as-is"
+
+
+def test_a_missing_local_config_still_restores(tmp_path):
+    """dst.exists() is False -> local defaults to {} and must not trip the guard."""
+    src = tmp_path / "backup_config.json"
+    src.write_text(json.dumps(BIG))
+    dst = tmp_path / "config.json"
+    _restore_config_preserving_hardware(src, dst, keep_hardware=True)
+    assert json.loads(dst.read_text()) == BIG

--- a/test/test_restore_keeps_panel_hardware.py
+++ b/test/test_restore_keeps_panel_hardware.py
@@ -73,3 +73,32 @@ def test_unparseable_local_config_still_restores(tmp_path):
     _restore_config_preserving_hardware(src, dst, keep_hardware=True)
     assert json.loads(dst.read_text())["timezone"] == "America/New_York", (
         "a restore must never fail because of this merge")
+
+
+def test_the_destination_mode_is_preserved(tmp_path):
+    """config.json is installed with a deliberate mode; a merge must not widen it.
+
+    _copy_file preserves the destination's mode and owner on purpose -- these
+    files are root-owned while the web interface running the restore is not.
+    Writing the merged result directly would have replaced that with whatever
+    the umask allowed.
+    """
+    import os
+    import stat as statmod
+    src = tmp_path / "b.json"; src.write_text(json.dumps(BIG))
+    dst = tmp_path / "c.json"; dst.write_text(json.dumps(SMALL))
+    os.chmod(dst, 0o600)
+
+    _restore_config_preserving_hardware(src, dst, keep_hardware=True)
+
+    mode = statmod.S_IMODE(os.stat(dst).st_mode)
+    assert mode == 0o600, f"restore widened config.json from 0600 to {oct(mode)}"
+    assert json.loads(dst.read_text())["display"]["hardware"]["cols"] == 64
+
+
+def test_no_scratch_file_is_left_behind(tmp_path):
+    src = tmp_path / "b.json"; src.write_text(json.dumps(BIG))
+    dst = tmp_path / "c.json"; dst.write_text(json.dumps(SMALL))
+    _restore_config_preserving_hardware(src, dst, keep_hardware=True)
+    leftovers = [p.name for p in tmp_path.iterdir() if "tmp" in p.name]
+    assert not leftovers, f"scratch files left in place: {leftovers}"

--- a/test/test_restore_keeps_panel_hardware.py
+++ b/test/test_restore_keeps_panel_hardware.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""A restore must not repoint this device at another machine's panel.
+
+display.hardware describes the panel physically wired to this device -- cols,
+rows, chain_length, hardware_mapping, panel_type, multiplexing, the refresh
+cap. A backup carries the panel of the machine it was taken on. Restoring a
+512x64 rig's backup onto a 128x32 one used to overwrite the smaller panel's
+geometry with the larger one's, and nothing on screen explains why: the
+display just stops being right.
+
+That is not hypothetical. It happened, and the rig it happened to had to be
+reflashed.
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.backup_manager import _restore_config_preserving_hardware  # noqa: E402
+
+BIG = {"display": {"hardware": {"cols": 128, "rows": 64, "chain_length": 4,
+                                "hardware_mapping": "adafruit-hat-pwm"},
+                   "runtime": {"gpio_slowdown": 4}},
+       "timezone": "America/New_York", "some-plugin": {"enabled": True}}
+SMALL = {"display": {"hardware": {"cols": 64, "rows": 32, "chain_length": 2,
+                                  "hardware_mapping": "regular"},
+                     "runtime": {"gpio_slowdown": 2}},
+         "timezone": "UTC"}
+
+
+def _run(tmp, keep):
+    src = tmp / "backup_config.json"; src.write_text(json.dumps(BIG))
+    dst = tmp / "config.json"; dst.write_text(json.dumps(SMALL))
+    _restore_config_preserving_hardware(src, dst, keep_hardware=keep)
+    return json.loads(dst.read_text())
+
+
+def test_local_panel_survives(tmp_path):
+    out = _run(tmp_path, keep=True)
+    hw = out["display"]["hardware"]
+    assert (hw["cols"], hw["rows"], hw["chain_length"]) == (64, 32, 2), (
+        "the restore repointed this device at the backup's panel")
+    assert hw["hardware_mapping"] == "regular", "panel wiring came from the backup"
+
+
+def test_everything_else_is_restored(tmp_path):
+    out = _run(tmp_path, keep=True)
+    assert out["timezone"] == "America/New_York", "config was not restored"
+    assert out["some-plugin"] == {"enabled": True}, "plugin config was not restored"
+    assert out["display"]["runtime"] == {"gpio_slowdown": 4}, (
+        "only display.hardware should be held back")
+
+
+def test_opting_in_takes_the_backups_panel(tmp_path):
+    out = _run(tmp_path, keep=False)
+    hw = out["display"]["hardware"]
+    assert (hw["cols"], hw["rows"], hw["chain_length"]) == (128, 64, 4)
+
+
+def test_a_device_with_no_local_hardware_takes_the_backups(tmp_path):
+    src = tmp_path / "b.json"; src.write_text(json.dumps(BIG))
+    dst = tmp_path / "c.json"; dst.write_text(json.dumps({"timezone": "UTC"}))
+    _restore_config_preserving_hardware(src, dst, keep_hardware=True)
+    out = json.loads(dst.read_text())
+    assert out["display"]["hardware"]["cols"] == 128, (
+        "nothing local to preserve, so the backup's panel should be used")
+
+
+def test_unparseable_local_config_still_restores(tmp_path):
+    src = tmp_path / "b.json"; src.write_text(json.dumps(BIG))
+    dst = tmp_path / "c.json"; dst.write_text("{ not json")
+    _restore_config_preserving_hardware(src, dst, keep_hardware=True)
+    assert json.loads(dst.read_text())["timezone"] == "America/New_York", (
+        "a restore must never fail because of this merge")


### PR DESCRIPTION
`restore_backup` copies the backup's `config.json` over the local one **wholesale**, `display.hardware` included:

```python
_copy_file(tmp_dir / _CONFIG_REL, project_root / _CONFIG_REL)
```

That block is not configuration in the portable sense. It describes the panel physically wired to *this* machine:

```
cols, rows, chain_length, hardware_mapping, panel_type,
multiplexing, led_rgb_sequence, led_pixel_mapper,
disable_hardware_pulsing, limit_refresh_rate_hz
```

So restoring a backup taken on a **512×64** rig onto a **128×32** one repoints the smaller panel at the larger one's geometry. Nothing on screen explains that — the display just stops being right, and the setting that broke it is one the user never touched.

This is not a hypothetical. It happened on my rigs: a devpi backup was restored onto ledpi, and ledpi has not displayed correctly since.

## What changes

`display.hardware` is held back by default; everything else in `config.json` restores exactly as before. `RestoreOptions.restore_hardware` opts into the old behaviour for the case it genuinely suits — restoring onto identical hardware, or onto a replacement for the machine the backup came from.

When the two differ, both the kept and the discarded geometry are logged, so the decision is visible after the fact rather than silent.

Edge cases handled deliberately:

- **No local `display.hardware`** → take the backup's. There is nothing to preserve.
- **Unparseable file on either side** → fall back to the plain copy. A restore must never fail because of this merge.
- **`display.runtime`** is *not* held back — only the panel description is.

## Verification

Five tests covering each case. **Reverting the guard fails the one that matters** (`test_local_panel_survives`). 40 backup and restore tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration restoration now preserves the destination device’s display hardware settings by default.
  * Added an option to explicitly restore display hardware settings from the backup instead.

* **Bug Fixes**
  * Restoration continues successfully when local hardware data is unavailable or the local configuration is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->