### PR TITLE
fix(web): report real disk usage and MemAvailable on the live status stream

### DIFF
--- a/test/test_live_status_fields.py
+++ b/test/test_live_status_fields.py
@@ -1,0 +1,103 @@
+"""Tests for the metrics the live status stream reports.
+
+Two gaps made a struggling 1GB Pi look healthy on the dashboard:
+
+* ``disk_used_percent`` was the literal ``0`` in the SSE generator, so every
+  consumer of the live stream displayed 0% disk no matter how full the card was.
+  /api/v3/system/status computed it properly, but the live view -- the one people
+  actually watch -- did not.
+
+* ``memory_available_mb`` was absent. /api/v3/system/status carries it with a
+  comment explaining that MemAvailable, not used%, is what separates a board
+  that is fine from one about to fail fork(). The live stream omitted the one
+  number that predicts the failure.
+
+A wrong number is worse than a missing one, so an unreadable disk now reports
+None (the UI renders '--') rather than a confident 0.
+
+These import web_interface.system_metrics rather than web_interface.app on
+purpose: importing the app constructs a Flask application and a CacheManager,
+and the latter claims the cache directory with a cleanup thread -- which broke
+test_cache_cleanup_thread_ownership and the starlark route tests when this file
+first reached for the generator directly.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from web_interface.system_metrics import collect_system_metrics  # noqa: E402
+
+
+@pytest.fixture
+def metrics(monkeypatch):
+    """collect_system_metrics() with psutil's readings under our control."""
+    def _collect(disk_percent=12.0, available_bytes=512 * 1024 * 1024,
+                 used_percent=67.7, raise_disk=False):
+        import psutil
+        if raise_disk:
+            monkeypatch.setattr(psutil, "disk_usage",
+                                lambda _p: (_ for _ in ()).throw(OSError("no such mount")))
+        else:
+            monkeypatch.setattr(psutil, "disk_usage",
+                                lambda _p: SimpleNamespace(percent=disk_percent))
+        monkeypatch.setattr(psutil, "virtual_memory",
+                            lambda: SimpleNamespace(percent=used_percent,
+                                                    available=available_bytes))
+        return collect_system_metrics()
+    return _collect
+
+
+class TestDiskUsageIsReal:
+    def test_reported_value_comes_from_the_filesystem(self, metrics):
+        # The regression: this field was the literal 0.
+        assert metrics(disk_percent=91.4)["disk_used_percent"] == 91.4
+
+    def test_a_full_disk_is_not_reported_as_zero(self, metrics):
+        assert metrics(disk_percent=99.9)["disk_used_percent"] != 0
+
+    def test_unreadable_disk_is_null_not_a_confident_zero(self, metrics):
+        # null renders as '--'; 0 would read as "plenty of room".
+        assert metrics(raise_disk=True)["disk_used_percent"] is None
+
+
+class TestMemAvailableIsReported:
+    def test_mem_available_is_present_and_in_mb(self, metrics):
+        got = metrics(available_bytes=292 * 1024 * 1024)["memory_available_mb"]
+        assert got == pytest.approx(292.0, abs=0.1)
+
+    def test_the_1gb_danger_case_is_visible(self, metrics):
+        """67% used can be fine or nearly out of memory; only MemAvailable says."""
+        m = metrics(used_percent=67.7, available_bytes=40 * 1024 * 1024)
+        assert m["memory_used_percent"] == 67.7
+        assert m["memory_available_mb"] == pytest.approx(40.0, abs=0.1)
+
+
+class TestEveryPredictiveFieldIsPresent:
+    def test_nothing_the_dashboard_needs_is_missing(self, metrics):
+        m = metrics()
+        for field in ("cpu_percent", "cpu_temp", "memory_used_percent",
+                      "memory_available_mb", "disk_used_percent"):
+            assert field in m, f"{field} missing from collected metrics"
+
+    def test_absent_psutil_still_yields_every_key(self, monkeypatch):
+        """The no-psutil fallback must not drop fields the UI reads."""
+        import builtins
+        real_import = builtins.__import__
+
+        def _no_psutil(name, *args, **kwargs):
+            if name == "psutil":
+                raise ImportError("psutil missing")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _no_psutil)
+        m = collect_system_metrics()
+        for field in ("cpu_percent", "cpu_temp", "memory_used_percent",
+                      "memory_available_mb", "disk_used_percent"):
+            assert field in m
+        assert m["disk_used_percent"] is None

