### PR TITLE
test: install PyYAML so the starlark route tests can load the plugin

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,3 +7,8 @@ freezegun>=1.2,<2        # deterministic time for golden-image tests
 psutil>=6.0.0,<8.0.0     # optional at runtime; installed for tests so the
                          # /system/status endpoint's real path is exercised
 mypy>=1.5.0,<2.0.0       # static type checking (also pinned in .pre-commit-config.yaml)
+PyYAML>=6.0.2,<7.0.0     # not a core dependency: test_starlark_pixlet_routes loads
+                         # plugin-repos/starlark-apps/tronbyte_repository.py the way
+                         # the blueprint does, and that plugin imports yaml. The
+                         # plugin declares it in its own requirements.txt, which the
+                         # store installs on a real rig but CI never does.


### PR DESCRIPTION
`Tests` has been red on `main` since #535. All 13 failures in `test/web_interface/test_starlark_pixlet_routes.py` are the same error:

```
ModuleNotFoundError: No module named 'yaml'
```

## What is actually happening

The test loads a **plugin** module by path — deliberately, and the helper says so:

```python
def _repository_module():
    """Load tronbyte_repository.py the way the blueprint does."""
    path = (Path(__file__).resolve().parents[2]
            / 'plugin-repos' / 'starlark-apps' / 'tronbyte_repository.py')
```

That is the right thing for the test to do, because the core web blueprint really does `exec` that plugin module. And the plugin imports `yaml`.

**Nothing is undeclared.** `plugin-repos/starlark-apps/requirements.txt` already pins `PyYAML>=6.0.2`, and on a real rig the plugin store installs it. But CI installs only `requirements.txt` and `requirements-test.txt`, so a core test reaching into a plugin gets none of that plugin's dependencies.

## Why test requirements and not core

`PyYAML` is **not** a core dependency — nothing under `src/` or `web_interface/` imports `yaml`. Putting it in `requirements.txt` would tell every user's rig to install a package the display never uses.

This is the same shape as the `psutil` entry directly above it: a package the core does not require, installed so a test can exercise a real path instead of a stub. The comment records why, so the next person does not "tidy up" an apparently unused dependency.

## Verification

Locally, with `yaml` available, the file goes from 13 failures to **64 passing**. One unrelated failure remains, and only on Windows — `os.geteuid` does not exist there, so it will not occur on the Linux runner.

## Note on scope

This is pre-existing on `main` and unrelated to the scroll work in #542 and #545 — both of those are red for this reason and will go green once this lands. Kept as its own PR rather than folded into a scroll change, since it fixes `main` for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)