### PR TITLE
fix(memory): release fetched payloads once they have been delivered

### DIFF
--- a/src/background_data_service.py
+++ b/src/background_data_service.py
@@ -199,14 +199,18 @@ class BackgroundDataService:
                     cached=True,
                     fetch_time=0.0
                 )
+                # Filed before the callback runs, as it always was: a callback
+                # that queries get_result()/is_request_complete() for its own
+                # request must still find it. Releasing afterwards mutates the
+                # same object the dict holds.
+                self.completed_requests[request_id] = result
+
                 if callback:
                     try:
                         callback(result)
                     except Exception as e:
                         logger.error(f"Error in callback for request {request_id}: {e}")
                     self._release_payload(result)
-
-                self.completed_requests[request_id] = result
 
                 logger.debug(f"Cache hit for {sport} {year} data")
                 return request_id

--- a/src/background_data_service.py
+++ b/src/background_data_service.py
@@ -57,7 +57,15 @@ class FetchRequest:
 
 @dataclass
 class FetchResult:
-    """Result of a background fetch operation."""
+    """Result of a background fetch operation.
+
+    ``data`` survives on the stored result only for requests submitted without
+    a ``callback``, where polling ``get_result()`` is the sole way to collect
+    it. When a callback was given, the payload has already been delivered and
+    the service releases it -- see :meth:`BackgroundDataService._release_payload`.
+    Either way the data remains in the cache under the request's ``cache_key``,
+    which is where consumers read it from.
+    """
     request_id: str
     success: bool
     data: Optional[Any] = None
@@ -191,14 +199,15 @@ class BackgroundDataService:
                     cached=True,
                     fetch_time=0.0
                 )
-                self.completed_requests[request_id] = result
-                
                 if callback:
                     try:
                         callback(result)
                     except Exception as e:
                         logger.error(f"Error in callback for request {request_id}: {e}")
-                
+                    self._release_payload(result)
+
+                self.completed_requests[request_id] = result
+
                 logger.debug(f"Cache hit for {sport} {year} data")
                 return request_id
         
@@ -333,8 +342,29 @@ class BackgroundDataService:
                     request.callback(result)
                 except Exception as e:
                     logger.error(f"Error in callback for request {request.id}: {e}")
-        
+                # Delivered. Drop both references -- they point at the same
+                # object, so one survivor keeps the whole payload resident.
+                self._release_payload(result)
+                request.result = None
+
         return result
+
+    @staticmethod
+    def _release_payload(result: FetchResult) -> None:
+        """Drop a delivered payload, keeping the result's status and timings.
+
+        Only called once a callback has been handed the data. Consumers read
+        fetched data back from the cache under ``cache_key``; the copy carried
+        here was pinning a parsed season schedule -- 946 games for NCAA
+        football, roughly a tenth of total RAM on a 1GB Pi -- in memory until
+        the hourly sweep.
+
+        The cache-hit path matters most: it runs once per update interval per
+        sport, mints a fresh request_id each time, and a memory-tier miss
+        re-parses the payload from disk. Those were genuinely separate copies
+        accumulating toward the 500-entry cap, not shared references.
+        """
+        result.data = None
     
     def _make_request_with_retry(self, request: FetchRequest) -> requests.Response:
         """

--- a/test/test_background_payload_release.py
+++ b/test/test_background_payload_release.py
@@ -51,9 +51,37 @@ def service(cache):
 
 
 def _wait(service, req_id, timeout=5):
+    """Wait for the result to be FILED.
+
+    Enough for anything that is true by the time the worker stores the result:
+    its success flag, its error, the cache write that happened during the
+    fetch.
+    """
     deadline = time.time() + timeout
     while not service.is_request_complete(req_id) and time.time() < deadline:
         time.sleep(0.02)
+
+
+def _wait_for_release(service, req_id, timeout=5):
+    """Wait for the payload to be RELEASED, which is strictly later.
+
+    The worker files the result, then runs the callback, then releases. So
+    is_request_complete() goes true while the callback still has not run --
+    waiting on it alone leaves a window in which `seen` is empty and the
+    payload is still resident, and the assertions race the worker. It passes
+    in practice only because a one-line callback usually beats the 20ms poll.
+
+    Release happens after the callback returns, so a released payload also
+    means the callback has finished: one wait covers both.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        result = service.get_result(req_id)
+        if result is not None and result.data is None:
+            return
+        time.sleep(0.02)
+    raise AssertionError(
+        f"payload for {req_id} was never released (callback may not have run)")
 
 
 def _resp():
@@ -76,7 +104,7 @@ class TestFetchPath:
                 sport="ncaa_fb", year=2026, url="https://example.com/s",
                 cache_key="ncaa_fb_2026", callback=callback, max_retries=0,
             )
-            _wait(service, req_id)
+            _wait_for_release(service, req_id)
 
         assert seen['events'] == 50, "callback must still be handed the payload"
 

