### PR TITLE
Add render_width/render_height support to Starlark Apps

### DIFF
--- a/plugin-repos/starlark-apps/manager.py
+++ b/plugin-repos/starlark-apps/manager.py
@@ -796,15 +796,25 @@ class StarlarkAppsPlugin(BasePlugin):
             magnify = self._get_effective_magnify()
             self.logger.debug(f"Using magnify={magnify} for {app.app_id}")
 
-            # Filter out LEDMatrix-internal timing keys before passing to pixlet
-            INTERNAL_KEYS = {'render_interval', 'display_duration'}
+            # Optional native render size for an app whose own declared canvas
+            # differs from Pixlet's 64x32 default -- without this an app
+            # declaring a wider native canvas got half its own content
+            # clipped at render time, before magnify ever got a chance to
+            # scale anything.
+            render_width = app.config.get("render_width")
+            render_height = app.config.get("render_height")
+
+            # Filter out LEDMatrix-internal timing/sizing keys before passing to pixlet
+            INTERNAL_KEYS = {'render_interval', 'display_duration', 'render_width', 'render_height'}
             pixlet_config = {k: v for k, v in app.config.items() if k not in INTERNAL_KEYS}
 
             success, error = self.pixlet.render(
                 star_file=str(app.star_file),
                 output_path=str(app.cache_file),
                 config=pixlet_config,
-                magnify=magnify
+                magnify=magnify,
+                width=render_width,
+                height=render_height
             )
 
             if not success:

--- a/plugin-repos/starlark-apps/pixlet_renderer.py
+++ b/plugin-repos/starlark-apps/pixlet_renderer.py
@@ -218,7 +218,9 @@ class PixletRenderer:
         star_file: str,
         output_path: str,
         config: Optional[Dict[str, Any]] = None,
-        magnify: int = 1
+        magnify: int = 1,
+        width: Optional[int] = None,
+        height: Optional[int] = None
     ) -> Tuple[bool, Optional[str]]:
         """
         Render a .star file to WebP output.
@@ -228,6 +230,21 @@ class PixletRenderer:
             output_path: Where to save WebP output
             config: Configuration dictionary to pass to app
             magnify: Magnification factor (default 1)
+            width: Optional native render width in pixels. Previously
+                there was no way to tell Pixlet to render at anything
+                other than its own default (64), relying entirely on
+                magnify to scale up afterward -- fine for apps designed
+                at that native size, but wrong for an app whose own
+                declared canvas size is genuinely different (confirmed
+                on real hardware, 2026-09-06, with an imported app
+                declaring width=128: rendering at the default 64 and
+                then magnifying silently clipped half the app's own
+                content before scaling ever happened, rather than
+                producing a correctly-sized image). Passed through as
+                Pixlet's own -w flag when provided; omitted (Pixlet's
+                default) otherwise, preserving existing behavior for
+                every other app.
+            height: Same as width, for Pixlet's -t flag.
 
         Returns:
             Tuple of (success: bool, error_message: Optional[str])
@@ -287,6 +304,10 @@ class PixletRenderer:
                 "-o", output_path,
                 "-m", str(magnify)
             ])
+            if width is not None:
+                cmd.extend(["-w", str(width)])
+            if height is not None:
+                cmd.extend(["-t", str(height)])
 
             # Build sanitized command for logging (redact sensitive values)
             sanitized_cmd = [self.pixlet_binary, "render", star_file]
@@ -294,6 +315,10 @@ class PixletRenderer:
                 config_keys = list(config.keys())
                 sanitized_cmd.append(f"[{len(config_keys)} config entries: {', '.join(config_keys)}]")
             sanitized_cmd.extend(["-o", output_path, "-m", str(magnify)])
+            if width is not None:
+                sanitized_cmd.extend(["-w", str(width)])
+            if height is not None:
+                sanitized_cmd.extend(["-t", str(height)])
             logger.debug(f"Executing Pixlet: {' '.join(sanitized_cmd)}")
 
             # Execute rendering


### PR DESCRIPTION
## Problem

`pixlet_renderer.py`'s `render()` only ever passes `-o` and `-m` (magnify)
to Pixlet — there's no way to tell it to render at anything other than its
own default 64x32 canvas. That's fine for apps designed at that native
size, but breaks for any app whose own declared canvas is genuinely
different (e.g. an imported app with a 128-wide layout).

Confirmed on real hardware: rendering such an app at the default 64 and
then magnifying afterward silently clips half the app's own content
before scaling ever happens, instead of producing a correctly-sized
image.

## Fix

Adds optional `width`/`height` parameters to `PixletRenderer.render()`,
passed through as Pixlet's own `-w`/`-t` flags when provided. The
Starlark Apps manager reads new `render_width`/`render_height` keys from
an app's own `config.json` and passes them through.

## Backwards compatibility

Fully opt-in and additive:
- Both new parameters default to `None`.
- When unset (every existing app), the code path is unchanged — no `-w`/
  `-t` flags are added, and Pixlet falls back to its normal default exactly
  as before.
- `magnify` and the separate `scale_output`/`scale_method` post-processing
  step are untouched.

## Testing

Verified on real hardware with an app that declares `render_width: 128,
render_height: 32` in its `config.json` — previously showed only the left
half of its content, magnified; now renders correctly at full width. Apps
without these keys set were confirmed unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Starlark apps can now specify custom native canvas widths and heights.
  * Apps with canvases larger than the default display size can render at their full dimensions instead of being clipped.

* **Bug Fixes**
  * Preserved existing rendering behavior for apps that do not specify custom dimensions.
  * Prevented rendering-only sizing settings from being treated as general app configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->