### PR TITLE
fix(sports): say when the schema cannot be read, instead of failing silently

### DIFF
--- a/src/common/sports_card.py
+++ b/src/common/sports_card.py
@@ -17,9 +17,12 @@ deliberate difference is `crisp_size`, which takes the seven-plugin guard
 the extra guard only stops a None size raising TypeError.
 """
 
+import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Tuple
 from zoneinfo import ZoneInfo
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "ELEMENT_FOR_FONT", "FAVORITE_RESULT_COLOR_DEFAULTS", "FONT_NAME_ALIASES",
@@ -395,7 +398,14 @@ def schema_font_size(schema_path: str, element_key) -> Optional[int]:
                 size = spec.get('properties', {}).get('font_size', {}).get('default')
                 if size is not None:
                     cache[key] = int(size)
-        except Exception:
+        except Exception as exc:
+            # See sports_shared._schema_font_size: an unreadable schema
+            # silently disables the pixel-grid snap for every element.
+            # Built once per schema path, so this cannot repeat per frame.
+            logger.warning(
+                "could not read %s (%s: %s); font sizes will skip their "
+                "pixel grid snap and may render a pixel narrow",
+                schema_path, type(exc).__name__, exc)
             cache = {}
         _SCHEMA_FONT_SIZE_CACHE[schema_path] = cache
     return cache.get(element_key)

--- a/src/common/sports_shared.py
+++ b/src/common/sports_shared.py
@@ -288,7 +288,23 @@ class SportsCoreSharedMixin:
                     size = spec.get('properties', {}).get('font_size', {}).get('default')
                     if size is not None:
                         cache[key] = int(size)
-            except Exception:
+            except Exception as exc:
+                # Say so. An unreadable schema is not cosmetic: every element's
+                # configured size then stops matching "the schema default", is
+                # treated as a deliberate user choice, and skips the snap to the
+                # font's pixel grid -- which renders 4x6-font.ttf at 6 instead
+                # of 7, a 3px-wide glyph instead of 4px. That shipped once,
+                # silently, and was found by a user counting pixels on a photo
+                # of the panel.
+                #
+                # Logged, not raised: a missing schema must not stop a plugin
+                # rendering. The cache is built once per class, so this cannot
+                # repeat per frame.
+                logger.warning(
+                    "%s: could not read config_schema.json (%s: %s); every font "
+                    "size will be treated as user-chosen and will skip its pixel "
+                    "grid snap. Font sizes may render a pixel narrow.",
+                    type(self).__name__, type(exc).__name__, exc)
                 cache = {}
             self.__class__._SCHEMA_FONT_SIZES = cache
         return cache.get(element_key)


### PR DESCRIPTION
`_schema_font_size` swallowed every exception and cached an empty dict.

That isn't cosmetic. With no schema, a configured font size can't be compared against the schema default — so **every** size is treated as a deliberate user choice and skips the snap to the font's pixel grid. `4x6-font.ttf` then renders at 6 instead of 7: a **3px-wide glyph instead of 4px**.

That shipped. On a 256×64 panel it made the odds, team records and date row hard to read, and it was found by a **user counting pixels on a photo of the panel** — not by anything here. The cause (`_plugin_dir` returning `None` under the real plugin loader) is fixed in #519. This makes the same class of failure audible next time:

```
Orphan: could not read config_schema.json (FileNotFoundError: ...); every font
size will be treated as user-chosen and will skip its pixel grid snap. Font
sizes may render a pixel narrow.
```

The message names the **consequence**, not just the error — `FileNotFoundError` alone doesn't suggest "your fonts are a pixel narrow".

Logged rather than raised: an unreadable schema must not stop a plugin rendering. The cache is built once per class (per schema path in `sports_card`), so this can't repeat per frame. Verified the warning actually fires in both modules.

## Scope is deliberately small

I went in expecting to fix ~23 handlers and found that was the wrong target:

| | |
|---|---|
| handlers that swallow and return a default | 23 — but **all** catch specific types (`TypeError`, `ValueError`, `ImportError`), turning bad config values into defaults, which is what they're for |
| broad handlers across the font/odds paths | 77 — **74 already log** |
| both broad **and** silent | **2** — these |

Changing the typed handlers would have added noise and risk for no benefit.

Core suite: **3881 passed, 0 failed.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added warning messages when schema font-size settings cannot be read.
  - Clarified that affected font sizes will be treated as user-selected without pixel-grid snapping.
  - Preserved existing behavior while making configuration read failures visible for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->