### PR TITLE
fix(store): land the install_from_url gate, which never reached main

### DIFF
--- a/src/plugin_system/store_manager.py
+++ b/src/plugin_system/store_manager.py
@@ -1602,6 +1602,26 @@ class PluginStoreManager:
                     'error': f'Manifest missing required fields: {", ".join(missing_fields)}'
                 }
             
+            # Refuse a plugin that needs a newer core than this one, exactly as
+            # _install_plugin_impl does after its download. Sideloading is an
+            # explicit act rather than an automatic store update, but the floor
+            # is not advice about intent -- it is a statement that the plugin
+            # cannot run here, and letting it through produces the same silent
+            # PluginState.ERROR at load. This was the last of the three routes
+            # in that skipped the check.
+            #
+            # Before the move, so the `finally` below removes the temp tree and
+            # nothing half-installed is left behind.
+            from src import __version__ as core_version
+            from src.plugin_system import compatibility
+
+            compatible, reason = compatibility.check(manifest, core_version)
+            if not compatible:
+                self.logger.error(
+                    "Refusing to install %s from %s: %s",
+                    plugin_id, repo_url, reason)
+                return {'success': False, 'error': reason}
+
             # Validate version fields consistency (warnings only, not required)
             validation_errors = self._validate_manifest_version_fields(manifest)
             if validation_errors:

--- a/test/test_plugin_compatibility_gate.py
+++ b/test/test_plugin_compatibility_gate.py
@@ -155,8 +155,9 @@ class TestInstallGate:
     rediscovering it. `update_plugin` also has a git branch that pulls in
     place and never re-downloads; that one is gated separately by
     `_gate_pulled_commit` and pinned in `TestGitPullGate` below. A third
-    route, `install_from_url`, is still ungated — sideloading from a URL
-    checks required fields but not the floor.
+    route, `install_from_url` (sideloading from a URL), is gated in that
+    function and pinned in `TestSideloadGate`. All three refuse on the same
+    rule.
     """
 
     def _install_with_manifest(self, store, manifest, core_version, monkeypatch):
@@ -216,6 +217,73 @@ class TestInstallGate:
             "nearly every published manifest floors at 2.0.0")
         assert (path / "manifest.json").exists()
 
+
+class TestSideloadGate:
+    """`install_from_url` never looked at the core version.
+
+    Sideloading is an explicit act rather than an automatic store update, so
+    the argument for gating it is different: not "the user did not choose
+    this", but that the floor states the plugin *cannot run here*. Letting it
+    through produces the same silent PluginState.ERROR at load that the store
+    gate exists to prevent, and the user who typed the URL is no better placed
+    to diagnose it than one who pressed Update.
+    """
+
+    def _sideload(self, store, manifest, core_version, monkeypatch):
+        mgr, plugins_dir = store
+        plugin_id = manifest["id"]
+
+        def fake_clone(repo_url, target_path, branches=None):
+            target_path.mkdir(parents=True, exist_ok=True)
+            (target_path / "manifest.json").write_text(
+                json.dumps(manifest), encoding="utf-8")
+            (target_path / "manager.py").write_text(
+                "class P: pass\n", encoding="utf-8")
+            return "main"
+
+        monkeypatch.setattr(mgr, "_install_via_git", fake_clone)
+        monkeypatch.setattr(mgr, "_install_dependencies", lambda *a, **k: True)
+
+        import src
+        monkeypatch.setattr(src, "__version__", core_version)
+        return mgr.install_from_url("https://example.invalid/plugin"), \
+            plugins_dir / plugin_id
+
+    def test_refuses_a_plugin_that_needs_a_newer_core(self, store, monkeypatch):
+        manifest = {
+            "id": "sideload-newer", "name": "Sideload", "class_name": "P",
+            "display_modes": ["a"], "min_ledmatrix_version": "9.9.9",
+        }
+        result, path = self._sideload(store, manifest, "3.2.0", monkeypatch)
+
+        assert result["success"] is False
+        assert "9.9.9" in result["error"], result["error"]
+        assert not path.exists(), (
+            "a refused sideload must not leave the plugin installed")
+
+    def test_allows_a_compatible_plugin(self, store, monkeypatch):
+        """The guard against over-refusing: a gate that blocks everything
+        passes the test above and breaks sideloading entirely."""
+        manifest = {
+            "id": "sideload-fine", "name": "Sideload", "class_name": "P",
+            "display_modes": ["a"], "min_ledmatrix_version": "3.0.0",
+        }
+        result, path = self._sideload(store, manifest, "3.2.0", monkeypatch)
+
+        assert result["success"] is True, result.get("error")
+        assert (path / "manifest.json").exists()
+
+    def test_untrustworthy_core_does_not_block_a_2_0_0_floor(
+            self, store, monkeypatch):
+        """Same rule as the other two routes: a v3.1.0 release reports 1.0.0,
+        and nearly every published manifest floors at 2.0.0."""
+        manifest = {
+            "id": "sideload-floored", "name": "Sideload", "class_name": "P",
+            "display_modes": ["a"], "versions": [{"ledmatrix_min": "2.0.0"}],
+        }
+        result, _ = self._sideload(store, manifest, "1.0.0", monkeypatch)
+
+        assert result["success"] is True, result.get("error")
 
 # --------------------------------------------------------------------------
 # The git-pull update path — the one route that does not re-download


### PR DESCRIPTION
**#510 shows as merged, but into `fix/gate-git-pull-updates` — #508's branch — rather than `main`.** #508 reached main first, so the sideload gate was left behind on a branch that is no longer in anyone's way.

Same failure as plugins #350/#351, which merged into each other's bases. Worth knowing the pattern: GitHub reports these as `MERGED`, `gh pr list` shows nothing outstanding, and the code simply isn't there.

## State on main today

| route | gated? |
|---|---|
| `install_plugin` — every path that re-downloads | ✅ #431/#433 |
| `update_plugin`'s git branch | ✅ #508 |
| `install_from_url` — sideloading | ❌ **missing** |

`install_from_url` validates required manifest fields, warns on version-field and schema problems, then installs whatever it found — never comparing the core version.

Verified on main before opening this: `compatibility.check` appears 0 times inside `install_from_url`, and `class TestSideloadGate` is absent from the test file.

## This PR

Cherry-picked unchanged from the orphaned branch — it applies to `main` with **no conflict**.

`TestSideloadGate` pins the same three cases the other two routes pin: refuses a floor above this core and leaves nothing behind; **still allows a compatible plugin** (the guard against a gate that refuses everything and passes the first test); and does not block a `2.0.0` floor on a core reporting an untrustworthy version.

Full suite: **3725 passed, 6 skipped.**

## Verified on hardware

The install gate this completes was exercised end-to-end on a live rig (core `v3.2.0-55-g154525be`) by attempting to install `calendar`, which floors at 3.3.0:

```
store_manager - INFO  - Downloading 9 files for plugins/calendar via API
store_manager - ERROR - Refusing to install calendar: Google Calendar supports
                        LEDMatrix >=3.3.0, but this system is running 3.2.0.
```

Refused after download, with **no partial directory left behind**, and the operation reported as failed rather than silently succeeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RRtqXDCnvnY6EQwhT5CV9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Custom URL plugin installations now verify compatibility before completing installation.
  - Incompatible plugins are rejected with an error instead of being installed.
  - Temporary files are cleaned up after rejected installations.
  - Compatible plugins continue to install successfully, including those meeting the ecosystem’s minimum supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->