--- a/test/test_background_payload_release.py
+++ b/test/test_background_payload_release.py
@@ -1,0 +1,159 @@
+"""A delivered fetch payload must not stay resident on the stored result.
+
+BackgroundDataService kept the fetched body on the FetchResult it filed in
+`completed_requests`, which is swept only hourly and capped at 500 entries by
+count. For status records that is free; for a season schedule it is not. NCAA
+football's 2026 schedule is 946 games, and on a 1GB Pi 3B+ the parsed payload
+measured ~90MB -- a tenth of the board's memory, pinned for an hour after the
+consumer had already been handed it.
+
+The cache-hit path was the worse of the two. It runs once per update interval
+per sport, mints a fresh request_id each time, and hands back whatever the
+cache returns -- so a memory-tier miss (the tier is capped at 150 entries)
+re-parses the payload from disk into a genuinely new object. Those accumulate
+as separate copies rather than shared references, which is the staircase seen
+in the field: RSS stepping up ~90MB per sport as seasons loaded and never
+coming back down.
+
+Releasing is safe because the payload is written to the cache under the
+request's cache_key before the result is built, and that is where consumers
+read it from -- the callback is handed the object directly and the plugins use
+it only in passing before reading the cache back.
+
+Requests submitted *without* a callback keep their payload: polling
+get_result() is then the only way to collect it, so releasing would break that
+contract.
+"""
+
+import time
+import pytest
+from unittest.mock import MagicMock, Mock, patch
+
+from src.background_data_service import BackgroundDataService
+
+
+PAYLOAD = {"events": [{"id": f"g{i}"} for i in range(50)]}
+
+
+@pytest.fixture
+def cache():
+    m = MagicMock()
+    m.get.return_value = None
+    m.set.return_value = None
+    return m
+
+
+@pytest.fixture
+def service(cache):
+    svc = BackgroundDataService(cache, max_workers=2, request_timeout=5)
+    yield svc
+    svc.shutdown(wait=False)
+
+
+def _wait(service, req_id, timeout=5):
+    deadline = time.time() + timeout
+    while not service.is_request_complete(req_id) and time.time() < deadline:
+        time.sleep(0.02)
+
+
+def _resp():
+    r = Mock()
+    r.json.return_value = PAYLOAD
+    r.raise_for_status.return_value = None
+    return r
+
+
+class TestFetchPath:
+    def test_callback_receives_the_payload_then_it_is_released(self, service, cache):
+        seen = {}
+
+        def callback(result):
+            # The consumer's one look at the data happens here.
+            seen['events'] = len(result.data['events'])
+
+        with patch.object(service.session, "get", return_value=_resp()):
+            req_id = service.submit_fetch_request(
+                sport="ncaa_fb", year=2026, url="https://example.com/s",
+                cache_key="ncaa_fb_2026", callback=callback, max_retries=0,
+            )
+            _wait(service, req_id)
+
+        assert seen['events'] == 50, "callback must still be handed the payload"
+
+        stored = service.get_result(req_id)
+        assert stored is not None
+        assert stored.success is True
+        assert stored.data is None, "payload must not stay on the stored result"
+
+    def test_nothing_is_lost_the_cache_holds_it(self, service, cache):
+        with patch.object(service.session, "get", return_value=_resp()):
+            req_id = service.submit_fetch_request(
+                sport="ncaa_fb", year=2026, url="https://example.com/s",
+                cache_key="ncaa_fb_2026", callback=lambda r: None, max_retries=0,
+            )
+            _wait(service, req_id)
+
+        cache.set.assert_called_once()
+        key, written = cache.set.call_args[0][:2]
+        assert key == "ncaa_fb_2026"
+        assert written == PAYLOAD, "the payload must be persisted before release"
+
+    def test_without_a_callback_the_payload_is_kept(self, service, cache):
+        # Polling get_result() is then the only delivery mechanism.
+        with patch.object(service.session, "get", return_value=_resp()):
+            req_id = service.submit_fetch_request(
+                sport="nfl", year=2026, url="https://example.com/s",
+                cache_key="nfl_2026", max_retries=0,
+            )
+            _wait(service, req_id)
+
+        assert service.get_result(req_id).data == PAYLOAD
+
+    def test_a_failed_fetch_still_records_its_error(self, service, cache):
+        with patch.object(service.session, "get", side_effect=Exception("boom")):
+            req_id = service.submit_fetch_request(
+                sport="nfl", year=2026, url="https://example.com/s",
+                cache_key="nfl_2026", callback=lambda r: None, max_retries=0,
+            )
+            _wait(service, req_id)
+
+        stored = service.get_result(req_id)
+        assert stored.success is False
+        assert stored.error is not None
+
+
+class TestCacheHitPath:
+    def test_cache_hit_releases_after_the_callback(self, service, cache):
+        cache.get.return_value = PAYLOAD
+        seen = {}
+
+        req_id = service.submit_fetch_request(
+            sport="ncaa_fb", year=2026, url="https://example.com/s",
+            cache_key="ncaa_fb_2026",
+            callback=lambda r: seen.update(events=len(r.data['events'])),
+        )
+
+        assert seen['events'] == 50
+        assert service.get_result(req_id).data is None
+
+    def test_repeated_cache_hits_do_not_accumulate_payloads(self, service, cache):
+        # The staircase: one entry per update interval per sport, each one
+        # potentially a freshly parsed copy after a memory-tier miss.
+        cache.get.return_value = PAYLOAD
+
+        for _ in range(25):
+            service.submit_fetch_request(
+                sport="ncaa_fb", year=2026, url="https://example.com/s",
+                cache_key="ncaa_fb_2026", callback=lambda r: None,
+            )
+
+        retained = [r for r in service.completed_requests.values() if r.data is not None]
+        assert retained == [], f"{len(retained)} payloads still resident"
+
+    def test_cache_hit_without_a_callback_is_unchanged(self, service, cache):
+        cache.get.return_value = PAYLOAD
+        req_id = service.submit_fetch_request(
+            sport="nfl", year=2026, url="https://example.com/s",
+            cache_key="nfl_2026",
+        )
+        assert service.get_result(req_id).data == PAYLOAD


