### PR TITLE
fix(web): say when a system action failed for want of passwordless sudo

### DIFF
--- a/test/test_system_action_sudo_diagnosis.py
+++ b/test/test_system_action_sudo_diagnosis.py
@@ -94,6 +94,35 @@ class TestTheExceptionPathNamesTheCause:
         assert 'configure_web_sudo.sh' in body['message']
 
 
+class TestTheEarlyReturnPathsAlsoGetTheHint:
+    """start_display with a mode builds its own response and returns before the
+    shared nonzero-result path, so it needed the hint separately. Found by
+    CodeRabbit on #560; verified against the code before fixing."""
+
+    def test_on_demand_start_reports_the_sudo_cause(self, client):
+        with patch('subprocess.run',
+                   side_effect=lambda a, **k: _result(a, 1, "sudo: a password is required")):
+            body = client.post('/api/v3/system/action',
+                               json={'action': 'start_display', 'mode': 'nfl_live'}).get_json()
+
+        assert 'configure_web_sudo.sh' in body['message'],             "the on-demand branch still reported only 'Failed to start display'"
+        assert body['status'] == 'error'
+
+    def test_on_demand_start_keeps_its_success_message(self, client):
+        with patch('subprocess.run', side_effect=lambda a, **k: _result(a, 0)):
+            body = client.post('/api/v3/system/action',
+                               json={'action': 'start_display', 'mode': 'nfl_live'}).get_json()
+        assert body['status'] == 'success'
+        assert body['message'] == 'Display started'
+
+    def test_an_unrelated_on_demand_failure_is_not_blamed_on_sudo(self, client):
+        with patch('subprocess.run',
+                   side_effect=lambda a, **k: _result(a, 5, "Unit not found.")):
+            body = client.post('/api/v3/system/action',
+                               json={'action': 'start_display', 'mode': 'nfl_live'}).get_json()
+        assert body['message'] == 'Failed to start display'
+
+
 class TestSuccessIsUnchanged:
     def test_a_working_action_still_reports_success(self, client):
         with patch('subprocess.run', side_effect=lambda a, **k: _result(a, 0)):

