### PR TITLE
chore: delete three functions nothing calls

### DIFF
--- a/src/base_classes/baseball.py
+++ b/src/base_classes/baseball.py
@@ -37,51 +37,6 @@ class Baseball(SportsCore):
         self.data_source = ESPNDataSource(logger)
         self.sport = "baseball"
 
-    def _get_baseball_display_text(self, game: Dict) -> str:
-        """Get baseball-specific display text."""
-        try:
-            display_parts = []
-
-            # Inning information
-            if self.show_innings:
-                inning = game.get("inning", "")
-                if inning:
-                    display_parts.append(f"Inning: {inning}")
-
-            # Outs information
-            if self.show_outs:
-                outs = game.get("outs", 0)
-                if outs is not None:
-                    display_parts.append(f"Outs: {outs}")
-
-            # Bases information
-            if self.show_bases:
-                bases = game.get("bases", "")
-                if bases:
-                    display_parts.append(f"Bases: {bases}")
-
-            # Count information
-            if self.show_count:
-                strikes = game.get("strikes", 0)
-                balls = game.get("balls", 0)
-                if strikes is not None and balls is not None:
-                    display_parts.append(f"Count: {balls}-{strikes}")
-
-            # Pitcher/Batter information
-            if self.show_pitcher_batter:
-                pitcher = game.get("pitcher", "")
-                batter = game.get("batter", "")
-                if pitcher:
-                    display_parts.append(f"Pitcher: {pitcher}")
-                if batter:
-                    display_parts.append(f"Batter: {batter}")
-
-            return " | ".join(display_parts) if display_parts else ""
-
-        except Exception as e:
-            self.logger.error(f"Error getting baseball display text: {e}")
-            return ""
-
     def _is_baseball_game_live(self, game: Dict) -> bool:
         """Check if a baseball game is currently live."""
         try:

--- a/src/web_interface/api_helpers.py
+++ b/src/web_interface/api_helpers.py
@@ -105,27 +105,3 @@ def validate_request_json(required_fields: list, data: Optional[Dict] = None) ->
         )
     
     return data, None
-
-
-def validate_request_params(required_params: list) -> Tuple[Optional[Dict], Optional[Any]]:
-    """
-    Validate request has required query parameters.
-    
-    Args:
-        required_params: List of required parameter names
-    
-    Returns:
-        Tuple of (params_dict, error_response) or (params_dict, None) if valid
-    """
-    missing_params = [param for param in required_params if param not in request.args]
-    if missing_params:
-        return None, error_response(
-            ErrorCode.INVALID_INPUT,
-            f"Missing required parameters: {', '.join(missing_params)}",
-            context={'missing_params': missing_params},
-            status_code=400
-        )
-    
-    params = {param: request.args.get(param) for param in required_params}
-    return params, None
-

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -352,20 +352,6 @@ def _validate_time_format(time_str):
     except (ValueError, TypeError):
         return False, f"Invalid time format: {time_str}. Expected HH:MM format."
 
-def _validate_time_range(start_time_str, end_time_str, allow_overnight=True):
-    """Validate time range. Returns (is_valid, error_message)"""
-    try:
-        start_time = datetime.strptime(start_time_str, '%H:%M').time()
-        end_time = datetime.strptime(end_time_str, '%H:%M').time()
-
-        # Allow overnight schedules (start > end) or same-day schedules
-        if not allow_overnight and start_time >= end_time:
-            return False, f"Start time ({start_time_str}) must be before end time ({end_time_str}) for same-day schedules"
-
-        return True, None
-    except (ValueError, TypeError) as e:
-        return False, f"Invalid time format: {str(e)}"
-
 @api_v3.route('/config/schedule', methods=['POST'])
 def save_schedule_config():
     """Save schedule configuration"""


### PR DESCRIPTION
| file | function | lines |
|---|---|---|
| `src/base_classes/baseball.py` | `_get_baseball_display_text` | 45 |
| `src/web_interface/api_helpers.py` | `validate_request_params` | 22 |
| `web_interface/blueprints/api_v3.py` | `_validate_time_range` | 14 |

Each has **exactly one occurrence** across both repositories — its own definition. No decorator, no `__all__`, no `getattr` dispatch, nothing in templates or JavaScript.

## A fourth candidate, dropped

`_unshare_element_fonts` in `src/common/sports_shared.py` looked unreferenced too. It is not: eight scoreboard plugins call `SportsCore._unshare_element_fonts` directly from their `test_element_text_colors.py`, and inherit it at runtime. It is live API.

The earlier reading came from a `ledmatrix-plugins` checkout that was 84 commits behind `main`. Worth recording as the reason this kind of claim gets re-verified against a fresh tree rather than trusted from an earlier scan.

## Context

This is the whole of the core's dead code. An AST pass over all 327 tracked modules — cross-referenced against both repositories including templates and JavaScript, excluding decorated functions (Flask routes, properties, overrides) — turns up nothing else. For a 120,000-line codebase that is an unusually good result.

## Testing

Full suite: **4,265 passed, 68 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RRtqXDCnvnY6EQwhT5CV9