### PR DESCRIPTION
## Summary

`BackgroundDataService` kept the fetched body on the `FetchResult` it filed in
`completed_requests`, which is swept hourly and capped at **500 entries by
count**. For a status record that costs nothing. For a season schedule it costs
a tenth of the board.

## Measurement

From a 1-second RSS profile on a 1GB Pi 3B+:

```
boot                    118 MB
after plugin load       404 MB
+21 MB   ← NFL season schedule fetch
+90 MB   ← NCAA football 2026 season (946 games)
        = 494 MB, and then flat
```

Flat really means flat — four consecutive minutes at exactly 505 MB later in the
same run. This is **not a leak**; it is a staircase that never comes down.

The consequence is not a clean OOM. When a later fetch lands while headroom is
low, available memory reaches ~70 MB and `fork()` starts failing — so the board
cannot start a process at all:

- `sshd` accepts the TCP connection and closes it before sending its banner
- systemd cannot respawn the display service
- the panel goes dark while the kernel keeps answering pings at 0% loss

It looks like a hardware fault. It isn't. On the affected board this was chased
through a replacement SD card, a replacement PSU, and separating panel power
before the profile above identified it.

## Why the cache-hit path is the worse of the two

```python
cached_data = self.cache_manager.get(cache_key)
if cached_data:
    result = FetchResult(..., data=cached_data, cached=True)
    self.completed_requests[request_id] = result   # ← retained
```

It runs once per update interval per sport, mints a fresh `request_id` each
time, and files whatever the cache returned. The memory tier is capped at 150
entries on a 1GB board, so a tier miss re-parses the payload from disk into a
**genuinely new object** — separate copies accumulating toward the 500-entry
cap, not shared references.

Same shape as the bug fixed in #464: bounded by entry count, when entries range
from 200 bytes to tens of megabytes.

## Why releasing is safe

The payload is written to the cache *before* the result is built:

```python
self.cache_manager.set(request.cache_key, data)   # persisted here
```

The callback is handed the object directly, and consumers read it back from the
cache under `cache_key` afterwards — the plugins' callbacks use it only in
passing, to log an event count, before reading the cache. Nothing is lost; the
data moves from RAM to the disk cache that was already holding it.

Note these were references to one object, not copies, so both the result and
`request.result` are cleared — one surviving reference keeps the payload
resident.

## Backwards compatibility

Requests submitted **without** a callback keep their payload, because polling
`get_result()` is then the only way to collect it. The existing contract and the
existing test covering it (`test_successful_fetch_completes`) are untouched.

## Testing

New `test/test_background_payload_release.py` — 7 tests covering both paths,
that nothing is lost (the cache write is asserted), that failures still record
their error, and that the no-callback contract is preserved.

Verified it is a real regression test. Against unfixed `background_data_service.py`:

```
FAILED  TestFetchPath::test_callback_receives_the_payload_then_it_is_released
FAILED  TestCacheHitPath::test_cache_hit_releases_after_the_callback
FAILED  TestCacheHitPath::test_repeated_cache_hits_do_not_accumulate_payloads
3 failed, 4 passed
```

The 4 that pass either way are the backwards-compatibility ones, which pin
unchanged behaviour by design. With the fix, all 7 pass.

Existing `test/test_background_data_service.py`: **24 passed**, unchanged.

Full suite diffed against `main`: no new failures. One test surfaced in the
diff, `test_display_dirty_tracking::test_snapshot_still_written_on_skip`, and
it is flaky in isolation on both branches — 3/5 pass on this branch, 3/5 on
`main`. Unrelated to this change.

## Not addressed here

Two adjacent issues, left out because they bound the *transient* peak rather
than what stays resident, and both are behaviour changes worth their own review:

- `ThreadPoolExecutor(max_workers=3)` allows three concurrent fetches, so three
  large parses can peak simultaneously
- there is no in-flight dedupe by `cache_key` — a second submit for a key
  already being fetched starts a second fetch. Observed in the field:
  `Starting background fetch for 2026 season schedule` logged twice in the same
  second


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background data handling after callback-based requests.
  * Reduced unnecessary memory usage by releasing payload data after completed callback requests and cache hits.
  * Preserved payloads for polling requests and continued recording fetch errors correctly.

* **Tests**
  * Added coverage for payload cleanup, cache behavior, polling requests, repeated cache hits, and failed fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->