--- a/test/test_system_action_sudo_diagnosis.py
+++ b/test/test_system_action_sudo_diagnosis.py
@@ -1,0 +1,102 @@
+"""A privileged system action that cannot run must say why.
+
+The web interface runs unprivileged. Its systemctl/reboot/journalctl calls only
+work once scripts/install/configure_web_sudo.sh has granted NOPASSWD, and
+first_time_install.sh never invokes that script -- so on a fresh device every
+one of those actions fails. What the user got back was:
+
+    {"message": "Action failed; see logs for details", "status": "error"}
+
+...and the log viewer was broken for exactly the same reason, so "see logs" led
+nowhere. This is the closed loop that src/web_interface/error_handler.py's
+describe_exception() was written to break; /system/action's exception handler
+was simply still discarding the cause.
+
+Observed live: POSTing reboot_system to a Pi returned that bare sentence, and
+pinning down "no passwordless sudo" took reading the installer instead of
+reading the response.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from web_interface.blueprints.api_v3 import api_v3  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.register_blueprint(api_v3, url_prefix='/api/v3')
+    return app.test_client()
+
+
+def _act(client, action='stop_display'):
+    return client.post('/api/v3/system/action', json={'action': action})
+
+
+def _result(args, rc=0, stderr=''):
+    return subprocess.CompletedProcess(args, rc, stdout='', stderr=stderr)
+
+
+class TestSudoRefusalIsNamed:
+    @pytest.mark.parametrize("stderr", [
+        "sudo: a password is required",
+        "sudo: no tty present and no askpass program specified",
+        "sudo: a terminal is required to read the password",
+    ])
+    def test_every_sudo_refusal_wording_is_recognised(self, client, stderr):
+        with patch('subprocess.run', side_effect=lambda a, **k: _result(a, 1, stderr)):
+            body = _act(client).get_json()
+
+        assert body['status'] == 'error'
+        # The point: the response tells the user what to do about it.
+        assert 'configure_web_sudo.sh' in body['message']
+
+    def test_the_raw_stderr_is_still_returned(self, client):
+        with patch('subprocess.run',
+                   side_effect=lambda a, **k: _result(a, 1, "sudo: a password is required")):
+            body = _act(client).get_json()
+        assert 'a password is required' in body['stderr']
+
+
+class TestUnrelatedFailuresAreNotMisattributed:
+    def test_a_real_systemctl_error_keeps_the_generic_message(self, client):
+        with patch('subprocess.run',
+                   side_effect=lambda a, **k: _result(a, 5, "Unit ledmatrix.service not found.")):
+            body = _act(client).get_json()
+
+        assert 'configure_web_sudo.sh' not in body['message'], \
+            "a missing unit was blamed on sudo"
+        assert 'Unit ledmatrix.service not found.' in body['stderr']
+        assert body['returncode'] == 5
+
+
+class TestTheExceptionPathNamesTheCause:
+    def test_the_exception_type_and_message_are_returned(self, client):
+        with patch('subprocess.run', side_effect=FileNotFoundError(2, "sudo")):
+            body = _act(client).get_json()
+
+        # The regression: 'details' was absent and the cause was discarded.
+        assert 'FileNotFoundError' in body['details']
+
+    def test_a_sudo_shaped_exception_also_gets_the_hint(self, client):
+        with patch('subprocess.run',
+                   side_effect=PermissionError("sudo: a password is required")):
+            body = _act(client).get_json()
+        assert 'configure_web_sudo.sh' in body['message']
+
+
+class TestSuccessIsUnchanged:
+    def test_a_working_action_still_reports_success(self, client):
+        with patch('subprocess.run', side_effect=lambda a, **k: _result(a, 0)):
+            body = _act(client).get_json()
+        assert body['status'] == 'success'
+        assert 'configure_web_sudo.sh' not in body.get('message', '')

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -1993,6 +1993,33 @@ def check_for_update():
         return jsonify(_update_check_failed(
             "Could not check for updates; see logs for details."))
 
+#: sudo's own wording when it needs a password it cannot ask for. The web
+#: interface runs unprivileged, so its systemctl/reboot/journalctl calls only
+#: work once scripts/install/configure_web_sudo.sh has granted NOPASSWD --
+#: which first_time_install.sh does not do. That makes this the common case on
+#: a fresh device, and "Action failed; see logs for details" named none of it,
+#: while the log viewer was broken for the very same reason.
+_SUDO_NEEDS_PASSWORD = (
+    'a password is required',
+    'no tty present',
+    'a terminal is required',
+)
+
+_SUDO_HINT = (
+    'Passwordless sudo is not configured for the web interface user, so this '
+    'action cannot run. Run scripts/install/configure_web_sudo.sh as that user, '
+    'then retry.'
+)
+
+
+def _sudo_hint_for(text):
+    """An actionable hint when `text` is sudo refusing to prompt, else None."""
+    lowered = (text or '').lower()
+    if any(marker in lowered for marker in _SUDO_NEEDS_PASSWORD):
+        return _SUDO_HINT
+    return None
+
+
 @api_v3.route('/system/action', methods=['POST'])
 def execute_system_action():
     """Execute system actions (start/stop/reboot/etc)"""
@@ -2360,6 +2387,9 @@ def execute_system_action():
         if result.returncode != 0:
             resp['returncode'] = result.returncode
             resp['stderr'] = result.stderr.strip()
+            hint = _sudo_hint_for(result.stderr)
+            if hint:
+                resp['message'] = hint
         return jsonify(resp)
 
     except subprocess.TimeoutExpired as e:
@@ -2367,7 +2397,13 @@ def execute_system_action():
         return jsonify({'status': 'error', 'message': 'Command timed out', 'returncode': -1, 'stderr': 'timeout'})
     except Exception as e:
         logger.error("execute_system_action failed: %s", e, exc_info=True)
-        return jsonify({'status': 'error', 'message': 'Action failed; see logs for details'}), 500
+        detail = describe_exception(e)
+        resp = {
+            'status': 'error',
+            'message': _sudo_hint_for(detail) or 'Action failed; see logs for details',
+            'details': detail,
+        }
+        return jsonify(resp), 500
 
 @api_v3.route('/system/git-info', methods=['GET'])
 def get_git_info():

--- a/web_interface/blueprints/api_v3.py
+++ b/web_interface/blueprints/api_v3.py
@@ -2055,7 +2055,14 @@ def execute_system_action():
                     logger.error("start_display (%s) stderr: %s", mode, result.stderr.strip())
                 resp = {
                     'status': 'success' if result.returncode == 0 else 'error',
-                    'message': 'Display started' if result.returncode == 0 else 'Failed to start display',
+                    # This branch returns before the shared nonzero-result
+                    # response below, so it needs the hint of its own or an
+                    # on-demand start reports "Failed to start display" and
+                    # says nothing about the sudo that actually refused it.
+                    'message': (
+                        'Display started' if result.returncode == 0
+                        else _sudo_hint_for(result.stderr) or 'Failed to start display'
+                    ),
                 }
                 if result.returncode != 0:
                     resp['returncode'] = result.returncode


### PR DESCRIPTION
## How this was found

I POSTed `reboot_system` to a live Pi through the web API. The entire response was:

```json
{"message": "Action failed; see logs for details", "status": "error"}
```

Pinning down the cause took reading `first_time_install.sh`, not reading the response.

## The cause

The web interface runs unprivileged. Its `systemctl` / `reboot` / `journalctl` calls only work once `scripts/install/configure_web_sudo.sh` has granted NOPASSWD:

```
$WEB_USER ALL=(ALL) NOPASSWD: $SYSTEMCTL_PATH start ledmatrix.service
$WEB_USER ALL=(ALL) NOPASSWD: $REBOOT_PATH
...
```

**`first_time_install.sh` never invokes that script**, and it isn't mentioned in the root README or `GETTING_STARTED.md` — only listed in passing in `scripts/install/README.md`. So on a fresh device every privileged action fails: `start_display`, `stop_display`, both autostart toggles, reboot, and the log viewer.

That last one closes the loop. "See logs for details" is unreachable advice when `journalctl` is refused for the same reason — I saw exactly that on another device, where the log stream returned `Error running journalctl` while the dashboard itself kept working.

This is the failure `src/web_interface/error_handler.py` was written to break. Its `describe_exception()` docstring says so directly:

> The generic "an error occurred; see logs for details" tells a user nothing and, when the failure is bad enough, the logs are unreachable too: a device whose storage was failing returned that message from every endpoint *including* the log viewer, because journalctl could not be executed.

`/system/action`'s exception handler was still discarding the cause, despite the blueprint already importing the helper at line 28.

## Changes

- The exception path returns `'details': describe_exception(e)`, matching how the other handlers in this blueprint already report (see line 321).
- A failure whose stderr or exception text is sudo refusing to prompt — `a password is required`, `no tty present`, `a terminal is required` — reports what to do about it and names `configure_web_sudo.sh`.
- Unrelated failures keep the generic message and their `stderr`, so a missing unit isn't misattributed to sudo.
- Nothing changes when the action succeeds.

## Deliberately not changed

I did **not** make the installer run `configure_web_sudo.sh`. Auto-granting NOPASSWD sudo is a security decision for the maintainer, not something to slip into an installer as a side effect of a bug fix. Making the refusal legible is the part that's unambiguously an improvement — and once the message names the script, the setup step becomes discoverable on its own.

If you'd rather the installer offered it (prompted, or behind a flag), that's a small follow-up and I'm happy to do it.

## Tests

`test/test_system_action_sudo_diagnosis.py` — 8 cases: all three sudo refusal wordings produce the actionable hint, raw stderr is still returned, a real `systemctl` error keeps the generic message and isn't blamed on sudo, the exception path names the exception type, a sudo-shaped exception also gets the hint, and success is unchanged.

Verified against the current `main` version of `api_v3.py` — 5 of the 8 fail, and the 3 that pass are the guards on behaviour this PR doesn't change:

```
FAILED test_every_sudo_refusal_wording_is_recognised  (×3)
FAILED test_the_exception_type_and_message_are_returned
FAILED test_a_sudo_shaped_exception_also_gets_the_hint
```

```
failures unique to this PR:  none
            mine    main
failed       103     103
passed      4191    4183   (+8, all new)
```

The 103 are pre-existing on this Windows dev machine (`os.geteuid`, POSIX permission semantics), verified by diffing full failure lists rather than counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - System action failures caused by missing sudo passwords now provide a clear configuration hint.
  - Error responses preserve relevant command output and include the underlying exception cause when available.
  - Unrelated service errors continue to show their generic messages and original return codes.
  - Successful system actions remain unchanged.

- **Tests**
  - Added regression coverage for sudo-related failures, unrelated errors, exception handling, and successful actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->