### PR TITLE
feat(render_plugin): add --display-mode so multi-mode plugins can be rendered

### DIFF
--- a/scripts/render_plugin.py
+++ b/scripts/render_plugin.py
@@ -155,7 +155,10 @@ def main() -> int:
             try:
                 plugin_instance.display(display_mode=args.display_mode,
                                         force_clear=True)
-            except TypeError:
+            except TypeError as error:
+                if ("unexpected keyword argument" not in str(error)
+                        or "display_mode" not in str(error)):
+                    raise
                 logger.warning(
                     "%s.display() does not accept display_mode; rendering its "
                     "default screen instead", args.plugin)

--- a/scripts/render_plugin.py
+++ b/scripts/render_plugin.py
@@ -52,6 +52,10 @@ def main() -> int:
     parser.add_argument('--height', type=int, default=32, help='Display height (default: 32)')
     parser.add_argument('--skip-update', action='store_true',
                         help='Skip calling update() (render display only)')
+    parser.add_argument('--display-mode', default=None,
+                        help='Display mode to render, for plugins that declare '
+                             'more than one in their manifest (e.g. nrl_live). '
+                             'Omitted, the plugin picks its own default.')
 
     args = parser.parse_args()
 
@@ -141,8 +145,23 @@ def main() -> int:
         except Exception as e:
             logger.warning("update() raised: %s — continuing to display()", e)
 
+    # A plugin that declares several display modes usually renders nothing
+    # useful without being told which one to draw: the scoreboards keep their
+    # state on per-mode sub-managers and their no-argument path returns False.
+    # Only pass the argument when asked for, so the many plugins whose display()
+    # takes no display_mode keep working untouched.
     try:
-        plugin_instance.display(force_clear=True)
+        if args.display_mode:
+            try:
+                plugin_instance.display(display_mode=args.display_mode,
+                                        force_clear=True)
+            except TypeError:
+                logger.warning(
+                    "%s.display() does not accept display_mode; rendering its "
+                    "default screen instead", args.plugin)
+                plugin_instance.display(force_clear=True)
+        else:
+            plugin_instance.display(force_clear=True)
         logger.debug("display() completed")
     except Exception as e:
         logger.error("Error in display(): %s", e)


### PR DESCRIPTION
## The problem

`scripts/render_plugin.py` always calls:

```python
plugin_instance.display(force_clear=True)
```

with no mode. That is fine for a plugin declaring one display mode. The sports scoreboards declare three or more and keep their per-mode state on sub-managers (`self._managers["live"]`), and their no-argument path selects nothing and returns `False` — so the render comes out blank with nothing in the output explaining why.

Measured on `nrl-scoreboard` with identical seeded state:

```
live.display() directly                  -> True,  1892 lit pixels
plugin.display(display_mode="nrl_live")  -> True,  1892 lit pixels
plugin.display()          [no mode]      -> False,    0 lit pixels
```

## The change

`--display-mode` passes the requested mode through. It is **only** passed when asked for, so the many plugins whose `display()` takes no `display_mode` keep working untouched. A plugin that declares modes but does not accept the argument degrades to its default screen with a warning rather than a `TypeError`.

```
--display-mode DISPLAY_MODE
                      Display mode to render, for plugins that declare more
                      than one in their manifest (e.g. nrl_live). Omitted,
                      the plugin picks its own default.
```

## Why it matters beyond the scoreboards

This is what lets the plugin READMEs show a scoreboard at all — six of them are currently the only plugins in the registry with no screenshot, because their content lives entirely behind named modes.

It also unblocks screens I previously had to describe in prose rather than picture: `birdnet_stats` (ChuckBuilds/ledmatrix-plugins#413) and the weather plugin's hourly, daily and almanac modes.

## Verification

- `pytest test/ -k "render_plugin or plugin_system"`: 24 passed
- End to end: `nrl-scoreboard` rendered through the documentation pipeline with `--display-mode nrl_live` now draws its live card ("2nd Half", PEN 18-24 MEL) where it previously produced an empty panel
- Plugins that take no `display_mode` are unaffected — the argument is not passed unless requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line option to select which screen a multi-mode plugin displays.

- **Compatibility**
  - Plugins that do not support the new display selection continue to render using their existing behavior, with a warning shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->