### PR TITLE
fix(install): don't abort when journald settings are absent

### DIFF
--- a/first_time_install.sh
+++ b/first_time_install.sh
@@ -1740,12 +1740,15 @@ journald_effective() {
        systemd-analyze cat-config systemd/journald.conf >/dev/null 2>&1; then
         systemd-analyze cat-config systemd/journald.conf 2>/dev/null
     else
-        cat /etc/systemd/journald.conf /etc/systemd/journald.conf.d/*.conf 2>/dev/null
+        cat /etc/systemd/journald.conf /etc/systemd/journald.conf.d/*.conf 2>/dev/null || true
     fi
 }
 journald_conf="$(journald_effective)"
-journald_storage="$(printf '%s\n' "$journald_conf" | grep -E '^[[:space:]]*Storage=' | tail -n1 | cut -d= -f2 | tr -d '[:space:]')"
-journald_cap="$(printf '%s\n' "$journald_conf" | grep -E '^[[:space:]]*SystemMaxUse=' | tail -n1 | cut -d= -f2 | tr -d '[:space:]')"
+# Both settings are optional, and stock images ship them commented out. grep
+# exits 1 on no match, which pipefail turns fatal under set -e — an absent
+# setting must read as empty, not abort the install.
+journald_storage="$(printf '%s\n' "$journald_conf" | grep -E '^[[:space:]]*Storage=' | tail -n1 | cut -d= -f2 | tr -d '[:space:]' || true)"
+journald_cap="$(printf '%s\n' "$journald_conf" | grep -E '^[[:space:]]*SystemMaxUse=' | tail -n1 | cut -d= -f2 | tr -d '[:space:]' || true)"
 
 if [ "$journald_storage" = "persistent" ] && [ -n "$journald_cap" ]; then
     echo "Persistent journald storage already configured (SystemMaxUse=$journald_cap)"
@@ -1771,7 +1774,7 @@ else
     # after ledmatrix-persistent.conf (zz-local.conf and friends) still wins.
     # Writing the file is not evidence it took effect -- re-read and say so
     # plainly rather than reporting success we cannot confirm.
-    journald_now="$(journald_effective | grep -E '^[[:space:]]*Storage=' | tail -n1 | cut -d= -f2 | tr -d '[:space:]')"
+    journald_now="$(journald_effective | grep -E '^[[:space:]]*Storage=' | tail -n1 | cut -d= -f2 | tr -d '[:space:]' || true)"
     if [ "$journald_now" = "persistent" ]; then
         echo "  Persistent journald storage active"
     else


### PR DESCRIPTION
## Problem

`first_time_install.sh` dies in Step 13 ("Apply performance optimizations") at line 1748, exit 1, on every fresh Raspberry Pi OS image. Reproduced on a Pi 4 (hdpi) — three consecutive install runs all failed at the identical spot.

The journald-persistence block greps the effective journald config for `Storage=` and `SystemMaxUse=`. Both settings are optional and stock images ship them commented out (`#SystemMaxUse=`), so `grep` exits 1. Under the script's `set -Eeuo pipefail`, that fails the command-substitution assignment and the ERR trap aborts the whole install.

`Storage=` happens to survive on current Raspberry Pi OS only because the image ships a `Storage=volatile` drop-in; the `SystemMaxUse=` lookup fails on essentially every system that hasn't set an explicit cap.

## Fix

Guard the four optional-lookup pipelines with `|| true` so an absent setting reads as an empty string instead of aborting:

- `journald_storage=` and `journald_cap=` assignments (the crash site)
- the `journald_now=` re-read after writing the drop-in
- the `cat` fallback inside `journald_effective()` (fails if neither config path exists)

Downstream logic already handles empty values (`[ -n "$journald_cap" ]` decides whether to write `SystemMaxUse=64M`), so no other changes are needed.

## Verification

- `bash -n` passes.
- Reproduced the failing input (`Storage=volatile` present, `SystemMaxUse=` commented) under `set -Eeuo pipefail` with an ERR trap: unpatched pipelines fire the trap; patched ones yield `storage=volatile`, `cap=""` and continue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YF7Q48EYCCkU1Vs932uDY1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability when journald configuration settings are missing or commented out.
  * Prevented valid installations from stopping unexpectedly while reading or verifying journald settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->