### PR TITLE
fix(sports): fetch odds for the games shown, not the whole schedule window

### DIFF
--- a/src/base_classes/sports/modes.py
+++ b/src/base_classes/sports/modes.py
@@ -145,8 +145,7 @@ class SportsUpcoming(SportsCore):
                     if (game['home_abbr'] in self.favorite_teams or 
                         game['away_abbr'] in self.favorite_teams):
                         favorite_games_found += 1
-                    if self.show_odds:
-                        self._fetch_odds(game)
+                    # Odds are NOT fetched here -- see after selection below.
 
             # Enhanced logging for debugging
             self.logger.info(f"Found {all_upcoming_games} total upcoming games in data")
@@ -189,6 +188,20 @@ class SportsUpcoming(SportsCore):
                 team_games.sort(key=lambda g: g.get('start_time_utc') or datetime.max.replace(tzinfo=timezone.utc))
                 # Limit to the specified number of upcoming games
                 team_games = team_games[:self.upcoming_games_to_show]
+
+            # Odds are fetched here, for the games that survived selection,
+            # rather than in the loop that collects them. That loop walks every
+            # upcoming game in the schedule window, and for a college league
+            # the window is enormous -- a live rig logged 946 upcoming games in
+            # one cycle and displayed 1 of them. The comment up there claimed
+            # odds were fetched "only for games that will be displayed", but
+            # the only narrowing it applied was show_favorite_teams_only, which
+            # is not the default; in the usual case nothing narrowed it at all
+            # and every game cost a separate ESPN request on a Pi that is also
+            # driving the panel.
+            if self.show_odds:
+                for game in team_games:
+                    self._fetch_odds(game)
 
             # Log changes or periodically
             should_log = (

--- a/test/test_sports_odds_fanout.py
+++ b/test/test_sports_odds_fanout.py
@@ -52,14 +52,57 @@ def _innermost_loop_iterable(lineno):
     return None if best is None else ast.unparse(best.iter)
 
 
-def _guards_above(lineno):
-    """Source of every `if` test enclosing this line."""
-    out = []
+def _spans(body, lineno):
+    """True when `lineno` falls inside this list of statements."""
+    return any(n.lineno <= lineno <= (n.end_lineno or n.lineno) for n in body)
+
+
+def _parents(tree):
+    table = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            table[child] = node
+    return table
+
+
+PARENTS = _parents(TREE)
+
+
+def _mentions_positively(test, names):
+    """True when `test` references every name, none of them under a `not`.
+
+    Structural, not textual. Matching the unparsed source would accept
+    `not (details["is_live"] or details["is_halftime"])` -- which selects
+    exactly the non-live games this guard exists to exclude -- because the
+    names still appear in the text.
+    """
+    found = set()
+    for node in ast.walk(test):
+        if not (isinstance(node, ast.Constant) and node.value in names):
+            continue
+        negated = False
+        cursor = node
+        while cursor is not test and cursor in PARENTS:
+            cursor = PARENTS[cursor]
+            if isinstance(cursor, ast.UnaryOp) and isinstance(cursor.op, ast.Not):
+                negated = True
+                break
+        if not negated:
+            found.add(node.value)
+    return found >= set(names)
+
+
+def _guarded_by_positive(lineno, names):
+    """True when some enclosing `if` runs this line only if `names` hold.
+
+    Only the TRUE branch counts: an `if` whose `else` contains the call would
+    otherwise look like a guard while doing the opposite.
+    """
     for node in ast.walk(TREE):
-        if isinstance(node, ast.If) and \
-                node.lineno <= lineno <= (node.end_lineno or node.lineno):
-            out.append(ast.unparse(node.test))
-    return out
+        if isinstance(node, ast.If) and _spans(node.body, lineno) \
+                and _mentions_positively(node.test, names):
+            return True
+    return False
 
 
 def test_every_fetch_site_is_accounted_for():
@@ -86,8 +129,8 @@ def test_live_only_fetches_for_games_actually_in_progress():
     for cls, _fn, lineno in _fetch_sites():
         if cls != "SportsLive":
             continue
-        guards = " ".join(_guards_above(lineno))
-        assert "is_live" in guards and "is_halftime" in guards, (
-            f"SportsLive._fetch_odds at line {lineno} is not gated on a game "
-            f"being in progress; guards were: {guards!r}. Without that test it "
-            "fans out across the whole event list.")
+        assert _guarded_by_positive(lineno, {"is_live", "is_halftime"}), (
+            f"SportsLive._fetch_odds at line {lineno} does not sit in the true "
+            "branch of a test requiring the game to be in progress. Without "
+            "that, it fans out across the whole event list -- one sequential "
+            "ESPN request per game.")

--- a/test/test_sports_odds_fanout.py
+++ b/test/test_sports_odds_fanout.py
@@ -1,0 +1,93 @@
+"""Odds must be fetched for the games shown, not every game in the window.
+
+SportsUpcoming.update() collected every upcoming game in the schedule window
+and called _fetch_odds() on each one *inside* that collection loop, narrowing
+to upcoming_games_to_show only afterwards. The comment there said odds were
+fetched "only for games that will be displayed", but the sole narrowing it
+applied was show_favorite_teams_only, which is not the default -- so in the
+usual configuration nothing narrowed it at all.
+
+Measured on a live rig: a college league produced 946 upcoming games in one
+cycle and displayed 1 of them. The same shape on the football plugin produced
+a burst of 467 sequential ESPN requests that ran for 35s and blew that
+plugin's 30s update budget, and it repeats every time the 1h odds TTL expires.
+
+SportsLive is deliberately different: it walks the raw event list because it
+has to find which games are live, but only fetches odds for a game that has
+already passed the is_live/is_halftime test, so the fan-out is bounded by how
+many games are actually in progress.
+"""
+import ast
+from pathlib import Path
+
+import pytest
+
+MODES = (Path(__file__).resolve().parent.parent
+         / "src" / "base_classes" / "sports" / "modes.py")
+TREE = ast.parse(MODES.read_text(encoding="utf-8"))
+
+
+def _fetch_sites():
+    """(class name, method name, lineno) for every self._fetch_odds(...) call."""
+    calls = [n.lineno for n in ast.walk(TREE)
+             if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+             and n.func.attr == "_fetch_odds"]
+    sites = []
+    for cls in [n for n in ast.walk(TREE) if isinstance(n, ast.ClassDef)]:
+        for fn in [n for n in cls.body if isinstance(n, ast.FunctionDef)]:
+            for lineno in calls:
+                if fn.lineno <= lineno <= (fn.end_lineno or fn.lineno):
+                    sites.append((cls.name, fn.name, lineno))
+    assert len(sites) == len(calls), "a _fetch_odds call sits outside any method"
+    return sites
+
+
+def _innermost_loop_iterable(lineno):
+    best = None
+    for node in ast.walk(TREE):
+        if isinstance(node, ast.For) and \
+                node.lineno <= lineno <= (node.end_lineno or node.lineno):
+            if best is None or node.lineno > best.lineno:
+                best = node
+    return None if best is None else ast.unparse(best.iter)
+
+
+def _guards_above(lineno):
+    """Source of every `if` test enclosing this line."""
+    out = []
+    for node in ast.walk(TREE):
+        if isinstance(node, ast.If) and \
+                node.lineno <= lineno <= (node.end_lineno or node.lineno):
+            out.append(ast.unparse(node.test))
+    return out
+
+
+def test_every_fetch_site_is_accounted_for():
+    """A new call site must be classified deliberately, not inherited silently."""
+    found = {(cls, fn) for cls, fn, _ in _fetch_sites()}
+    assert found == {("SportsUpcoming", "update"), ("SportsLive", "update")}, (
+        f"unexpected _fetch_odds call sites: {sorted(found)}. Each one is a "
+        "sequential ESPN request per game -- classify it here on purpose.")
+
+
+def test_upcoming_fetches_only_the_selected_games():
+    for cls, _fn, lineno in _fetch_sites():
+        if cls != "SportsUpcoming":
+            continue
+        iterable = _innermost_loop_iterable(lineno)
+        assert iterable == "team_games", (
+            f"SportsUpcoming._fetch_odds at line {lineno} iterates over "
+            f"{iterable!r}. It must run over team_games -- already narrowed to "
+            "upcoming_games_to_show -- not over every event in the schedule "
+            "window. Each item costs one sequential ESPN request.")
+
+
+def test_live_only_fetches_for_games_actually_in_progress():
+    for cls, _fn, lineno in _fetch_sites():
+        if cls != "SportsLive":
+            continue
+        guards = " ".join(_guards_above(lineno))
+        assert "is_live" in guards and "is_halftime" in guards, (
+            f"SportsLive._fetch_odds at line {lineno} is not gated on a game "
+            f"being in progress; guards were: {guards!r}. Without that test it "
+            "fans out across the whole event list.")


### PR DESCRIPTION
## The bug

`SportsUpcoming.update()` walks every upcoming game in the schedule window and calls `_fetch_odds()` on each one **inside that collection loop**, narrowing to `upcoming_games_to_show` only afterwards. Each call is a separate sequential ESPN request.

The comment sitting directly above it claimed odds were fetched *"only for games that will be displayed"* — but the sole narrowing it applied was `show_favorite_teams_only`, which is not the default. In the usual configuration nothing narrowed it at all.

## Measured on devpi

The football plugin has the same shape, and it is the reason its `update()` keeps timing out:

```
467 odds requests in one 35s burst — 467 distinct events, zero repeats
315 NFL + 152 college-football  (roughly a whole season, not a display window)

ERROR - plugin football-scoreboard operation timed out after 30.0s
```

The burst repeats every time the 1h odds TTL expires:

| hour | requests | cache misses | cache hits |
|---|---|---|---|
| 11:00 | 67 | 67 | 258 |
| 12:00 | 327 | 327 | 5 |
| 13:00 | 957 | 957 | 1060 |
| 14:00 | 1261 | 1261 | 0 |

Between expiries the request rate is **zero** and the cache works correctly — I confirmed a cached entry is a legitimate MISS only once past its 3600s TTL. So this is a thundering herd on expiry, not a caching failure. Fetching only what's displayed is what actually shrinks it.

## The fix

The fetch moves after selection, over `team_games` — the list already cut to `upcoming_games_to_show`. This mirrors the fix the **football plugin already carries**; the shared base class never received it.

`SportsLive` is deliberately left alone: it walks the raw event list because it has to determine which games are live, but only fetches odds for a game that has already passed the `is_live`/`is_halftime` test, so its fan-out is bounded by how many games are actually in progress. The test pins that distinction rather than quietly assuming it.

## On the test

It reads the **AST**, not the source text, and asserts the *complete set* of call sites — so a new one has to be classified deliberately instead of inheriting whichever behaviour it happens to land in.

Writing it that way is what found the `SportsLive` site, which I had missed reading the file by hand. My first version of the assertion was also wrong — it demanded every site iterate `team_games`, which would have flagged the legitimate live path. The test now distinguishes the two.

Mutation-checked:

```
=== fix reverted ===
AssertionError: SportsUpcoming._fetch_odds at line 149 iterates over 'events'.
It must run over team_games -- already narrowed to upcoming_games_to_show --
not over every event in the schedule window.
1 failed, 2 passed
```

## Scope

No plugin currently imports `src.base_classes.sports` — every sports plugin vendors its own copy — so this is **latent today**, not an active fix for the rigs. It matters because the shared base is what a new sports plugin would build on, and it would inherit a fan-out that ESPN will rate-limit.

**Not fixed here, and still open:** I could not account for all 467 requests from football's own two call sites, which are both bounded (`upcoming_games_to_show` is 1 for NFL, and the live filter admitted 0 games that cycle). That needs runtime instrumentation rather than more reading, so I have not guessed at it.

Suite: **525 passed, 9 skipped** across the sports and odds tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upcoming-game odds processing so odds are fetched only for games selected for display.
  * Prevented unnecessary odds requests for games outside the relevant set.
  * Ensured live-game odds are fetched only when games are actively live or in halftime.

* **Tests**
  * Added coverage to verify odds-fetching behavior across upcoming and live game modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->