### PR TITLE
fix(web): default web_display_autostart to true, as the installer already does

### DIFF
--- a/scripts/utils/start_web_conditionally.py
+++ b/scripts/utils/start_web_conditionally.py
@@ -74,23 +74,41 @@ def install_dependencies():
         print(f"Failed to install dependencies: {e}")
         return False
 
+#: String spellings that turn autostart OFF. Anything else -- including the key
+#: being absent entirely -- leaves it on.
+DISABLED_STRINGS = ("off", "false", "no", "0")
+
+
+def autostart_enabled(config_data):
+    """Whether to bring the web interface up. Defaults to True.
+
+    config.template.json and first_time_install.sh both ship
+    ``web_display_autostart`` as true, so a config that lacks the key is an
+    older or hand-edited one rather than a request to stay down. Defaulting to
+    False meant any such config silently got no web interface -- and because
+    the "not starting" path exits 0, systemd reported the unit as successfully
+    started while nothing was listening. Only an explicit false/off disables it.
+    """
+    value = config_data.get("web_display_autostart", True)
+    if isinstance(value, str):
+        return value.strip().lower() not in DISABLED_STRINGS
+    return bool(value)
+
+
 def main():
     try:
         with open(CONFIG_FILE, 'r') as f:
             config_data = json.load(f)
     except FileNotFoundError:
-        print(f"Config file {CONFIG_FILE} not found. Web interface will not start.")
-        sys.exit(0) # Exit gracefully, don't start
-    except Exception as e:
-        print(f"Error reading config file {CONFIG_FILE}: {e}. Web interface will not start.")
-        sys.exit(1) # Exit with error, service might restart depending on config
+        # The web interface is how a config gets created and repaired, so a
+        # missing one is the case where the user needs it most.
+        print(f"Config file {CONFIG_FILE} not found. Starting the web interface so it can be configured.")
+        config_data = {}
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Error reading config file {CONFIG_FILE}: {e}. Starting the web interface anyway so the config can be repaired.")
+        config_data = {}
 
-    autostart_enabled = config_data.get("web_display_autostart", False)
-
-    # Handle both boolean True and string "on"/"true" values
-    is_enabled = (autostart_enabled is True) or (isinstance(autostart_enabled, str) and autostart_enabled.lower() in ("on", "true", "yes", "1"))
-
-    if is_enabled:
+    if autostart_enabled(config_data):
         print("Configuration 'web_display_autostart' is enabled. Starting web interface...")
 
         # Only install dependencies if not already done during first-time setup
@@ -116,7 +134,7 @@ def main():
             print(f"Failed to exec web interface: {e}")
             sys.exit(1) # Failed to start
     else:
-        print("Configuration 'web_display_autostart' is false or not set. Web interface will not be started.")
+        print("Configuration 'web_display_autostart' is explicitly disabled. Web interface will not be started.")
         sys.exit(0) # Exit gracefully, service considered successful
 
 if __name__ == '__main__':

