### PR TITLE
chore: ignore team logos fetched at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,25 @@ skin_renders/
 # JS test deps (test/js)
 node_modules/
 package-lock.json
+
+# Team logos fetched at runtime.
+#
+# src/logo_downloader.py and LogoHelper write into assets/sports/<league>_logos/
+# whenever a plugin meets a team whose logo is not on disk. Those directories are
+# also tracked -- 209 NCAA logos and 153 soccer ones ship with the repo -- so
+# every rig accumulated untracked files it was never meant to commit and
+# `git status` was permanently dirty. That noise is not harmless: it trains
+# everyone to ignore the one signal that says a checkout is not what you think
+# it is, which is how a stale tree sat unnoticed on a rig until a restart
+# surfaced four dead sports plugins.
+#
+# Ignoring a directory does not untrack what is already in it, so the logos that
+# ship keep shipping. Only new downloads are hidden.
+#
+# Adding a logo on purpose is rare and deliberate -- the last time was #415, four
+# named NCAA logos a plugin needed, and there has been no other in a year. Do it
+# with an explicit override:
+#     git add -f assets/sports/ncaa_logos/DUKE.png
+assets/sports/*_logos/
+assets/stocks/ticker_icons/
+assets/stocks/crypto_icons/


### PR DESCRIPTION
## The problem

`src/logo_downloader.py` and `LogoHelper` write into `assets/sports/<league>_logos/` whenever a plugin meets a team whose logo is not on disk. Those directories are **also tracked** — 209 NCAA logos and 153 soccer ones ship with the repo — so every rig accumulates untracked files nobody intended to commit.

This checkout had 62. hdpi shows the same pattern.

```
     56 assets/sports/ncaa_logos
      2 assets/sports/soccer_logos
      1 assets/sports/ufc_scoreboard_logos
      1 assets/sports/nrl_logos
      1 assets/sports/nfl_logos
      1 assets/sports/afl_logos
```

The cost is not the files. It is that a permanently dirty `git status` trains everyone to ignore the one signal that says a checkout is not what you think it is — which is how a stale tree sat unnoticed on a rig for hours until a restart surfaced four sports plugins that could no longer import.

## Why this is safe

Ignoring a directory does **not** untrack what is already in it. The logos that ship keep shipping — verified: 209 and 153 still tracked, and the diff contains no deletions. Only new downloads are hidden.

## Why ignoring is the right call rather than committing them

Deliberate logo additions are rare and explicit. The last one was #415 — four *named* NCAA logos a plugin needed — and `git log --since="1 year ago"` finds no other. So the common case is runtime noise and the rare case is intentional, which is the right way round for an ignore rule. The escape hatch is documented in the `.gitignore` comment:

```
git add -f assets/sports/ncaa_logos/DUKE.png
```

Verified working.

## Result

Untracked files: **62 → 0**.

## Not in scope

The 213 MB of tracked assets and the 199 MB pack are a separate question that would need a history rewrite. Flagging, not touching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RRtqXDCnvnY6EQwhT5CV9