### PR TITLE
test(logging): stop the location assertion matching the clock

### DIFF
--- a/test/test_logging_config.py
+++ b/test/test_logging_config.py
@@ -89,11 +89,17 @@ class TestContextualFormatter:
         assert "hello" in out
 
     def test_location_toggle(self):
+        # Assert on the whole "module.func:lineno" token, not a bare ":42".
+        # The formatted line starts with an HH:MM:SS timestamp, so a bare
+        # ":{lineno}" also matches the clock whenever the minute or second
+        # happens to equal the line number -- about 3% of runs, which is a
+        # flaky failure with nothing wrong.
         record = make_record()
+        location = f"{record.module}.{record.funcName}:{record.lineno}"
         with_loc = ContextualFormatter(include_location=True).format(record)
         without = ContextualFormatter(include_location=False).format(record)
-        assert f":{record.lineno}" in with_loc
-        assert f":{record.lineno}" not in without
+        assert location in with_loc
+        assert location not in without
 
     def test_record_not_mutated_no_double_prefix(self):
         # Regression: a record is formatted once PER HANDLER. The formatter


### PR DESCRIPTION
Found by a full-suite run that went red on a file I hadn't touched:

```
E   AssertionError: assert ':42' not in '2026-08-22 08:05:42.274 - INFO - test.logger - hello'
E     ':42' is contained here:
E       2026-08-22 08:05:42.274 - INFO - test.logger - hello
```

`test_location_toggle` checks that location info is absent when `include_location=False`. It does that by asserting the substring `f":{record.lineno}"` is missing — and `make_record()` hardcodes `lineno=42`.

Every formatted line begins with an `HH:MM:SS.mmm` timestamp, so `":42"` also matches **the clock**. The test fails whenever the minute or the second happens to be 42 — about **3% of runs**, at a time of day nobody can reproduce on request.

## The fix

Assert on the whole token the format string actually emits:

```python
fmt = '... - %(module)s.%(funcName)s:%(lineno)d - %(message)s'
```

so the assertion becomes `f"{record.module}.{record.funcName}:{record.lineno}"`. That can't collide with a timestamp, and it checks the thing the test is named for rather than a fragment of it.

## Verification

Formatted a record stamped `08:42:42` — minute *and* second colliding:

```
formatted: 2026-08-22 08:42:42.043 - INFO - test.logger - hello
old assertion ':42' not in line    -> False   (the flake)
new assertion location not in line -> True    (fixed)
```

`test/test_logging_config.py` passes; full suite unaffected.

Worth noting because it is the second time this suite has produced a failure that looks like a real regression and isn't — the other being `test_install_lowmem.py`'s tmpfs assumption (#492). Both cost more to diagnose than to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STMbQE4YctTacQXfbYqKuW