--- a/web_interface/app.py
+++ b/web_interface/app.py
@@ -32,6 +32,8 @@ _JOURNALCTL = shutil.which('journalctl')
 _SYSTEMCTL = shutil.which('systemctl')
 _VCGENCMD = shutil.which('vcgencmd')
 
+from web_interface.system_metrics import collect_system_metrics
+
 # Create Flask app
 app = Flask(__name__)
 app.secret_key = os.urandom(24)
@@ -606,26 +608,12 @@ def system_status_generator():
     """Generate system status updates"""
     while True:
         try:
-            # Try to import psutil for system stats
-            try:
-                import psutil
-                # interval=None is non-blocking; primed at module startup above
-                cpu_percent = round(psutil.cpu_percent(interval=None), 1)
-                memory = psutil.virtual_memory()
-                memory_used_percent = round(memory.percent, 1)
-
-                # Try to get CPU temperature (Raspberry Pi specific)
-                cpu_temp = 0
-                try:
-                    with open('/sys/class/thermal/thermal_zone0/temp', 'r') as f:
-                        cpu_temp = round(float(f.read()) / 1000.0, 1)
-                except (OSError, ValueError):
-                    pass
-
-            except ImportError:
-                cpu_percent = 0
-                memory_used_percent = 0
-                cpu_temp = 0
+            metrics = collect_system_metrics()
+            cpu_percent = metrics['cpu_percent']
+            memory_used_percent = metrics['memory_used_percent']
+            memory_available_mb = metrics['memory_available_mb']
+            disk_used_percent = metrics['disk_used_percent']
+            cpu_temp = metrics['cpu_temp']
 
             # Check if display service is running (cached to avoid per-client subprocess forks)
             now = time.time()
@@ -646,8 +634,9 @@ def system_status_generator():
                 'service_active': service_active,
                 'cpu_percent': cpu_percent,
                 'memory_used_percent': memory_used_percent,
+                'memory_available_mb': memory_available_mb,
                 'cpu_temp': cpu_temp,
-                'disk_used_percent': 0,
+                'disk_used_percent': disk_used_percent,
                 'power': _get_power_status()
             }
             yield status

--- a/web_interface/system_metrics.py
+++ b/web_interface/system_metrics.py
@@ -1,0 +1,62 @@
+"""System metrics for the status stream.
+
+Deliberately free of Flask and app imports: importing web_interface.app
+constructs the Flask application and a CacheManager, and the latter claims the
+cache directory with a cleanup thread. Reading a CPU percentage should not do
+that, and neither should testing it.
+
+Every value is best-effort. A number that cannot be taken comes back as None so
+the UI can render '--', because a confident wrong number is worse than a blank:
+``disk_used_percent`` used to be hardcoded to 0, which read as "plenty of room"
+on a card that was filling up.
+"""
+
+from typing import Any, Dict, Optional
+
+_THERMAL_ZONE = '/sys/class/thermal/thermal_zone0/temp'
+
+
+def _cpu_temp_c() -> Optional[float]:
+    """CPU temperature in degrees C, or None off a Raspberry Pi."""
+    try:
+        with open(_THERMAL_ZONE, 'r') as f:
+            return round(float(f.read()) / 1000.0, 1)
+    except (OSError, ValueError):
+        return None
+
+
+def collect_system_metrics() -> Dict[str, Any]:
+    """Collect the numbers that predict trouble on a small board.
+
+    ``memory_available_mb`` is MemAvailable rather than a used percentage: it
+    accounts for reclaimable page cache, so it is what separates a board at 70%
+    "used" that is fine from one at 70% that is about to fail fork(). A 1GB Pi
+    can sit at either and only this number tells them apart.
+    """
+    try:
+        import psutil
+    except ImportError:
+        return {
+            'cpu_percent': 0,
+            'memory_used_percent': 0,
+            'memory_available_mb': None,
+            'disk_used_percent': None,
+            'cpu_temp': _cpu_temp_c() or 0,
+        }
+
+    # interval=None is non-blocking; app startup primes psutil's internal state.
+    cpu_percent = round(psutil.cpu_percent(interval=None), 1)
+    memory = psutil.virtual_memory()
+
+    try:
+        disk_used_percent: Optional[float] = round(psutil.disk_usage('/').percent, 1)
+    except OSError:
+        disk_used_percent = None
+
+    return {
+        'cpu_percent': cpu_percent,
+        'memory_used_percent': round(memory.percent, 1),
+        'memory_available_mb': round(memory.available / (1024 * 1024), 1),
+        'disk_used_percent': disk_used_percent,
+        'cpu_temp': _cpu_temp_c() or 0,
+    }