--- a/test/test_web_autostart_default.py
+++ b/test/test_web_autostart_default.py
@@ -1,0 +1,63 @@
+"""Tests for the web interface's autostart default.
+
+Regression under test: ``start_web_conditionally.py`` read the flag with
+``config_data.get("web_display_autostart", False)``, so a config that simply
+lacked the key got no web interface. Both config.template.json and
+first_time_install.sh ship the key as ``true``, so absence means an older or
+hand-edited config -- not a request to stay down.
+
+The failure was silent in the worst way: the "not starting" path exits 0, so
+``systemctl status ledmatrix-web`` reported the unit as successfully started
+while nothing was listening on the port, and the journal's only trace was one
+line saying the flag was "false or not set".
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (Path(__file__).resolve().parents[1]
+          / "scripts" / "utils" / "start_web_conditionally.py")
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("start_web_conditionally", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestAutostartDefault:
+    def test_absent_key_still_starts(self, mod):
+        # The regression: this returned False and the UI silently stayed down.
+        assert mod.autostart_enabled({}) is True
+
+    def test_unreadable_config_still_starts(self, mod):
+        # main() falls back to {} when the config is missing or corrupt, because
+        # the web interface is how a broken config gets repaired.
+        assert mod.autostart_enabled({}) is True
+
+    def test_explicit_true_starts(self, mod):
+        assert mod.autostart_enabled({"web_display_autostart": True}) is True
+
+    def test_explicit_false_does_not_start(self, mod):
+        assert mod.autostart_enabled({"web_display_autostart": False}) is False
+
+    @pytest.mark.parametrize("value", ["off", "false", "no", "0", "OFF", " False "])
+    def test_disabling_strings_do_not_start(self, mod, value):
+        assert mod.autostart_enabled({"web_display_autostart": value}) is False
+
+    @pytest.mark.parametrize("value", ["on", "true", "yes", "1", "TRUE"])
+    def test_enabling_strings_start(self, mod, value):
+        assert mod.autostart_enabled({"web_display_autostart": value}) is True
+
+
+class TestShippedDefaultsAgree:
+    def test_template_ships_autostart_true(self):
+        """The code default must match what the installer actually writes."""
+        import json
+        template = json.loads(
+            (SCRIPT.parents[2] / "config" / "config.template.json").read_text(encoding="utf-8"))
+        assert template["web_display_autostart"] is True


### PR DESCRIPTION
## What

`scripts/utils/start_web_conditionally.py` read the autostart flag as:

```python
autostart_enabled = config_data.get("web_display_autostart", False)
```

The default is `False`, but the project ships the key as `true` in two places:

- `config/config.template.json:2` → `"web_display_autostart": true`
- `first_time_install.sh:774` → writes `true`

So the code default contradicted the shipped default. Any config missing the key — an older install, a hand-edited file, or one rewritten by a tool that drops unknown keys — silently got no web interface.

## Why it was hard to spot

The "not starting" path exits `0`, so systemd reported the unit as **successfully started** while nothing was listening:

```
Started ledmatrix-web.service - LED Matrix Web Interface (Conditional Start).
Configuration 'web_display_autostart' is false or not set. Web interface will not be started.
ledmatrix-web.service: Deactivated successfully.
```

`systemctl status` shows success, the port is dead, and the one diagnostic line reads as a deliberate setting rather than a missing key.

## Changes

- **Default to enabled.** Only an explicit `false` / `off` / `no` / `0` disables autostart. Extracted into `autostart_enabled()` so the rule is testable.
- **Start the web interface when `config.json` is missing or unparseable**, rather than exiting. The web interface is how a config gets created and repaired, so a broken config is exactly when it's needed most — leaving it down means there's no way back in.
- **Clearer journal message**: "explicitly disabled" distinguishes a real setting from an absent key.

## Tests

`test/test_web_autostart_default.py` — 16 cases covering absent key, explicit booleans, enabling/disabling string spellings, and a guard asserting the code default agrees with what `config.template.json` ships (so these can't drift apart again).

```
122 passed
```

Verified against clean `main` as well: the same web test files pass both with and without this change.

## Note on scope

This was found while debugging a Pi 3B+ whose web UI wouldn't load. I could **not** reproduce the exact sequence that left that device's flag reading false — every config snapshot on it showed `true`. This PR therefore doesn't claim to fix that specific trigger; it makes the silent-no-web-UI outcome impossible by default, and makes the remaining disabled case legible in the journal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The web interface now starts automatically by default when no autostart setting is provided.
  - Autostart can be disabled using explicit values such as “off,” “false,” “no,” or “0.”
  - Boolean and supported text settings continue to control whether the web interface starts.

- **Bug Fixes**
  - Missing, invalid, or unreadable configuration files no longer prevent startup. The web interface starts so configuration can be created or repaired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->