### PR TITLE
fix(display): draw text 1-bit, so glyphs stay crisp on the LED grid

### DIFF
--- a/src/display_manager.py
+++ b/src/display_manager.py
@@ -364,6 +364,7 @@ class DisplayManager:
             # Create image with the (logical) display dimensions
             self.image = Image.new('RGB', (self.matrix.width, self.matrix.height))
             self.draw = ImageDraw.Draw(self.image)
+            self.draw.fontmode = "1"  # 1-bit text: the panel has no partial brightness, so AA only smears glyphs.
             logger.info(f"Image canvas created with dimensions: {self.matrix.width}x{self.matrix.height}")
             
             # Initialize font with Press Start 2P
@@ -403,6 +404,7 @@ class DisplayManager:
 
             self.image = Image.new('RGB', (fallback_width, fallback_height))
             self.draw = ImageDraw.Draw(self.image)
+            self.draw.fontmode = "1"  # 1-bit text: the panel has no partial brightness, so AA only smears glyphs.
             # Simple fallback visualization so web UI shows a realistic canvas
             try:
                 self.draw.rectangle([0, 0, fallback_width - 1, fallback_height - 1], outline=(255, 0, 0))
@@ -705,6 +707,7 @@ class DisplayManager:
             # self.image, so swapping the buffer below is enough on its own.
             self.image = Image.new('RGB', (target_w, target_h))
             self.draw = ImageDraw.Draw(self.image)
+            self.draw.fontmode = "1"  # 1-bit text: the panel has no partial brightness, so AA only smears glyphs.
             yield
         finally:
             self.matrix = real_matrix
@@ -814,6 +817,7 @@ class DisplayManager:
                 
                 self.image = Image.new('RGB', (width, height))
                 self.draw = ImageDraw.Draw(self.image)
+                self.draw.fontmode = "1"  # 1-bit text: the panel has no partial brightness, so AA only smears glyphs.
                 logger.debug("Cleared display in fallback mode")
                 return
                 
@@ -825,6 +829,7 @@ class DisplayManager:
             # Create a new black image
             self.image = Image.new('RGB', (self.matrix.width, self.matrix.height))
             self.draw = ImageDraw.Draw(self.image)
+            self.draw.fontmode = "1"  # 1-bit text: the panel has no partial brightness, so AA only smears glyphs.
 
             if not self._capture_mode_active:
                 # Clear both canvases and the underlying matrix to ensure no artifacts.
@@ -1258,6 +1263,7 @@ class DisplayManager:
             try:
                 self.image = Image.new('RGB', (self.width, self.height))
                 self.draw = ImageDraw.Draw(self.image)
+                self.draw.fontmode = "1"  # 1-bit text: the panel has no partial brightness, so AA only smears glyphs.
             except (OSError, RuntimeError, ValueError, MemoryError):
                 logger.debug("Canvas reset during cleanup failed", exc_info=True)
         # Reset the singleton state when cleaning up

--- a/src/plugin_system/testing/visual_display_manager.py
+++ b/src/plugin_system/testing/visual_display_manager.py
@@ -70,6 +70,7 @@ class VisualTestDisplayManager:
         # Canvas
         self.image = Image.new('RGB', (width, height), (0, 0, 0))
         self.draw = ImageDraw.Draw(self.image)
+        self.draw.fontmode = "1"  # Match production: 1-bit text, so goldens show what the panel shows.
 
         # Matrix proxy (plugins access display_manager.matrix.width/height)
         self.matrix = _MatrixProxy(width, height)
@@ -184,6 +185,7 @@ class VisualTestDisplayManager:
         self.clear_called = True
         self.image = Image.new('RGB', (self._width, self._height), (0, 0, 0))
         self.draw = ImageDraw.Draw(self.image)
+        self.draw.fontmode = "1"  # Match production: 1-bit text, so goldens show what the panel shows.
 
     def update_display(self):
         """No-op for hardware; marks that display was updated."""
@@ -211,6 +213,7 @@ class VisualTestDisplayManager:
             self.matrix = _MatrixProxy(target_w, target_h)
             self.image = Image.new('RGB', (target_w, target_h), (0, 0, 0))
             self.draw = ImageDraw.Draw(self.image)
+            self.draw.fontmode = "1"  # Match production: 1-bit text, so goldens show what the panel shows.
             yield
         finally:
             self._width, self._height = prev_w, prev_h
@@ -569,6 +572,7 @@ class VisualTestDisplayManager:
         self.draw_calls = []
         self.image = Image.new('RGB', (self._width, self._height), (0, 0, 0))
         self.draw = ImageDraw.Draw(self.image)
+        self.draw.fontmode = "1"  # Match production: 1-bit text, so goldens show what the panel shows.
         self._scrolling_state = {
             'is_scrolling': False,
             'last_scroll_activity': 0,
@@ -582,3 +586,4 @@ class VisualTestDisplayManager:
         """Clean up resources."""
         self.image = Image.new('RGB', (self._width, self._height), (0, 0, 0))
         self.draw = ImageDraw.Draw(self.image)
+        self.draw.fontmode = "1"  # Match production: 1-bit text, so goldens show what the panel shows.


### PR DESCRIPTION
## The bug

An LED panel has no partial brightness. PIL defaults `ImageDraw`'s `fontmode` to `"L"`, which anti-aliases TrueType glyphs into a grey fringe the panel can only round off — a 4px glyph arrives smeared into 3px.

`DisplayManager` creates its shared `draw` in **six** places and set `fontmode` at none of them, while `_load_fonts` loads `extra_small_font` as **4x6-font.ttf at size 6**. Measured at draw time, that face at that size puts **74% of its lit pixels at partial coverage**. Every plugin that draws small text through the shared `draw` inherited the blur.

## The harness had the same gap, and that mattered more

`src/plugin_system/testing/visual_display_manager.py` creates its own `draw` in five places, also at the default. So the harness was recording **anti-aliased goldens that production would never produce** — it structurally could not have caught this.

That is not a theoretical point. After the production fix, `geochron` was *still* rendering anti-aliased under the harness; tracing the draw object's creation stack led to `visual_display_manager.py:72`. Fixing only production would have left the harness disagreeing with the panel.

Both are now `"1"`, so the harness renders what the panel renders.

## Verification

A probe hooked `ImageDraw.text` and recorded, for every real draw, the `fontmode` in effect, the font and size, the call site, and the `Draw()` object's creation site.

- before: **18 anti-aliased sites across 9 plugins**
- after: **0**, across 31 plugins × all 8 panel sizes

Companion plugin-side PR: ChuckBuilds/ledmatrix-plugins#417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RRtqXDCnvnY6EQwhT5CV9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized text rendering to use 1-bit, non-anti-aliased output across physical and visual displays.
  * Improved consistency between displayed text and visual test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->