### PR DESCRIPTION
## What

Two numbers that predict instability on a 1 GB Pi 3B+ never reached the dashboard.

**`disk_used_percent` was a hardcoded literal `0`** in the SSE generator:

```python
'disk_used_percent': 0,
```

`/api/v3/system/status` computes it properly, but the *live* stream — the one the UI subscribes to globally via `app-shell.js` — always sent 0. `tools.html` renders that field, so a filling SD card displayed 0% forever.

**`memory_available_mb` was absent from the stream.** The REST endpoint carries it with a comment explaining exactly why it matters:

> MemAvailable, not total-minus-used: it accounts for reclaimable page cache, so it is what actually predicts memory trouble. A board can read 70% "used" and be fine, or read the same and be about to fail `fork()`, and only this number tells them apart.

That reasoning is right, and the live view was missing the number.

## Changes

- Real `disk_used_percent` from `psutil.disk_usage('/')`.
- `memory_available_mb` added to the stream.
- An unreadable disk reports `None`, not `0`. The UI already renders null as `--`; a confident `0` reads as "plenty of room", which is worse than a blank.
- Metric collection extracted to `web_interface/system_metrics.py`, free of Flask and app imports.

That last point isn't cosmetic. Importing `web_interface.app` constructs the Flask application **and** a `CacheManager`, and the latter claims the cache directory with a cleanup thread. My first version of these tests imported the generator directly and broke `test_cache_cleanup_thread_ownership` ("one thread per directory") plus four starlark route tests purely through that side effect — 7 extra failures that passed in isolation and only showed up in a full run. Reading a CPU percentage shouldn't boot a web app, and testing it shouldn't either.

## Tests

`test/test_live_status_fields.py` — 7 cases: disk value comes from the filesystem, a full disk isn't reported as zero, an unreadable disk is null rather than a confident zero, MemAvailable is present and in MB, the 1 GB danger case (67% used with 40 MB available) is visible, and the no-`psutil` fallback still yields every key the UI reads.

```
failures unique to this PR:  none
            mine             main
failed       103              103
passed      4190             4183   (+7, all new)
```

The 103 are pre-existing on this Windows dev machine (`os.geteuid`, POSIX permission semantics). Verified by diffing the full failure lists both ways, not just the counts.

## Context, and what I found already handled

This came out of a long session debugging two 1 GB Pi 3B+ boards. One of them sat at **600 MHz — 43% of rated clock** — under continuous undervoltage for a long stretch, which caused plugin `update()` timeouts and an empty display, and nothing on the dashboard said so.

Worth recording that most of the low-memory hardening I went looking for is **already in place**, so I'm not touching it: journald is capped at 64 M via a drop-in, swap is configured, `MemoryCache` scales its entry ceiling to board RAM (`#464`), the background data service drops to one worker on small boards, and `_execute_update_now` already holds a plugin's lock for the *real* duration of a timed-out update so unkillable leaked threads cannot pile up. That last one is a genuinely subtle piece of work.

## Suggested follow-up (not in this PR)

`_get_power_status()` decodes all eight `get_throttled` bits correctly and the flags render — but only on the **Tools** page. During four hours of debugging a board that was undervolted the entire time, nobody looked there. Surfacing an active `under_voltage_now` / `throttled_now` / `soft_temp_limit_now` as a banner on the overview would have cut that short, and the data already flows on the stream this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard system status now reports actual disk usage and available memory.
  * System metrics gracefully display unavailable values when readings cannot be obtained.
  * Status reporting continues to provide all dashboard fields when system monitoring is unavailable.

* **Tests**
  * Added coverage for disk, memory, fallback, and unavailable-reading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->